### PR TITLE
fix(anthropic): set default max_tokens when unset

### DIFF
--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -15,6 +15,7 @@ import (
 const (
 	defaultBaseURL      = "https://api.anthropic.com/v1"
 	defaultAnthropicVer = "2023-06-01"
+	defaultMaxTokens    = 4096
 
 	// Content block types for Anthropic API
 	blockTypeText     = "text"
@@ -208,7 +209,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *messagesRequest {
 		Model:       params.Model.ID,
 		System:      system,
 		Messages:    messages,
-		MaxTokens:   params.MaxTokens,
+		MaxTokens:   resolveMaxTokens(params, p.thinking),
 		Temperature: params.Temperature,
 		TopP:        params.TopP,
 	}
@@ -229,6 +230,19 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *messagesRequest {
 	}
 
 	return req
+}
+
+func resolveMaxTokens(params *sdk.GenerateParams, thinking *ThinkingConfig) *int {
+	if params.MaxTokens != nil {
+		return params.MaxTokens
+	}
+
+	maxTokens := defaultMaxTokens
+	if thinking != nil && thinking.Type != "" && thinking.Type != "disabled" && thinking.BudgetTokens > 0 {
+		maxTokens += thinking.BudgetTokens
+	}
+
+	return &maxTokens
 }
 
 func convertTools(tools []sdk.Tool) []anthropicTool {

--- a/provider/anthropic/messages/messages_test.go
+++ b/provider/anthropic/messages/messages_test.go
@@ -90,6 +90,95 @@ func TestDoGenerate(t *testing.T) {
 	}
 }
 
+func TestDoGenerate_DefaultMaxTokens(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			MaxTokens int `json:"max_tokens"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if body.MaxTokens != 4096 {
+			t.Fatalf("max_tokens: got %d, want 4096", body.MaxTokens)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_default_max", "type": "message", "model": "claude-sonnet-4-20250514", "role": "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "OK"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 5, "output_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := messages.New(messages.WithAPIKey("test-key"), messages.WithBaseURL(srv.URL))
+
+	result, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    &sdk.Model{ID: "claude-sonnet-4-20250514"},
+		Messages: []sdk.Message{sdk.UserMessage("Hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+	if result.Text != "OK" {
+		t.Errorf("text: got %q", result.Text)
+	}
+}
+
+func TestDoGenerate_DefaultMaxTokens_ThinkingBudgetReserveAnswerBudget(t *testing.T) {
+	const budgetTokens = 50000
+	const answerTokens = 4096
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			MaxTokens int `json:"max_tokens"`
+			Thinking  struct {
+				Type         string `json:"type"`
+				BudgetTokens int    `json:"budget_tokens"`
+			} `json:"thinking"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if body.MaxTokens != budgetTokens+answerTokens {
+			t.Fatalf("max_tokens: got %d, want %d", body.MaxTokens, budgetTokens+answerTokens)
+		}
+		if body.Thinking.Type != "enabled" || body.Thinking.BudgetTokens != budgetTokens {
+			t.Fatalf("thinking: got %+v", body.Thinking)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_default_thinking_max", "type": "message", "model": "claude-sonnet-4-20250514", "role": "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "OK"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 5, "output_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := messages.New(
+		messages.WithAPIKey("test-key"),
+		messages.WithBaseURL(srv.URL),
+		messages.WithThinking(messages.ThinkingConfig{
+			Type:         "enabled",
+			BudgetTokens: budgetTokens,
+		}),
+	)
+
+	result, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    &sdk.Model{ID: "claude-sonnet-4-20250514"},
+		Messages: []sdk.Message{sdk.UserMessage("Hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+	if result.Text != "OK" {
+		t.Errorf("text: got %q", result.Text)
+	}
+}
+
 func TestDoGenerate_SystemMessage(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {


### PR DESCRIPTION
这个 PR 修复了 Anthropic Messages 请求在未显式传入 MaxTokens 时缺少 max_tokens 的问题。此前 provider 会直接省略该字段，在 Anthropic 兼容接口上可能返回 400，影响未设置输出上限的生成与流式请求

修复后：请求构造阶段会为 max_tokens 补默认值，并在开启 thinking 且存在 budget_tokens 时保证下限大于 budget。现在未配置 MaxTokens 的调用也会发送合法请求，可保证 Anthropic 兼容端点的默认行为一致