### PR TITLE
fix(tests): resolve pre-existing SA5011 staticcheck warnings

### DIFF
--- a/provider/anthropic/messages/messages_test.go
+++ b/provider/anthropic/messages/messages_test.go
@@ -619,8 +619,7 @@ func TestDoStream_ToolCall(t *testing.T) {
 	}
 	if gotToolCall == nil {
 		t.Fatal("missing StreamToolCallPart")
-	}
-	if gotToolCall.ToolCallID != "toolu_xyz" || gotToolCall.ToolName != "get_weather" {
+	} else if gotToolCall.ToolCallID != "toolu_xyz" || gotToolCall.ToolName != "get_weather" {
 		t.Errorf("tool call: %+v", gotToolCall)
 	}
 	input, ok := gotToolCall.Input.(map[string]any)

--- a/provider/google/generativeai/generativeai_test.go
+++ b/provider/google/generativeai/generativeai_test.go
@@ -634,8 +634,7 @@ func TestDoStream_ToolCall(t *testing.T) {
 	}
 	if gotToolCall == nil {
 		t.Fatal("missing StreamToolCallPart")
-	}
-	if gotToolCall.ToolName != "get_weather" {
+	} else if gotToolCall.ToolName != "get_weather" {
 		t.Errorf("tool call name: got %q", gotToolCall.ToolName)
 	}
 	input, ok := gotToolCall.Input.(map[string]any)

--- a/provider/openai/completions/completions_test.go
+++ b/provider/openai/completions/completions_test.go
@@ -504,8 +504,7 @@ func TestDoStream_ToolCall(t *testing.T) {
 	}
 	if gotToolCall == nil {
 		t.Fatal("missing StreamToolCallPart")
-	}
-	if gotToolCall.ToolCallID != "call_xyz" || gotToolCall.ToolName != "get_weather" {
+	} else if gotToolCall.ToolCallID != "call_xyz" || gotToolCall.ToolName != "get_weather" {
 		t.Errorf("tool call: %+v", gotToolCall)
 	}
 	input, ok := gotToolCall.Input.(map[string]any)

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -587,8 +587,7 @@ func TestResponsesDoStream_ToolCall(t *testing.T) {
 	}
 	if gotToolCall == nil {
 		t.Fatal("missing StreamToolCallPart")
-	}
-	if gotToolCall.ToolCallID != "call_xyz" || gotToolCall.ToolName != "get_weather" {
+	} else if gotToolCall.ToolCallID != "call_xyz" || gotToolCall.ToolName != "get_weather" {
 		t.Errorf("tool call: %+v", gotToolCall)
 	}
 	input := gotToolCall.Input.(map[string]any)

--- a/sdk/mcp_test.go
+++ b/sdk/mcp_test.go
@@ -223,8 +223,7 @@ func TestConvertInputSchema(t *testing.T) {
 		}
 		if s == nil {
 			t.Fatal("expected non-nil schema")
-		}
-		if s.Type != "object" {
+		} else if s.Type != "object" {
 			t.Errorf("type = %q, want %q", s.Type, "object")
 		}
 	})


### PR DESCRIPTION
## Summary

Fix 10 pre-existing `SA5011` (possible nil pointer dereference) warnings from staticcheck. All affected files pre-date this repo's speech provider work.

## Root cause

`t.Fatal` terminates the goroutine via `runtime.Goexit`, not `return`. staticcheck cannot prove execution stops there, so it flags any pointer dereference on the next line as potentially unsafe.

## Fix

Restructured each `if nil { t.Fatal } / if ptr.Field` pair into `if nil { t.Fatal } else if ptr.Field` — no test logic changed.

## Affected files

- `provider/anthropic/messages/messages_test.go`
- `provider/openai/completions/completions_test.go`
- `provider/openai/responses/responses_test.go`
- `provider/google/generativeai/generativeai_test.go`
- `sdk/mcp_test.go`