### PR TITLE
ci: enable manual trigger, align Google env, bump test model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,10 @@ ANTHROPIC_MODEL=claude-sonnet-4-20250514
 ANTHROPIC_REASONING_MODEL=anthropic/claude-3.5-sonnet:thinking
 # Set to "bearer" when using proxies like OpenRouter (uses Authorization: Bearer instead of x-api-key)
 ANTHROPIC_AUTH_MODE=
+
+# Google Gemini (Generative Language API)
+# Get a key at https://aistudio.google.com/apikey
+# The long env name mirrors the Vercel AI SDK convention; keep it stable.
+GOOGLE_GENERATIVE_AI_API_KEY=AIzaxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+GOOGLE_GENERATIVE_AI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+GOOGLE_GENERATIVE_AI_MODEL=gemini-2.5-flash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -53,7 +54,9 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || github.event_name == 'workflow_dispatch'
 
     steps:
       - uses: actions/checkout@v4
@@ -70,5 +73,5 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
         run: go test ./... -count=1 -v -run '^TestIntegration_|^TestClient_' -timeout 120s

--- a/provider/google/generativeai/generativeai_test.go
+++ b/provider/google/generativeai/generativeai_test.go
@@ -972,7 +972,7 @@ func integrationModel(t *testing.T) *sdk.Model {
 	t.Helper()
 	m := os.Getenv("GOOGLE_GENERATIVE_AI_MODEL")
 	if m == "" {
-		m = "gemini-2.0-flash"
+		m = "gemini-2.5-flash"
 	}
 	return &sdk.Model{ID: m}
 }


### PR DESCRIPTION
## Summary

Three small CI cleanups discovered while running integration tests on a fork:

1. **Fix: Google integration env var name mismatch.**
   `ci.yml` exposed the secret as `GOOGLE_API_KEY`, but the test code in
   `provider/google/generativeai/generativeai_test.go::envOrSkip` reads
   `GOOGLE_GENERATIVE_AI_API_KEY` (matching the Vercel AI SDK convention this
   project was inspired by). The result is that when a Google secret is
   configured, the integration tests would silently SKIP instead of running.

2. **Enhancement: enable `workflow_dispatch`.**
   Lets maintainers manually trigger CI from the GitHub UI or
   `gh workflow run ci.yml --ref main`, without pushing an empty commit. The
   integration job condition is also updated so manual runs reach integration
   (PRs remain excluded, preserving the original cost / security intent).

3. **Maintenance: bump Gemini integration default model.**
   `gemini-2.0-flash` → `gemini-2.5-flash`. `gemini-2.0-flash-001` retires
   2026-06-01 per [Google's model lifecycle docs](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/model-versions),
   so the integration default would start 404'ing in ~10 days otherwise.

Also adds a Google Gemini section to `.env.example`, mirroring the existing
OpenAI / Anthropic sections, so new contributors don't need to grep test code
for the env var names.

## Impact on this repository

Upstream currently does not have integration secrets configured, so **this PR
does not change current CI behavior** — all integration tests continue to
SKIP as they do today. The fix only takes effect when a Google API key is
added in repository settings.

## Evidence

Verified on my fork (`akazwz/twilight-ai`) with `GOOGLE_GENERATIVE_AI_API_KEY`
configured as a repository secret. All three Google `TestIntegration_*` now
PASS against the real Gemini API:
