### PR TITLE
fix(anthropic): always send input for tool_use blocks

### DIFF
--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -478,11 +478,18 @@ func convertAssistantMessage(msg sdk.Message) anthropicMessage {
 			if id == "" {
 				id = generateID()
 			}
+			// The API requires tool_use blocks to always carry an input object.
+			// A no-argument tool call arrives with a nil Input, which the
+			// omitempty tag would drop entirely, so default it to an empty object.
+			input := p.Input
+			if input == nil {
+				input = map[string]any{}
+			}
 			blocks = append(blocks, contentBlock{
 				Type:  blockTypeToolUse,
 				ID:    id,
 				Name:  p.ToolName,
-				Input: p.Input,
+				Input: input,
 			})
 		}
 	}

--- a/provider/anthropic/messages/messages_test.go
+++ b/provider/anthropic/messages/messages_test.go
@@ -408,6 +408,70 @@ func TestDoGenerate_ToolCallMultiTurn(t *testing.T) {
 	}
 }
 
+func TestDoGenerate_ToolCallEmptyInput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Messages []json.RawMessage `json:"messages"`
+		}
+		json.NewDecoder(r.Body).Decode(&body)
+
+		var assistantMsg struct {
+			Content []map[string]json.RawMessage `json:"content"`
+		}
+		json.Unmarshal(body.Messages[1], &assistantMsg)
+		if len(assistantMsg.Content) != 1 {
+			t.Fatalf("expected 1 content block, got %d", len(assistantMsg.Content))
+		}
+		input, ok := assistantMsg.Content[0]["input"]
+		if !ok {
+			t.Fatalf("tool_use block is missing required input field: %v", assistantMsg.Content[0])
+		}
+		if string(input) != "{}" {
+			t.Errorf("input: got %s, want {}", input)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_2", "type": "message", "model": "claude-sonnet-4-20250514", "role": "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "done"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 10, "output_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := messages.New(messages.WithAPIKey("test-key"), messages.WithBaseURL(srv.URL))
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "claude-sonnet-4-20250514"},
+		Messages: []sdk.Message{
+			{
+				Role:    sdk.MessageRoleUser,
+				Content: []sdk.MessagePart{sdk.TextPart{Text: "List schedules"}},
+			},
+			{
+				Role: sdk.MessageRoleAssistant,
+				Content: []sdk.MessagePart{sdk.ToolCallPart{
+					ToolCallID: "toolu_empty",
+					ToolName:   "list_schedule",
+					Input:      nil,
+				}},
+			},
+			{
+				Role: sdk.MessageRoleTool,
+				Content: []sdk.MessagePart{sdk.ToolResultPart{
+					ToolCallID: "toolu_empty",
+					ToolName:   "list_schedule",
+					Result:     map[string]any{"count": 0},
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
 func TestDoGenerate_Thinking(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Problem
A no-argument tool call yields a `ToolCallPart` with a nil `Input`. When that assistant message is replayed to the API, `contentBlock.Input` is dropped by its `omitempty` tag, so the `tool_use` block is sent without the required `input` field, and the API rejects the request:

```
400 messages.N.content.M.tool_use.input: Field required
```

## Fix
In `convertAssistantMessage`, default a nil tool_use input to an empty object (`map[string]any{}`) so the field is always serialized. Removing `omitempty` from the shared `contentBlock.Input` is not viable because text/thinking/tool_result blocks legitimately omit it.

## Test
Adds `TestDoGenerate_ToolCallEmptyInput`, which replays an assistant `tool_use` with nil input and asserts the outgoing request carries `"input": {}`. It fails without the fix and passes with it.