### PR TITLE
fix(openai): support DeepSeek thinking disable

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1216,7 +1216,12 @@ type Option func(*Provider)
 func WithAPIKey(apiKey string) Option
 func WithBaseURL(baseURL string) Option
 func WithHTTPClient(client *http.Client) Option
+func WithDeepSeekChatCompletionsCompat() Option
 ```
+
+`WithDeepSeekChatCompletionsCompat` keeps the generic `/chat/completions`
+transport while adapting DeepSeek's thinking toggle: `WithReasoningEffort("none")`
+sends `thinking: {type: "disabled"}` and omits `reasoning_effort`.
 
 #### Methods
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -100,6 +100,7 @@ model := provider.ChatModel("gpt-4o-mini")
 | `WithBedrockCredentials(region, accessKeyID, secretAccessKey, sessionToken)` | disabled | Use AWS SigV4 with static AWS credentials for Bedrock |
 | `WithBaseURL(url)` | `https://api.openai.com/v1` | Base URL for API requests |
 | `WithHTTPClient(client)` | `&http.Client{}` | Custom HTTP client (for proxies, timeouts, etc.) |
+| `WithDeepSeekChatCompletionsCompat()` | disabled | Map `WithReasoningEffort("none")` to DeepSeek's thinking disable toggle |
 
 ### API Endpoints for Discovery
 
@@ -111,15 +112,35 @@ model := provider.ChatModel("gpt-4o-mini")
 
 ### OpenAI-Compatible Providers
 
-Any service that implements the OpenAI Chat Completions API works out of the box:
+Any service that implements the OpenAI Chat Completions API works out of the box.
+DeepSeek uses the same endpoint, but disables thinking with a `thinking` toggle
+instead of `reasoning_effort: "none"`, so enable the DeepSeek compatibility
+option when you need that behavior:
 
 ```go
 // DeepSeek
 provider := completions.New(
     completions.WithAPIKey("your-deepseek-key"),
     completions.WithBaseURL("https://api.deepseek.com"),
+    completions.WithDeepSeekChatCompletionsCompat(),
 )
+```
 
+The compatibility option keeps the generic Chat Completions provider and only
+adapts DeepSeek's thinking toggle:
+
+| SDK option/value | DeepSeek request |
+|------------------|------------------|
+| `WithReasoningEffort("none")` | `thinking: {type: "disabled"}` |
+| any other `WithReasoningEffort(...)` value | original `reasoning_effort` |
+
+Note: `"none"` is the effort floor, which for DeepSeek means off. Sending
+`reasoning_effort: "none"` alone does not stop it thinking, so the provider sends
+`thinking: {type: "disabled"}` instead.
+
+Other OpenAI-compatible services use `completions.New()` with a base URL:
+
+```go
 // Groq
 provider := completions.New(
     completions.WithAPIKey("your-groq-key"),
@@ -186,9 +207,9 @@ The `provider/openai/responses` package provides an implementation for the OpenA
 | **Reasoning models** | Basic support (`reasoning_content` field) | First-class (`reasoning` output items with summaries) |
 | **Citations** | Not supported | URL citations via annotations |
 | **Input format** | Nested `messages` array | Flat `input` array |
-| **Compatibility** | Broad (DeepSeek, Groq, Ollama, etc.) | OpenAI and OpenRouter |
+| **Compatibility** | Broad (DeepSeek, Groq, Ollama, Azure-style compatible endpoints, etc.) | OpenAI and OpenRouter |
 
-Use **Completions** when you need broad compatibility with OpenAI-compatible endpoints. Use **Responses** when you want native reasoning model support (o3, o4-mini) or URL citation annotations.
+Use **Completions** when you need broad compatibility with OpenAI-compatible endpoints. Add `WithDeepSeekChatCompletionsCompat()` when `WithReasoningEffort("none")` should disable DeepSeek thinking. Use **Responses** when you want native reasoning model support (o3, o4-mini) or URL citation annotations.
 
 ### Basic Usage
 

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/memohai/twilight-ai/internal/utils"
@@ -19,9 +20,14 @@ type Provider struct {
 	baseURL        string
 	httpClient     *http.Client
 	prepareRequest func(*http.Request) error
+	compat         chatCompletionsCompat
 }
 
 type Option func(*Provider)
+
+type chatCompletionsCompat string
+
+const chatCompletionsCompatDeepSeek chatCompletionsCompat = "deepseek"
 
 func WithAPIKey(apiKey string) Option {
 	return func(p *Provider) {
@@ -54,6 +60,14 @@ func WithBaseURL(baseURL string) Option {
 func WithHTTPClient(client *http.Client) Option {
 	return func(p *Provider) {
 		p.httpClient = client
+	}
+}
+
+// WithDeepSeekChatCompletionsCompat maps reasoning_effort "none" to DeepSeek's
+// thinking disable toggle while keeping the generic Chat Completions provider.
+func WithDeepSeekChatCompletionsCompat() Option {
+	return func(p *Provider) {
+		p.compat = chatCompletionsCompatDeepSeek
 	}
 }
 
@@ -210,7 +224,26 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *chatRequest {
 			JSONSchema: params.ResponseFormat.JSONSchema,
 		}
 	}
+	p.applyChatCompletionsCompat(req)
 	return req
+}
+
+func (p *Provider) applyChatCompletionsCompat(req *chatRequest) {
+	if p.compat != chatCompletionsCompatDeepSeek {
+		return
+	}
+	if req.ReasoningEffort == nil {
+		return
+	}
+	effort := strings.TrimSpace(*req.ReasoningEffort)
+	if effort == "" {
+		return
+	}
+	switch strings.ToLower(effort) {
+	case "none", "disable", "disabled":
+		req.ReasoningEffort = nil
+		req.Thinking = &chatThinking{Type: "disabled"}
+	}
 }
 
 func convertTools(tools []sdk.Tool) []chatTool {

--- a/provider/openai/completions/completions_test.go
+++ b/provider/openai/completions/completions_test.go
@@ -751,6 +751,98 @@ func TestDoGenerate_ReasoningFallback(t *testing.T) {
 	}
 }
 
+func TestDoGenerate_DeepSeekCompatDisablesThinking(t *testing.T) {
+	var body struct {
+		ReasoningEffort *string `json:"reasoning_effort"`
+		Thinking        *struct {
+			Type string `json:"type"`
+		} `json:"thinking"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":    "chatcmpl-deepseek",
+			"model": "deepseek-v4-flash",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithDeepSeekChatCompletionsCompat(),
+	)
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:           &sdk.Model{ID: "deepseek-v4-flash"},
+		Messages:        []sdk.Message{sdk.UserMessage("hi")},
+		ReasoningEffort: stringPtr("none"),
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	if body.ReasoningEffort != nil {
+		t.Fatalf("reasoning_effort should be omitted, got %q", *body.ReasoningEffort)
+	}
+	if body.Thinking == nil || body.Thinking.Type != "disabled" {
+		t.Fatalf("thinking: got %#v, want disabled", body.Thinking)
+	}
+}
+
+func TestDoGenerate_DeepSeekCompatLeavesOtherReasoningEffortAlone(t *testing.T) {
+	var body struct {
+		ReasoningEffort *string `json:"reasoning_effort"`
+		Thinking        *struct {
+			Type string `json:"type"`
+		} `json:"thinking"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":    "chatcmpl-deepseek",
+			"model": "deepseek-v4-pro",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithDeepSeekChatCompletionsCompat(),
+	)
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:           &sdk.Model{ID: "deepseek-v4-pro"},
+		Messages:        []sdk.Message{sdk.UserMessage("hi")},
+		ReasoningEffort: stringPtr("xhigh"),
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	if body.ReasoningEffort == nil || *body.ReasoningEffort != "xhigh" {
+		t.Fatalf("reasoning_effort: got %v, want xhigh", body.ReasoningEffort)
+	}
+	if body.Thinking != nil {
+		t.Fatalf("thinking should be omitted, got %#v", body.Thinking)
+	}
+}
+
 func TestDoStream_ReasoningFallback(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -1378,6 +1470,8 @@ func TestTestModel_NotSupported(t *testing.T) {
 		t.Error("expected model to not be supported")
 	}
 }
+
+func stringPtr(s string) *string { return &s }
 
 func TestMain(m *testing.M) {
 	testutil.LoadEnv()

--- a/provider/openai/completions/types.go
+++ b/provider/openai/completions/types.go
@@ -16,8 +16,13 @@ type chatRequest struct {
 	PresencePenalty     *float64           `json:"presence_penalty,omitempty"`
 	Seed                *int               `json:"seed,omitempty"`
 	ReasoningEffort     *string            `json:"reasoning_effort,omitempty"`
+	Thinking            *chatThinking      `json:"thinking,omitempty"`
 	Stream              bool               `json:"stream,omitempty"`
 	StreamOptions       *chatStreamOptions `json:"stream_options,omitempty"`
+}
+
+type chatThinking struct {
+	Type string `json:"type"`
 }
 
 type chatStreamOptions struct {
@@ -81,13 +86,13 @@ type chatChoice struct {
 }
 
 type chatRespMessage struct {
-	Role             string           `json:"role"`
-	Content          string           `json:"content"`
-	ReasoningContent string           `json:"reasoning_content,omitempty"`
-	Reasoning        string           `json:"reasoning,omitempty"`
-	Refusal          string           `json:"refusal,omitempty"`
-	ToolCalls        []chatToolCall   `json:"tool_calls,omitempty"`
-	Images           []chatImagePart  `json:"images,omitempty"`
+	Role             string          `json:"role"`
+	Content          string          `json:"content"`
+	ReasoningContent string          `json:"reasoning_content,omitempty"`
+	Reasoning        string          `json:"reasoning,omitempty"`
+	Refusal          string          `json:"refusal,omitempty"`
+	ToolCalls        []chatToolCall  `json:"tool_calls,omitempty"`
+	Images           []chatImagePart `json:"images,omitempty"`
 }
 
 type chatToolCall struct {

--- a/skill/reference.md
+++ b/skill/reference.md
@@ -730,6 +730,7 @@ type Option func(*Provider)
 func WithAPIKey(apiKey string) Option
 func WithBaseURL(baseURL string) Option
 func WithHTTPClient(client *http.Client) Option
+func WithDeepSeekChatCompletionsCompat() Option
 func New(options ...Option) *Provider
 
 func (p *Provider) Name() string
@@ -745,6 +746,7 @@ Default option values:
 
 - `WithBaseURL`: `https://api.openai.com/v1`
 - `WithHTTPClient`: `&http.Client{}`
+- `WithDeepSeekChatCompletionsCompat`: disabled. When enabled, `WithReasoningEffort("none")` sends `thinking:{type:"disabled"}` and omits `reasoning_effort`.
 
 Discovery endpoints:
 


### PR DESCRIPTION
## Summary

Fixes DeepSeek thinking disable support in the OpenAI Chat Completions provider.

- adds `WithDeepSeekChatCompletionsCompat()` to `provider/openai/completions`
- when enabled, maps `WithReasoningEffort("none")` to `thinking: {"type":"disabled"}` and omits `reasoning_effort`
- leaves other reasoning effort values and request fields unchanged

## Design notes

DeepSeek uses the OpenAI-compatible `/chat/completions` endpoint, but disabling thinking requires a `thinking` toggle instead of `reasoning_effort: "none"`. This keeps the behavior opt-in and avoids adding a dedicated DeepSeek provider or auto-detecting from model/base URL.

## Non-goals

- no dedicated `provider/deepseek` package
- no `max_tokens`, message content, JSON Schema, or usage translation changes
- no SDK-side mapping for `low`, `medium`, or `xhigh`; DeepSeek handles compatible effort values server-side

## Verification

- `go test ./...`