### PR TITLE
fix(google): classify embedding models by supportedGenerationMethods

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -111,7 +111,8 @@ type Model struct {
 }
 
 type ModelType string
-const ModelTypeChat ModelType = "chat"
+const ModelTypeChat      ModelType = "chat"
+const ModelTypeEmbedding ModelType = "embedding"
 ```
 
 #### Methods

--- a/provider/google/generativeai/generativeai.go
+++ b/provider/google/generativeai/generativeai.go
@@ -74,7 +74,7 @@ func (p *Provider) ListModels(ctx context.Context) ([]sdk.Model, error) {
 			ID:          id,
 			DisplayName: m.DisplayName,
 			Provider:    p,
-			Type:        sdk.ModelTypeChat,
+			Type:        googleModelType(m.SupportedGenerationMethods),
 		})
 	}
 	return models, nil
@@ -132,6 +132,23 @@ func (p *Provider) ChatModel(id string) *sdk.Model {
 		Provider: p,
 		Type:     sdk.ModelTypeChat,
 	}
+}
+
+func googleModelType(methods []string) sdk.ModelType {
+	hasGenerate := false
+	hasEmbed := false
+	for _, m := range methods {
+		switch m {
+		case "generateContent":
+			hasGenerate = true
+		case "embedContent":
+			hasEmbed = true
+		}
+	}
+	if hasEmbed && !hasGenerate {
+		return sdk.ModelTypeEmbedding
+	}
+	return sdk.ModelTypeChat
 }
 
 // ---------- DoGenerate ----------

--- a/provider/google/generativeai/generativeai_test.go
+++ b/provider/google/generativeai/generativeai_test.go
@@ -1106,6 +1106,49 @@ func TestListModels(t *testing.T) {
 	if models[0].DisplayName != "Gemini 2.5 Pro" {
 		t.Errorf("expected display name 'Gemini 2.5 Pro', got %q", models[0].DisplayName)
 	}
+	if models[0].Type != sdk.ModelTypeChat {
+		t.Errorf("expected chat type for model without supportedGenerationMethods, got %q", models[0].Type)
+	}
+}
+
+func TestListModels_EmbeddingType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{
+				{
+					"name":                       "models/gemini-2.5-flash",
+					"displayName":                "Gemini 2.5 Flash",
+					"supportedGenerationMethods": []string{"generateContent", "countTokens"},
+				},
+				{
+					"name":                       "models/gemini-embedding-001",
+					"displayName":                "Gemini Embedding 001",
+					"supportedGenerationMethods": []string{"embedContent", "countTokens"},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := generativeai.New(
+		generativeai.WithAPIKey("test-key"),
+		generativeai.WithBaseURL(srv.URL),
+	)
+
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels failed: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].Type != sdk.ModelTypeChat {
+		t.Errorf("expected chat type for generateContent model, got %q", models[0].Type)
+	}
+	if models[1].Type != sdk.ModelTypeEmbedding {
+		t.Errorf("expected embedding type for embedContent model, got %q", models[1].Type)
+	}
 }
 
 func TestProviderTest_OK(t *testing.T) {

--- a/sdk/model.go
+++ b/sdk/model.go
@@ -5,7 +5,8 @@ import "context"
 type ModelType string
 
 const (
-	ModelTypeChat ModelType = "chat"
+	ModelTypeChat      ModelType = "chat"
+	ModelTypeEmbedding ModelType = "embedding"
 )
 
 type Model struct {

--- a/skill/reference.md
+++ b/skill/reference.md
@@ -79,7 +79,8 @@ type ModelTestResult struct {
 ```go
 type ModelType string
 
-const ModelTypeChat ModelType = "chat"
+const ModelTypeChat      ModelType = "chat"
+const ModelTypeEmbedding ModelType = "embedding"
 
 type Model struct {
     ID          string


### PR DESCRIPTION
## Summary

- `ListModels` was hardcoding all Google models as `sdk.ModelTypeChat`, discarding the `supportedGenerationMethods` field already parsed in `googleModelObject`
- Models with only `embedContent` (no `generateContent`) are now correctly classified as `sdk.ModelTypeEmbedding`
- Adds `ModelTypeEmbedding` constant to the `sdk` package

## Context

Downstream in Memoh, model import uses `ListModels` to populate the user's model list. Without this fix, embedding models like `gemini-embedding-001` get imported as chat models with incorrect capability defaults (vision/tool-call/reasoning).

Related: memohai/Memoh#533

## Test plan

- [x] `go test ./... -race` — all 25 packages pass
- [x] New `TestListModels_EmbeddingType` verifies chat vs embedding classification
- [x] Existing `TestListModels` updated to also assert `Type == ModelTypeChat`