### PR TITLE
feat(speech): support Deepgram model discovery

### DIFF
--- a/provider/alibabacloud/speech/speech.go
+++ b/provider/alibabacloud/speech/speech.go
@@ -59,7 +59,7 @@ func (p *Provider) SpeechModel(id string) *sdk.SpeechModel {
 
 // ListModels returns the speech models exposed by this provider.
 func (p *Provider) ListModels(context.Context) ([]*sdk.SpeechModel, error) {
-	return nil, fmt.Errorf("alibabacloud speech: provider does not expose a remote models discovery API")
+	return nil, fmt.Errorf("alibabacloud speech: DashScope documents CosyVoice model names but does not expose a remote model discovery API for this provider")
 }
 
 // DoSynthesize synthesizes speech and returns the complete audio bytes.

--- a/provider/deepgram/speech/speech.go
+++ b/provider/deepgram/speech/speech.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -72,8 +73,55 @@ func (p *Provider) SpeechModel(id string) *sdk.SpeechModel {
 }
 
 // ListModels returns the speech models exposed by this provider.
-func (p *Provider) ListModels(context.Context) ([]*sdk.SpeechModel, error) {
-	return nil, fmt.Errorf("deepgram speech: provider does not expose a remote models discovery API in this SDK")
+func (p *Provider) ListModels(ctx context.Context) ([]*sdk.SpeechModel, error) {
+	resp, err := p.listModels(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	models := make([]*sdk.SpeechModel, 0, len(resp.TTS))
+	for _, m := range resp.TTS {
+		if m.CanonicalName != "" {
+			models = append(models, p.SpeechModel(m.CanonicalName))
+		}
+	}
+	if len(models) == 0 {
+		return nil, errors.New("deepgram speech: no speech models returned by provider")
+	}
+	return models, nil
+}
+
+type deepgramModelsResponse struct {
+	STT []deepgramModel `json:"stt"`
+	TTS []deepgramModel `json:"tts"`
+}
+
+type deepgramModel struct {
+	CanonicalName string `json:"canonical_name"`
+}
+
+func (p *Provider) listModels(ctx context.Context) (*deepgramModelsResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/v1/models", http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("deepgram speech: build list models request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+p.apiKey)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("deepgram speech: list models request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("deepgram speech: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var payload deepgramModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("deepgram speech: decode list models response: %w", err)
+	}
+	return &payload, nil
 }
 
 // DoSynthesize synthesizes speech and returns the complete audio bytes.

--- a/provider/deepgram/speech/speech_test.go
+++ b/provider/deepgram/speech/speech_test.go
@@ -120,14 +120,47 @@ func TestProvider_SpeechModel(t *testing.T) {
 
 func TestProvider_ListModels(t *testing.T) {
 	t.Parallel()
-	p := New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %s, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Token key" {
+			t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"stt":[{"canonical_name":"nova-3"}],"tts":[{"canonical_name":"aura-2-asteria-en"},{"canonical_name":"aura-2-orpheus-en"},{"uuid":"not-a-model-id"}]}`))
+	}))
+	defer srv.Close()
 
+	p := New(WithAPIKey("key"), WithBaseURL(srv.URL))
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models) = %d, want 2", len(models))
+	}
+	if models[0].ID != "aura-2-asteria-en" || models[1].ID != "aura-2-orpheus-en" {
+		t.Fatalf("unexpected models: %+v", models)
+	}
+}
+
+func TestProvider_ListModels_HTTPError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	p := New(WithAPIKey("bad"), WithBaseURL(srv.URL))
 	models, err := p.ListModels(context.Background())
 	if err == nil {
-		t.Fatal("expected unsupported error")
+		t.Fatal("expected error for 401")
 	}
-	if len(models) != 0 {
-		t.Fatalf("len(models) = %d, want 0", len(models))
+	if models != nil {
+		t.Fatalf("models = %+v, want nil", models)
 	}
 }
 

--- a/provider/deepgram/transcription/transcription.go
+++ b/provider/deepgram/transcription/transcription.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -47,8 +48,47 @@ func (p *Provider) TranscriptionModel(id string) *sdk.TranscriptionModel {
 	return &sdk.TranscriptionModel{ID: id, Provider: p}
 }
 
-func (p *Provider) ListModels(context.Context) ([]*sdk.TranscriptionModel, error) {
-	return nil, fmt.Errorf("deepgram transcription: provider does not expose a remote models discovery API in this SDK")
+func (p *Provider) ListModels(ctx context.Context) ([]*sdk.TranscriptionModel, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/v1/models", http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("deepgram transcription: build list models request: %w", err)
+	}
+	req.Header.Set("Authorization", "Token "+p.apiKey)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("deepgram transcription: list models request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("deepgram transcription: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var payload deepgramModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("deepgram transcription: decode list models response: %w", err)
+	}
+
+	models := make([]*sdk.TranscriptionModel, 0, len(payload.STT))
+	for _, m := range payload.STT {
+		if m.CanonicalName != "" {
+			models = append(models, p.TranscriptionModel(m.CanonicalName))
+		}
+	}
+	if len(models) == 0 {
+		return nil, errors.New("deepgram transcription: no transcription models returned by provider")
+	}
+	return models, nil
+}
+
+type deepgramModelsResponse struct {
+	STT []deepgramModel `json:"stt"`
+	TTS []deepgramModel `json:"tts"`
+}
+
+type deepgramModel struct {
+	CanonicalName string `json:"canonical_name"`
 }
 
 type audioConfig struct {

--- a/provider/deepgram/transcription/transcription_test.go
+++ b/provider/deepgram/transcription/transcription_test.go
@@ -11,13 +11,47 @@ import (
 
 func TestProvider_ListModels(t *testing.T) {
 	t.Parallel()
-	p := New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("path = %s, want /v1/models", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Token key" {
+			t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"stt":[{"canonical_name":"nova-3-general"},{"canonical_name":"flux-general-en"},{"uuid":"not-a-model-id"}],"tts":[{"canonical_name":"aura-2-asteria-en"}]}`))
+	}))
+	defer srv.Close()
+
+	p := New(WithAPIKey("key"), WithBaseURL(srv.URL))
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models) = %d, want 2", len(models))
+	}
+	if models[0].ID != "nova-3-general" || models[1].ID != "flux-general-en" {
+		t.Fatalf("unexpected models: %+v", models)
+	}
+}
+
+func TestProvider_ListModels_HTTPError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	p := New(WithAPIKey("bad"), WithBaseURL(srv.URL))
 	models, err := p.ListModels(context.Background())
 	if err == nil {
-		t.Fatal("expected unsupported error")
+		t.Fatal("expected error for 401")
 	}
-	if len(models) != 0 {
-		t.Fatalf("len(models) = %d, want 0", len(models))
+	if models != nil {
+		t.Fatalf("models = %+v, want nil", models)
 	}
 }
 

--- a/provider/edge/speech/speech.go
+++ b/provider/edge/speech/speech.go
@@ -50,7 +50,7 @@ func (p *Provider) SpeechModel(id string) *sdk.SpeechModel {
 
 // ListModels returns the speech models exposed by this provider.
 func (p *Provider) ListModels(context.Context) ([]*sdk.SpeechModel, error) {
-	return nil, fmt.Errorf("edge speech: provider does not expose a remote models discovery API")
+	return nil, fmt.Errorf("edge speech: provider does not expose a model discovery API; voices are bundled locally")
 }
 
 // DoSynthesize synthesizes speech and returns the complete audio.

--- a/provider/microsoft/speech/speech.go
+++ b/provider/microsoft/speech/speech.go
@@ -72,7 +72,7 @@ func (p *Provider) SpeechModel(id string) *sdk.SpeechModel {
 
 // ListModels returns the speech models exposed by this provider.
 func (p *Provider) ListModels(context.Context) ([]*sdk.SpeechModel, error) {
-	return nil, fmt.Errorf("microsoft speech: provider does not expose a remote models discovery API")
+	return nil, fmt.Errorf("microsoft speech: Azure exposes voice and custom voice model lists, not a standard TTS model discovery API for this provider")
 }
 
 // DoSynthesize synthesizes speech and returns the complete audio bytes.

--- a/provider/minimax/speech/speech.go
+++ b/provider/minimax/speech/speech.go
@@ -75,7 +75,7 @@ func (p *Provider) SpeechModel(id string) *sdk.SpeechModel {
 
 // ListModels returns the speech models exposed by this provider.
 func (p *Provider) ListModels(context.Context) ([]*sdk.SpeechModel, error) {
-	return nil, fmt.Errorf("minimax speech: provider does not expose a remote models discovery API in this SDK")
+	return nil, fmt.Errorf("minimax speech: list models unsupported: MiniMax /v1/models returns OpenAI-compatible LLM models, not TTS model discovery")
 }
 
 // t2aResponse is the JSON structure returned by the MiniMax /v1/t2a_v2 endpoint.

--- a/provider/minimax/speech/speech_test.go
+++ b/provider/minimax/speech/speech_test.go
@@ -151,8 +151,8 @@ func TestProvider_SpeechModel(t *testing.T) {
 
 func TestProvider_ListModels(t *testing.T) {
 	t.Parallel()
-	p := New()
 
+	p := New()
 	models, err := p.ListModels(context.Background())
 	if err == nil {
 		t.Fatal("expected unsupported error")

--- a/provider/openrouter/speech/speech.go
+++ b/provider/openrouter/speech/speech.go
@@ -88,7 +88,7 @@ func (p *Provider) SpeechModel(id string) *sdk.SpeechModel {
 
 // ListModels returns the speech models exposed by this provider.
 func (p *Provider) ListModels(ctx context.Context) ([]*sdk.SpeechModel, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/models", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/models?output_modalities=all", http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("openrouter speech: build list models request: %w", err)
 	}
@@ -104,15 +104,14 @@ func (p *Provider) ListModels(ctx context.Context) ([]*sdk.SpeechModel, error) {
 		return nil, fmt.Errorf("openrouter speech: unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 
-	modelIDs, err := decodeOpenRouterModelIDs(resp.Body)
+	rawModels, err := decodeOpenRouterModels(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("openrouter speech: decode list models response: %w", err)
 	}
 
-	models := make([]*sdk.SpeechModel, 0, len(modelIDs))
-	for _, id := range modelIDs {
-		m := struct{ ID string }{ID: id}
-		if isOpenRouterSpeechModel(m.ID) {
+	models := make([]*sdk.SpeechModel, 0, len(rawModels))
+	for _, m := range rawModels {
+		if isOpenRouterSpeechModel(m.ID, m.Architecture.OutputModalities) {
 			models = append(models, p.SpeechModel(m.ID))
 		}
 	}
@@ -122,45 +121,43 @@ func (p *Provider) ListModels(ctx context.Context) ([]*sdk.SpeechModel, error) {
 	return models, nil
 }
 
-func isOpenRouterSpeechModel(id string) bool {
-	id = strings.ToLower(id)
-	return strings.Contains(id, "audio") || strings.Contains(id, "tts")
+func isOpenRouterSpeechModel(id string, outputs []string) bool {
+	for _, output := range outputs {
+		switch strings.ToLower(output) {
+		case "speech", "audio":
+			return true
+		}
+	}
+	lowerID := strings.ToLower(id)
+	return strings.Contains(lowerID, "tts") || strings.Contains(lowerID, "audio")
 }
 
-func decodeOpenRouterModelIDs(r io.Reader) ([]string, error) {
+type openRouterModel struct {
+	ID           string `json:"id"`
+	Architecture struct {
+		InputModalities  []string `json:"input_modalities"`
+		OutputModalities []string `json:"output_modalities"`
+	} `json:"architecture"`
+}
+
+func decodeOpenRouterModels(r io.Reader) ([]openRouterModel, error) {
 	body, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
 
 	var wrapped struct {
-		Data []struct {
-			ID string `json:"id"`
-		} `json:"data"`
+		Data []openRouterModel `json:"data"`
 	}
 	if err := json.Unmarshal(body, &wrapped); err == nil && len(wrapped.Data) > 0 {
-		out := make([]string, 0, len(wrapped.Data))
-		for _, m := range wrapped.Data {
-			if m.ID != "" {
-				out = append(out, m.ID)
-			}
-		}
-		return out, nil
+		return wrapped.Data, nil
 	}
 
-	var direct []struct {
-		ID string `json:"id"`
-	}
+	var direct []openRouterModel
 	if err := json.Unmarshal(body, &direct); err != nil {
 		return nil, err
 	}
-	out := make([]string, 0, len(direct))
-	for _, m := range direct {
-		if m.ID != "" {
-			out = append(out, m.ID)
-		}
-	}
-	return out, nil
+	return direct, nil
 }
 
 // DoSynthesize synthesizes speech and returns the complete WAV audio.

--- a/provider/openrouter/speech/speech_test.go
+++ b/provider/openrouter/speech/speech_test.go
@@ -188,8 +188,11 @@ func TestProvider_ListModels(t *testing.T) {
 		if r.URL.Path != "/models" {
 			t.Errorf("path = %s, want /models", r.URL.Path)
 		}
+		if r.URL.Query().Get("output_modalities") != "all" {
+			t.Errorf("output_modalities = %q, want all", r.URL.Query().Get("output_modalities"))
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"id":"openai/gpt-audio-mini"},{"id":"openai/gpt-4o-audio-preview"},{"id":"openai/gpt-4.1-mini"}]}`))
+		_, _ = w.Write([]byte(`{"data":[{"id":"openai/gpt-audio-mini","architecture":{"input_modalities":["text"],"output_modalities":["audio"]}},{"id":"openai/gpt-4o-audio-preview","architecture":{"input_modalities":["text"],"output_modalities":["audio"]}},{"id":"openai/gpt-4.1-mini","architecture":{"input_modalities":["text"],"output_modalities":["text"]}}]}`))
 	}))
 	defer srv.Close()
 
@@ -209,7 +212,7 @@ func TestProvider_ListModels(t *testing.T) {
 func TestProvider_ListModels_ArrayResponse(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`[{"id":"openai/gpt-audio-mini"},{"id":"openai/gpt-4o-audio-preview"},{"id":"openai/gpt-4.1-mini"}]`))
+		_, _ = w.Write([]byte(`[{"id":"openai/gpt-audio-mini","architecture":{"input_modalities":["text"],"output_modalities":["audio"]}},{"id":"openai/gpt-4o-audio-preview","architecture":{"input_modalities":["text"],"output_modalities":["speech"]}},{"id":"openai/gpt-4.1-mini","architecture":{"input_modalities":["text"],"output_modalities":["text"]}}]`))
 	}))
 	defer srv.Close()
 

--- a/provider/openrouter/transcription/transcription.go
+++ b/provider/openrouter/transcription/transcription.go
@@ -49,7 +49,7 @@ func (p *Provider) TranscriptionModel(id string) *sdk.TranscriptionModel {
 }
 
 func (p *Provider) ListModels(ctx context.Context) ([]*sdk.TranscriptionModel, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/models?output_modalities=text", http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/models?output_modalities=all", http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("openrouter transcription: build list models request: %w", err)
 	}
@@ -110,15 +110,14 @@ func decodeOpenRouterModels(r io.Reader) ([]openRouterModel, error) {
 }
 
 func isAudioInputModel(id string, inputs []string) bool {
-	lowerID := strings.ToLower(id)
-	if strings.Contains(lowerID, "transcribe") || strings.Contains(lowerID, "audio") {
-		return true
-	}
 	for _, input := range inputs {
-		switch strings.ToLower(input) {
-		case "audio", "file":
+		if strings.ToLower(input) == "audio" {
 			return true
 		}
+	}
+	lowerID := strings.ToLower(id)
+	if strings.Contains(lowerID, "transcribe") {
+		return true
 	}
 	return false
 }

--- a/provider/openrouter/transcription/transcription.go
+++ b/provider/openrouter/transcription/transcription.go
@@ -111,15 +111,12 @@ func decodeOpenRouterModels(r io.Reader) ([]openRouterModel, error) {
 
 func isAudioInputModel(id string, inputs []string) bool {
 	for _, input := range inputs {
-		if strings.ToLower(input) == "audio" {
+		if strings.EqualFold(input, "audio") {
 			return true
 		}
 	}
 	lowerID := strings.ToLower(id)
-	if strings.Contains(lowerID, "transcribe") {
-		return true
-	}
-	return false
+	return strings.Contains(lowerID, "transcribe")
 }
 
 type audioConfig struct {

--- a/provider/openrouter/transcription/transcription_test.go
+++ b/provider/openrouter/transcription/transcription_test.go
@@ -12,7 +12,13 @@ import (
 func TestProvider_ListModels(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"data":[{"id":"openai/gpt-4o-mini-transcribe","architecture":{"input_modalities":["audio"],"output_modalities":["text"]}},{"id":"openai/gpt-4o-mini","architecture":{"input_modalities":["text"],"output_modalities":["text"]}}]}`))
+		if r.URL.Path != "/models" {
+			t.Errorf("path = %s, want /models", r.URL.Path)
+		}
+		if r.URL.Query().Get("output_modalities") != "all" {
+			t.Errorf("output_modalities = %q, want all", r.URL.Query().Get("output_modalities"))
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"openai/gpt-4o-mini-transcribe","architecture":{"input_modalities":["audio"],"output_modalities":["text"]}},{"id":"openai/gpt-audio-mini","architecture":{"input_modalities":["text"],"output_modalities":["audio"]}},{"id":"openai/gpt-4o-mini","architecture":{"input_modalities":["text"],"output_modalities":["text"]}}]}`))
 	}))
 	defer srv.Close()
 

--- a/provider/volcengine/speech/speech.go
+++ b/provider/volcengine/speech/speech.go
@@ -100,7 +100,7 @@ func (p *Provider) SpeechModel(id string) *sdk.SpeechModel {
 
 // ListModels returns the speech models exposed by this provider.
 func (p *Provider) ListModels(context.Context) ([]*sdk.SpeechModel, error) {
-	return nil, fmt.Errorf("volcengine speech: provider does not expose a remote models discovery API in this SDK")
+	return nil, fmt.Errorf("volcengine speech: provider exposes speaker or timbre lists, not a remote model discovery API for SAMI TTS")
 }
 
 // invokeResponse is the JSON structure returned by SAMI /api/v1/invoke.


### PR DESCRIPTION
## Summary

- Implement Deepgram speech and transcription model discovery via `GET /v1/models`.
- Return Deepgram `canonical_name` values for TTS and STT model IDs.
- Tighten OpenRouter speech and transcription discovery to request `output_modalities=all` and filter by architecture modalities.
- Keep Edge, MiniMax, Volcengine, Alibaba Cloud, and Microsoft speech discovery explicitly unsupported with provider-specific reasons.

## Notes

MiniMax exposes `GET /v1/models`, but the official endpoint is OpenAI-compatible model listing and returns LLM model IDs, not TTS discovery for `speech-*` models. The provider therefore remains unsupported for `ListModels`.

## Validation

- `git diff --check`
- `/Volumes/Storage/Languages/mise/data/installs/go/1.25.6/bin/go test -count=1 ./provider/deepgram/... ./provider/minimax/... ./provider/openrouter/... ./provider/openai/speech ./provider/openai/transcription ./provider/elevenlabs/... ./provider/google/transcription ./provider/edge/speech ./provider/volcengine/speech ./provider/alibabacloud/speech ./provider/microsoft/speech ./sdk/...`

Full provider suite was also run:

- `/Volumes/Storage/Languages/mise/data/installs/go/1.25.6/bin/go test ./provider/... ./sdk/...`

That suite still fails in existing OpenAI integration tests because configured model IDs such as `google/gemini-2.5-flash`, `deepseek/deepseek-r1`, `deepseek/deepseek-chat`, and `openai/o4-mini` are rejected by the remote OpenAI-compatible endpoint.
