### PR TITLE
feat(openai): add MiniMax chat completions compat

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1218,11 +1218,21 @@ func WithAPIKey(apiKey string) Option
 func WithBaseURL(baseURL string) Option
 func WithHTTPClient(client *http.Client) Option
 func WithDeepSeekChatCompletionsCompat() Option
+func WithMiniMaxChatCompletionsCompat() Option
 ```
 
 `WithDeepSeekChatCompletionsCompat` keeps the generic `/chat/completions`
 transport while adapting DeepSeek's thinking toggle: `WithReasoningEffort("none")`
 sends `thinking: {type: "disabled"}` and omits `reasoning_effort`.
+
+`WithMiniMaxChatCompletionsCompat` keeps the generic `/chat/completions`
+transport while adapting MiniMax: it sends `reasoning_split: true` (so reasoning
+is returned in the `reasoning_details` field instead of inline `<think>` tags)
+and maps reasoning effort onto MiniMax's `thinking` toggle —
+`WithReasoningEffort("none")` sends `thinking: {type: "disabled"}`, any other
+effort sends `thinking: {type: "adaptive"}`, and `reasoning_effort` is omitted.
+The provider reads `reasoning_details` as reasoning text and preserves it in
+assistant history for later tool-call turns.
 
 #### Methods
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -101,6 +101,7 @@ model := provider.ChatModel("gpt-4o-mini")
 | `WithBaseURL(url)` | `https://api.openai.com/v1` | Base URL for API requests |
 | `WithHTTPClient(client)` | `&http.Client{}` | Custom HTTP client (for proxies, timeouts, etc.) |
 | `WithDeepSeekChatCompletionsCompat()` | disabled | Map `WithReasoningEffort("none")` to DeepSeek's thinking disable toggle |
+| `WithMiniMaxChatCompletionsCompat()` | disabled | Send `reasoning_split: true` and map reasoning effort to MiniMax's thinking toggle |
 
 ### API Endpoints for Discovery
 
@@ -137,6 +138,34 @@ adapts DeepSeek's thinking toggle:
 Note: `"none"` is the effort floor, which for DeepSeek means off. Sending
 `reasoning_effort: "none"` alone does not stop it thinking, so the provider sends
 `thinking: {type: "disabled"}` instead.
+
+MiniMax also uses the OpenAI-compatible endpoint, but ignores `reasoning_effort`
+and, by default, inlines reasoning into `content` as `<think>` tags. Enable the
+MiniMax compatibility option to get clean, separated reasoning:
+
+```go
+// MiniMax
+provider := completions.New(
+    completions.WithAPIKey("your-minimax-key"),
+    completions.WithBaseURL("https://api.minimax.io/v1"),
+    completions.WithMiniMaxChatCompletionsCompat(),
+)
+```
+
+Use `https://api.minimaxi.com/v1` instead for China-region MiniMax API keys.
+
+The option always sends `reasoning_split: true` (so reasoning is returned in
+`reasoning_details`) and maps reasoning effort to MiniMax's `thinking` toggle:
+
+| SDK option/value | MiniMax request |
+|------------------|-----------------|
+| `WithReasoningEffort("none")` | `thinking: {type: "disabled"}` |
+| any other `WithReasoningEffort(...)` value | `thinking: {type: "adaptive"}` |
+| no reasoning effort | `thinking` omitted (MiniMax default) |
+
+Reasoning is read from `reasoning_details` and preserved in assistant history, so
+MiniMax otherwise uses the generic Chat Completions path with minimal special
+handling.
 
 Other OpenAI-compatible services use `completions.New()` with a base URL:
 

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -27,7 +27,10 @@ type Option func(*Provider)
 
 type chatCompletionsCompat string
 
-const chatCompletionsCompatDeepSeek chatCompletionsCompat = "deepseek"
+const (
+	chatCompletionsCompatDeepSeek chatCompletionsCompat = "deepseek"
+	chatCompletionsCompatMiniMax  chatCompletionsCompat = "minimax"
+)
 
 func WithAPIKey(apiKey string) Option {
 	return func(p *Provider) {
@@ -68,6 +71,16 @@ func WithHTTPClient(client *http.Client) Option {
 func WithDeepSeekChatCompletionsCompat() Option {
 	return func(p *Provider) {
 		p.compat = chatCompletionsCompatDeepSeek
+	}
+}
+
+// WithMiniMaxChatCompletionsCompat adapts MiniMax's OpenAI-compatible Chat
+// Completions transport: it sends reasoning_split=true so thinking is returned
+// in reasoning_details instead of inline <think> tags, and maps reasoning
+// efforts onto MiniMax's thinking toggle (none -> disabled, otherwise adaptive).
+func WithMiniMaxChatCompletionsCompat() Option {
+	return func(p *Provider) {
+		p.compat = chatCompletionsCompatMiniMax
 	}
 }
 
@@ -229,20 +242,38 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *chatRequest {
 }
 
 func (p *Provider) applyChatCompletionsCompat(req *chatRequest) {
-	if p.compat != chatCompletionsCompatDeepSeek {
-		return
-	}
-	if req.ReasoningEffort == nil {
-		return
-	}
-	effort := strings.TrimSpace(*req.ReasoningEffort)
-	if effort == "" {
-		return
-	}
-	switch strings.ToLower(effort) {
-	case "none", "disable", "disabled":
+	switch p.compat {
+	case chatCompletionsCompatDeepSeek:
+		if req.ReasoningEffort == nil {
+			return
+		}
+		effort := strings.TrimSpace(*req.ReasoningEffort)
+		if effort == "" {
+			return
+		}
+		switch strings.ToLower(effort) {
+		case "none", "disable", "disabled":
+			req.ReasoningEffort = nil
+			req.Thinking = &chatThinking{Type: "disabled"}
+		}
+	case chatCompletionsCompatMiniMax:
+		// MiniMax does not honor reasoning_effort; it gates thinking via the
+		// thinking toggle and separates reasoning into reasoning_details when
+		// reasoning_split is set.
+		req.ReasoningSplit = true
+		if req.ReasoningEffort == nil {
+			return
+		}
+		effort := strings.ToLower(strings.TrimSpace(*req.ReasoningEffort))
 		req.ReasoningEffort = nil
-		req.Thinking = &chatThinking{Type: "disabled"}
+		switch effort {
+		case "":
+			// no explicit effort: leave thinking at MiniMax's default.
+		case "none", "disable", "disabled":
+			req.Thinking = &chatThinking{Type: "disabled"}
+		default:
+			req.Thinking = &chatThinking{Type: "adaptive"}
+		}
 	}
 }
 
@@ -299,6 +330,7 @@ func convertAssistantMessage(msg sdk.Message) chatMessage {
 	var contentParts []sdk.MessagePart
 	var toolCalls []chatToolCall
 	var reasoning string
+	var reasoningDetails []chatReasoningDetail
 
 	for _, part := range msg.Content {
 		switch p := part.(type) {
@@ -321,6 +353,9 @@ func convertAssistantMessage(msg sdk.Message) chatMessage {
 			})
 		case sdk.ReasoningPart:
 			reasoning += p.Text
+			if details := extractMiniMaxReasoningDetails(p.ProviderMetadata); len(details) > 0 {
+				reasoningDetails = details
+			}
 		default:
 			contentParts = append(contentParts, part)
 		}
@@ -329,7 +364,9 @@ func convertAssistantMessage(msg sdk.Message) chatMessage {
 	if len(contentParts) > 0 {
 		cm.Content = convertContent(contentParts)
 	}
-	if reasoning != "" {
+	if len(reasoningDetails) > 0 {
+		cm.ReasoningDetails = reasoningDetails
+	} else if reasoning != "" {
 		cm.ReasoningContent = reasoning
 	}
 	if len(toolCalls) > 0 {
@@ -394,6 +431,9 @@ func (p *Provider) parseResponse(resp *chatResponse) (*sdk.GenerateResult, error
 		choice := resp.Choices[0]
 		result.Text = choice.Message.Content
 		result.Reasoning = reasoningFromMessage(&choice.Message)
+		if len(choice.Message.ReasoningDetails) > 0 {
+			result.ReasoningProviderMetadata = minimaxReasoningMetadata(choice.Message.ReasoningDetails)
+		}
 		result.FinishReason = mapFinishReason(choice.FinishReason)
 		result.RawFinishReason = choice.FinishReason
 
@@ -521,6 +561,11 @@ type streamingToolCall struct {
 // ---------- helpers ----------
 
 func reasoningFromMessage(m *chatRespMessage) string {
+	if len(m.ReasoningDetails) > 0 {
+		if text := reasoningTextFromDetails(m.ReasoningDetails); text != "" {
+			return text
+		}
+	}
 	if m.ReasoningContent != "" {
 		return m.ReasoningContent
 	}
@@ -528,10 +573,85 @@ func reasoningFromMessage(m *chatRespMessage) string {
 }
 
 func reasoningFromDelta(d *chatChunkDelta) string {
+	if len(d.ReasoningDetails) > 0 {
+		if text := reasoningTextFromDetails(d.ReasoningDetails); text != "" {
+			return text
+		}
+	}
 	if d.ReasoningContent != "" {
 		return d.ReasoningContent
 	}
 	return d.Reasoning
+}
+
+func reasoningTextFromDetails(details []chatReasoningDetail) string {
+	for i := len(details) - 1; i >= 0; i-- {
+		if text, _ := details[i]["text"].(string); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func minimaxReasoningMetadata(details []chatReasoningDetail) map[string]any {
+	if len(details) == 0 {
+		return nil
+	}
+	return map[string]any{
+		"minimax": map[string]any{
+			"reasoning_details": copyReasoningDetails(details),
+		},
+	}
+}
+
+func extractMiniMaxReasoningDetails(meta map[string]any) []chatReasoningDetail {
+	if meta == nil {
+		return nil
+	}
+	minimax, ok := meta["minimax"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return coerceReasoningDetails(minimax["reasoning_details"])
+}
+
+func coerceReasoningDetails(raw any) []chatReasoningDetail {
+	switch v := raw.(type) {
+	case []chatReasoningDetail:
+		return copyReasoningDetails(v)
+	case []map[string]any:
+		out := make([]chatReasoningDetail, 0, len(v))
+		for _, detail := range v {
+			out = append(out, copyReasoningDetail(detail))
+		}
+		return out
+	case []any:
+		out := make([]chatReasoningDetail, 0, len(v))
+		for _, item := range v {
+			if detail, ok := item.(map[string]any); ok {
+				out = append(out, copyReasoningDetail(detail))
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func copyReasoningDetails(details []chatReasoningDetail) []chatReasoningDetail {
+	out := make([]chatReasoningDetail, 0, len(details))
+	for _, detail := range details {
+		out = append(out, copyReasoningDetail(detail))
+	}
+	return out
+}
+
+func copyReasoningDetail(detail map[string]any) chatReasoningDetail {
+	out := make(chatReasoningDetail, len(detail))
+	for k, v := range detail {
+		out[k] = v
+	}
+	return out
 }
 
 func convertUsage(u *chatUsage) sdk.Usage {

--- a/provider/openai/completions/completions_test.go
+++ b/provider/openai/completions/completions_test.go
@@ -1471,6 +1471,279 @@ func TestTestModel_NotSupported(t *testing.T) {
 	}
 }
 
+func TestDoGenerate_MiniMaxCompatDisablesThinkingAndSplitsReasoning(t *testing.T) {
+	var body struct {
+		ReasoningEffort *string `json:"reasoning_effort"`
+		ReasoningSplit  bool    `json:"reasoning_split"`
+		Thinking        *struct {
+			Type string `json:"type"`
+		} `json:"thinking"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":    "chatcmpl-minimax",
+			"model": "MiniMax-M3",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithMiniMaxChatCompletionsCompat(),
+	)
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:           &sdk.Model{ID: "MiniMax-M3"},
+		Messages:        []sdk.Message{sdk.UserMessage("hi")},
+		ReasoningEffort: stringPtr("none"),
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	if !body.ReasoningSplit {
+		t.Fatal("expected reasoning_split=true")
+	}
+	if body.ReasoningEffort != nil {
+		t.Fatalf("reasoning_effort should be omitted, got %q", *body.ReasoningEffort)
+	}
+	if body.Thinking == nil || body.Thinking.Type != "disabled" {
+		t.Fatalf("thinking: got %#v, want disabled", body.Thinking)
+	}
+}
+
+func TestDoGenerate_MiniMaxCompatMapsReasoningEffortToAdaptiveThinking(t *testing.T) {
+	var body struct {
+		ReasoningEffort *string `json:"reasoning_effort"`
+		ReasoningSplit  bool    `json:"reasoning_split"`
+		Thinking        *struct {
+			Type string `json:"type"`
+		} `json:"thinking"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":    "chatcmpl-minimax",
+			"model": "MiniMax-M3",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithMiniMaxChatCompletionsCompat(),
+	)
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:           &sdk.Model{ID: "MiniMax-M3"},
+		Messages:        []sdk.Message{sdk.UserMessage("hi")},
+		ReasoningEffort: stringPtr("high"),
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	if !body.ReasoningSplit {
+		t.Fatal("expected reasoning_split=true")
+	}
+	if body.ReasoningEffort != nil {
+		t.Fatalf("reasoning_effort should be omitted, got %q", *body.ReasoningEffort)
+	}
+	if body.Thinking == nil || body.Thinking.Type != "adaptive" {
+		t.Fatalf("thinking: got %#v, want adaptive", body.Thinking)
+	}
+}
+
+func TestGenerateTextResult_MiniMaxReasoningDetailsPreserved(t *testing.T) {
+	var call int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		if call == 2 {
+			var body struct {
+				Messages []json.RawMessage `json:"messages"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if len(body.Messages) < 2 {
+				t.Fatalf("expected assistant history in second request, got %d messages", len(body.Messages))
+			}
+			var assistantMsg struct {
+				ReasoningContent string           `json:"reasoning_content"`
+				ReasoningDetails []map[string]any `json:"reasoning_details"`
+			}
+			if err := json.Unmarshal(body.Messages[1], &assistantMsg); err != nil {
+				t.Fatalf("decode assistant history: %v", err)
+			}
+			if assistantMsg.ReasoningContent != "" {
+				t.Fatalf("reasoning_content should be omitted for MiniMax history, got %q", assistantMsg.ReasoningContent)
+			}
+			if len(assistantMsg.ReasoningDetails) != 1 || assistantMsg.ReasoningDetails[0]["text"] != "Let me think" {
+				t.Fatalf("reasoning_details: got %#v", assistantMsg.ReasoningDetails)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":    "chatcmpl-minimax",
+			"model": "MiniMax-M3",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message": map[string]any{
+					"role":              "assistant",
+					"content":           "ok",
+					"reasoning_content": "legacy reasoning",
+					"reasoning_details": []map[string]any{{
+						"type":   "reasoning.text",
+						"id":     "reasoning-text-1",
+						"format": "MiniMax-response-v1",
+						"index":  0,
+						"text":   "Let me think",
+					}},
+				},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithMiniMaxChatCompletionsCompat(),
+	)
+	model := p.ChatModel("MiniMax-M3")
+
+	result, err := sdk.GenerateTextResult(
+		context.Background(),
+		sdk.WithModel(model),
+		sdk.WithMessages([]sdk.Message{sdk.UserMessage("hi")}),
+	)
+	if err != nil {
+		t.Fatalf("GenerateTextResult: %v", err)
+	}
+	if result.Reasoning != "Let me think" {
+		t.Fatalf("reasoning: got %q", result.Reasoning)
+	}
+
+	history := make([]sdk.Message, 0, 1+len(result.Messages)+1)
+	history = append(history, sdk.UserMessage("hi"))
+	history = append(history, result.Messages...)
+	history = append(history, sdk.UserMessage("continue"))
+	if _, err := sdk.GenerateTextResult(
+		context.Background(),
+		sdk.WithModel(model),
+		sdk.WithMessages(history),
+	); err != nil {
+		t.Fatalf("second GenerateTextResult: %v", err)
+	}
+}
+
+func TestDoStream_MiniMaxReasoningDetails(t *testing.T) {
+	var reasoningSplit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ReasoningSplit bool `json:"reasoning_split"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		reasoningSplit = body.ReasoningSplit
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		chunks := []string{
+			`{"id":"c1","model":"MiniMax-M3","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"legacy","reasoning_details":[{"type":"reasoning.text","id":"reasoning-text-1","format":"MiniMax-response-v1","index":0,"text":"Let"}]},"finish_reason":null}]}`,
+			`{"id":"c1","model":"MiniMax-M3","choices":[{"index":0,"delta":{"reasoning_content":" fallback","reasoning_details":[{"type":"reasoning.text","id":"reasoning-text-1","format":"MiniMax-response-v1","index":0,"text":" me think"}]},"finish_reason":null}]}`,
+			`{"id":"c1","model":"MiniMax-M3","choices":[{"index":0,"delta":{"content":"The answer"},"finish_reason":null}]}`,
+			`{"id":"c1","model":"MiniMax-M3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}`,
+		}
+		for _, c := range chunks {
+			fmt.Fprintf(w, "data: %s\n\n", c)
+			flusher.Flush()
+		}
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithMiniMaxChatCompletionsCompat(),
+	)
+	sr, err := p.DoStream(context.Background(), sdk.GenerateParams{
+		Model:    &sdk.Model{ID: "MiniMax-M3"},
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+
+	var reasoning, text string
+	var reasoningMeta map[string]any
+	for part := range sr.Stream {
+		switch p := part.(type) {
+		case *sdk.ReasoningDeltaPart:
+			reasoning += p.Text
+		case *sdk.ReasoningEndPart:
+			reasoningMeta = p.ProviderMetadata
+		case *sdk.TextDeltaPart:
+			text += p.Text
+		case *sdk.ErrorPart:
+			t.Fatalf("error: %v", p.Error)
+		}
+	}
+	if !reasoningSplit {
+		t.Fatal("expected reasoning_split=true on the streaming request")
+	}
+	if reasoning != "Let me think" {
+		t.Errorf("reasoning: got %q", reasoning)
+	}
+	details := minimaxReasoningDetailsFromTestMetadata(t, reasoningMeta)
+	if len(details) != 1 || details[0]["text"] != "Let me think" {
+		t.Errorf("reasoning metadata details: got %#v", details)
+	}
+	if text != "The answer" {
+		t.Errorf("text: got %q", text)
+	}
+}
+
+func minimaxReasoningDetailsFromTestMetadata(t *testing.T, meta map[string]any) []map[string]any {
+	t.Helper()
+	minimax, ok := meta["minimax"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected minimax metadata, got %#v", meta)
+	}
+	raw, err := json.Marshal(minimax["reasoning_details"])
+	if err != nil {
+		t.Fatalf("marshal reasoning_details metadata: %v", err)
+	}
+	var details []map[string]any
+	if err := json.Unmarshal(raw, &details); err != nil {
+		t.Fatalf("unmarshal reasoning_details metadata: %v", err)
+	}
+	return details
+}
+
 func stringPtr(s string) *string { return &s }
 
 func TestMain(m *testing.M) {

--- a/provider/openai/completions/stream.go
+++ b/provider/openai/completions/stream.go
@@ -23,6 +23,8 @@ type streamProcessor struct {
 	flushed            bool
 	finishStepPending  bool
 	pendingToolCalls   map[int]*streamingToolCall
+	reasoningDetails   []chatReasoningDetail
+	reasoningText      string
 }
 
 func (sp *streamProcessor) send(part sdk.StreamPart) bool {
@@ -36,7 +38,7 @@ func (sp *streamProcessor) send(part sdk.StreamPart) bool {
 
 func (sp *streamProcessor) endReasoning(id string) {
 	if sp.reasoningStartSent {
-		sp.send(&sdk.ReasoningEndPart{ID: id})
+		sp.send(&sdk.ReasoningEndPart{ID: id, ProviderMetadata: minimaxReasoningMetadata(sp.reasoningDetails)})
 		sp.reasoningStartSent = false
 	}
 }
@@ -107,11 +109,38 @@ func (sp *streamProcessor) processReasoning(delta *chatChunkDelta, chunkID strin
 	if reasoningContent == "" {
 		return
 	}
+	if len(delta.ReasoningDetails) > 0 {
+		reasoningContent = trimReasoningPrefix(reasoningContent, sp.reasoningText)
+		sp.reasoningText += reasoningContent
+		sp.reasoningDetails = reasoningDetailsWithText(delta.ReasoningDetails, sp.reasoningText)
+	}
+	if reasoningContent == "" {
+		return
+	}
 	if !sp.reasoningStartSent {
 		sp.send(&sdk.ReasoningStartPart{ID: chunkID})
 		sp.reasoningStartSent = true
 	}
 	sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent})
+}
+
+func trimReasoningPrefix(text, previous string) string {
+	if previous == "" {
+		return text
+	}
+	if len(text) >= len(previous) && text[:len(previous)] == previous {
+		return text[len(previous):]
+	}
+	return text
+}
+
+func reasoningDetailsWithText(details []chatReasoningDetail, text string) []chatReasoningDetail {
+	if len(details) == 0 {
+		return nil
+	}
+	out := copyReasoningDetails(details)
+	out[len(out)-1]["text"] = text
+	return out
 }
 
 func (sp *streamProcessor) processContent(delta *chatChunkDelta, chunkID string) {

--- a/provider/openai/completions/types.go
+++ b/provider/openai/completions/types.go
@@ -17,6 +17,7 @@ type chatRequest struct {
 	Seed                *int               `json:"seed,omitempty"`
 	ReasoningEffort     *string            `json:"reasoning_effort,omitempty"`
 	Thinking            *chatThinking      `json:"thinking,omitempty"`
+	ReasoningSplit      bool               `json:"reasoning_split,omitempty"`
 	Stream              bool               `json:"stream,omitempty"`
 	StreamOptions       *chatStreamOptions `json:"stream_options,omitempty"`
 }
@@ -46,12 +47,15 @@ type chatFunction struct {
 }
 
 type chatMessage struct {
-	Role             string         `json:"role"`
-	Content          any            `json:"content"`
-	ReasoningContent string         `json:"reasoning_content,omitempty"`
-	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
-	ToolCallID       string         `json:"tool_call_id,omitempty"`
+	Role             string                `json:"role"`
+	Content          any                   `json:"content"`
+	ReasoningContent string                `json:"reasoning_content,omitempty"`
+	ReasoningDetails []chatReasoningDetail `json:"reasoning_details,omitempty"`
+	ToolCalls        []chatToolCall        `json:"tool_calls,omitempty"`
+	ToolCallID       string                `json:"tool_call_id,omitempty"`
 }
+
+type chatReasoningDetail map[string]any
 
 type chatContentPartText struct {
 	Type string `json:"type"`
@@ -86,13 +90,14 @@ type chatChoice struct {
 }
 
 type chatRespMessage struct {
-	Role             string          `json:"role"`
-	Content          string          `json:"content"`
-	ReasoningContent string          `json:"reasoning_content,omitempty"`
-	Reasoning        string          `json:"reasoning,omitempty"`
-	Refusal          string          `json:"refusal,omitempty"`
-	ToolCalls        []chatToolCall  `json:"tool_calls,omitempty"`
-	Images           []chatImagePart `json:"images,omitempty"`
+	Role             string                `json:"role"`
+	Content          string                `json:"content"`
+	ReasoningContent string                `json:"reasoning_content,omitempty"`
+	ReasoningDetails []chatReasoningDetail `json:"reasoning_details,omitempty"`
+	Reasoning        string                `json:"reasoning,omitempty"`
+	Refusal          string                `json:"refusal,omitempty"`
+	ToolCalls        []chatToolCall        `json:"tool_calls,omitempty"`
+	Images           []chatImagePart       `json:"images,omitempty"`
 }
 
 type chatToolCall struct {
@@ -141,13 +146,14 @@ type chatChunkChoice struct {
 }
 
 type chatChunkDelta struct {
-	Role             string              `json:"role,omitempty"`
-	Content          string              `json:"content,omitempty"`
-	ReasoningContent string              `json:"reasoning_content,omitempty"`
-	Reasoning        string              `json:"reasoning,omitempty"`
-	Refusal          string              `json:"refusal,omitempty"`
-	ToolCalls        []chatToolCallChunk `json:"tool_calls,omitempty"`
-	Images           []chatImagePart     `json:"images,omitempty"`
+	Role             string                `json:"role,omitempty"`
+	Content          string                `json:"content,omitempty"`
+	ReasoningContent string                `json:"reasoning_content,omitempty"`
+	ReasoningDetails []chatReasoningDetail `json:"reasoning_details,omitempty"`
+	Reasoning        string                `json:"reasoning,omitempty"`
+	Refusal          string                `json:"refusal,omitempty"`
+	ToolCalls        []chatToolCallChunk   `json:"tool_calls,omitempty"`
+	Images           []chatImagePart       `json:"images,omitempty"`
 }
 
 type chatImagePart struct {


### PR DESCRIPTION
## Summary
- Add `WithMiniMaxChatCompletionsCompat()` for MiniMax OpenAI-compatible Chat Completions.
- Send `reasoning_split: true`, map SDK reasoning effort onto MiniMax `thinking`, and omit unsupported `reasoning_effort`.
- Parse `reasoning_details` for non-streaming and streaming responses, preserve it in assistant history for later tool-call turns, and update provider docs.

## Testing
- `go test ./...`
- Smoke-tested non-streaming and streaming requests against the MiniMax OpenAI-compatible endpoint; streaming `reasoning_details` can arrive as deltas, which is covered by the new tests.

## Notes
- MiniMax documents `reasoning_split: true` as the compatible format for preserving interleaved thinking via `reasoning_details`.
- China-region keys should use `https://api.minimaxi.com/v1`; international keys can use `https://api.minimax.io/v1`.
