### PR TITLE
fix(google): send tool schemas via parametersJsonSchema

### DIFF
--- a/provider/google/generativeai/generativeai.go
+++ b/provider/google/generativeai/generativeai.go
@@ -355,9 +355,9 @@ func convertTools(tools []sdk.Tool, toolChoice any) ([]toolGroup, *toolConfig) {
 	decls := make([]functionDeclaration, 0, len(tools))
 	for _, t := range tools {
 		decls = append(decls, functionDeclaration{
-			Name:        t.Name,
-			Description: t.Description,
-			Parameters:  t.Parameters,
+			Name:                 t.Name,
+			Description:          t.Description,
+			ParametersJSONSchema: t.Parameters,
 		})
 	}
 

--- a/provider/google/generativeai/generativeai_test.go
+++ b/provider/google/generativeai/generativeai_test.go
@@ -85,12 +85,22 @@ func TestDoGenerate(t *testing.T) {
 
 func TestDoGenerate_ToolCall(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rawBody map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&rawBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		data, err := json.Marshal(rawBody)
+		if err != nil {
+			t.Fatalf("marshal request body: %v", err)
+		}
+
 		var body struct {
 			Tools []struct {
 				FunctionDeclarations []struct {
-					Name        string `json:"name"`
-					Description string `json:"description"`
-					Parameters  any    `json:"parameters"`
+					Name                 string `json:"name"`
+					Description          string `json:"description"`
+					Parameters           any    `json:"parameters"`
+					ParametersJSONSchema any    `json:"parametersJsonSchema"`
 				} `json:"functionDeclarations"`
 			} `json:"tools"`
 			ToolConfig *struct {
@@ -99,7 +109,9 @@ func TestDoGenerate_ToolCall(t *testing.T) {
 				} `json:"functionCallingConfig"`
 			} `json:"toolConfig"`
 		}
-		json.NewDecoder(r.Body).Decode(&body)
+		if err := json.Unmarshal(data, &body); err != nil {
+			t.Fatalf("unmarshal request body: %v", err)
+		}
 
 		if len(body.Tools) != 1 {
 			t.Fatalf("expected 1 tool group, got %d", len(body.Tools))
@@ -109,6 +121,54 @@ func TestDoGenerate_ToolCall(t *testing.T) {
 		}
 		if body.Tools[0].FunctionDeclarations[0].Name != "get_weather" {
 			t.Errorf("tool name: got %q", body.Tools[0].FunctionDeclarations[0].Name)
+		}
+		if body.Tools[0].FunctionDeclarations[0].Parameters != nil {
+			t.Errorf("expected parameters to be omitted")
+		}
+		if body.Tools[0].FunctionDeclarations[0].ParametersJSONSchema == nil {
+			t.Errorf("expected parametersJsonSchema to be set")
+		}
+
+		toolsRaw, ok := rawBody["tools"].([]any)
+		if !ok || len(toolsRaw) != 1 {
+			t.Fatalf("raw tools: got %T %v", rawBody["tools"], rawBody["tools"])
+		}
+		toolRaw, ok := toolsRaw[0].(map[string]any)
+		if !ok {
+			t.Fatalf("raw tool type: got %T", toolsRaw[0])
+		}
+		declsRaw, ok := toolRaw["functionDeclarations"].([]any)
+		if !ok || len(declsRaw) != 1 {
+			t.Fatalf("raw functionDeclarations: got %T %v", toolRaw["functionDeclarations"], toolRaw["functionDeclarations"])
+		}
+		declRaw, ok := declsRaw[0].(map[string]any)
+		if !ok {
+			t.Fatalf("raw function declaration type: got %T", declsRaw[0])
+		}
+		if _, ok := declRaw["parameters"]; ok {
+			t.Errorf("expected raw parameters key to be omitted")
+		}
+		schema, ok := declRaw["parametersJsonSchema"].(map[string]any)
+		if !ok {
+			t.Fatalf("raw parametersJsonSchema type: got %T", declRaw["parametersJsonSchema"])
+		}
+		if schema["additionalProperties"] != false {
+			t.Errorf("additionalProperties: got %v, want false", schema["additionalProperties"])
+		}
+		props, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("properties type: got %T", schema["properties"])
+		}
+		location, ok := props["location"].(map[string]any)
+		if !ok {
+			t.Fatalf("location property type: got %T", props["location"])
+		}
+		if location["type"] != "string" {
+			t.Errorf("location type: got %v, want string", location["type"])
+		}
+		required, ok := schema["required"].([]any)
+		if !ok || len(required) != 1 || required[0] != "location" {
+			t.Errorf("required: got %v, want [location]", schema["required"])
 		}
 		if body.ToolConfig == nil || body.ToolConfig.FunctionCallingConfig.Mode != "AUTO" {
 			t.Errorf("expected AUTO tool config mode")
@@ -153,7 +213,8 @@ func TestDoGenerate_ToolCall(t *testing.T) {
 				Properties: map[string]*jsonschema.Schema{
 					"location": {Type: "string"},
 				},
-				Required: []string{"location"},
+				Required:             []string{"location"},
+				AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
 			},
 		}},
 		ToolChoice: "auto",
@@ -1065,6 +1126,58 @@ func TestIntegration_ToolCall(t *testing.T) {
 	}
 	for _, tc := range result.ToolCalls {
 		t.Logf("  tool=%q id=%s input=%v", tc.ToolName, tc.ToolCallID, tc.Input)
+	}
+}
+
+func TestIntegration_ToolCallWithAdditionalPropertiesSchema(t *testing.T) {
+	p := newIntegrationProvider(t)
+	model := integrationModel(t)
+	model.Provider = p
+
+	result, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: model,
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleUser,
+			Content: []sdk.MessagePart{sdk.TextPart{
+				Text: "Call get_weather with location San Francisco.",
+			}},
+		}},
+		Tools: []sdk.Tool{{
+			Name:        "get_weather",
+			Description: "Get the weather for a location.",
+			Parameters: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"location": {Type: "string", Description: "City name"},
+				},
+				Required:             []string{"location"},
+				AdditionalProperties: &jsonschema.Schema{Not: &jsonschema.Schema{}},
+			},
+		}},
+		ToolChoice: "required",
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate with additionalProperties in tool schema: %v", err)
+	}
+	t.Logf("finish=%s toolCalls=%d text=%q", result.FinishReason, len(result.ToolCalls), result.Text)
+
+	if result.FinishReason != sdk.FinishReasonToolCalls {
+		t.Errorf("finish: got %q, want %q", result.FinishReason, sdk.FinishReasonToolCalls)
+	}
+	if len(result.ToolCalls) == 0 {
+		t.Fatal("expected at least one tool call")
+	}
+	tc := result.ToolCalls[0]
+	t.Logf("  tool=%q id=%s input=%v", tc.ToolName, tc.ToolCallID, tc.Input)
+	if tc.ToolName != "get_weather" {
+		t.Errorf("tool name: got %q, want get_weather", tc.ToolName)
+	}
+	input, ok := tc.Input.(map[string]any)
+	if !ok {
+		t.Fatalf("input type: got %T", tc.Input)
+	}
+	if location, ok := input["location"].(string); !ok || location == "" {
+		t.Errorf("location input: got %v", input["location"])
 	}
 }
 

--- a/provider/google/generativeai/types.go
+++ b/provider/google/generativeai/types.go
@@ -3,12 +3,12 @@ package generativeai
 // --- Request types ---
 
 type generateRequest struct {
-	Contents          []content        `json:"contents"`
-	SystemInstruction *content         `json:"systemInstruction,omitempty"`
+	Contents          []content         `json:"contents"`
+	SystemInstruction *content          `json:"systemInstruction,omitempty"`
 	GenerationConfig  *generationConfig `json:"generationConfig,omitempty"`
-	Tools             []toolGroup      `json:"tools,omitempty"`
-	ToolConfig        *toolConfig      `json:"toolConfig,omitempty"`
-	SafetySettings    []safetySetting  `json:"safetySettings,omitempty"`
+	Tools             []toolGroup       `json:"tools,omitempty"`
+	ToolConfig        *toolConfig       `json:"toolConfig,omitempty"`
+	SafetySettings    []safetySetting   `json:"safetySettings,omitempty"`
 }
 
 type content struct {
@@ -69,9 +69,9 @@ type toolGroup struct {
 }
 
 type functionDeclaration struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Parameters  any    `json:"parameters,omitempty"`
+	Name                 string `json:"name"`
+	Description          string `json:"description"`
+	ParametersJSONSchema any    `json:"parametersJsonSchema,omitempty"`
 }
 
 type toolConfig struct {
@@ -91,14 +91,14 @@ type safetySetting struct {
 // --- Response types ---
 
 type generateResponse struct {
-	Candidates    []candidate    `json:"candidates"`
-	UsageMetadata *usageMetadata `json:"usageMetadata,omitempty"`
+	Candidates     []candidate     `json:"candidates"`
+	UsageMetadata  *usageMetadata  `json:"usageMetadata,omitempty"`
 	PromptFeedback *promptFeedback `json:"promptFeedback,omitempty"`
 }
 
 type candidate struct {
-	Content      *content       `json:"content,omitempty"`
-	FinishReason string         `json:"finishReason,omitempty"`
+	Content       *content       `json:"content,omitempty"`
+	FinishReason  string         `json:"finishReason,omitempty"`
 	SafetyRatings []safetyRating `json:"safetyRatings,omitempty"`
 }
 


### PR DESCRIPTION
## 背景

关联 issue：memohai/Memoh#620

Memoh 在使用 Gemini tool calling 时会遇到 400 报错。原因是 Twilight AI 旧实现把 `sdk.Tool.Parameters` 放到了 Gemini `functionDeclarations[].parameters`。但 Gemini 的 `parameters` 是 Schema 子集，不支持完整 JSON Schema 字段，例如 `additionalProperties`。

当工具参数 schema 包含 `additionalProperties: false` 时，Gemini 会返回：

```text
Unknown name "additionalProperties" at 'tools[0].function_declarations[0].parameters'
```

## 修改内容

- Google Generative AI provider 改为通过 `parametersJsonSchema` 发送工具参数 schema
- 保留完整 JSON Schema 语义，包括 `additionalProperties: false`
- 增加真实 Gemini integration test，覆盖带 `additionalProperties` 的 tool schema
- 加强 mock 单测，确保请求体：
  - 不再发送 `parameters`
  - 发送 `parametersJsonSchema`
  - 保留 `additionalProperties: false`

## 验证

已通过：

- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go build ./...`
- `go test ./... -short -race -count=1`
- `go test ./provider/google/generativeai -run TestIntegration_ToolCallWithAdditionalPropertiesSchema -count=1 -v`
