### PR TITLE
feat(anthropic): cache_control on tool_result and assistant blocks

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -166,7 +166,8 @@ type MessagePart interface {
 
 ```go
 type TextPart struct {
-    Text string
+    Text         string
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 
 type ReasoningPart struct {
@@ -175,31 +176,48 @@ type ReasoningPart struct {
 }
 
 type ImagePart struct {
-    Image     string  // URL or base64
-    MediaType string  // optional, e.g. "image/png"
+    Image        string  // URL or base64
+    MediaType    string  // optional, e.g. "image/png"
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 
 type FilePart struct {
-    Data      string
-    MediaType string  // optional
-    Filename  string  // optional
+    Data         string
+    MediaType    string  // optional
+    Filename     string  // optional
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 
 type ToolCallPart struct {
-    ToolCallID string
-    ToolName   string
-    Input      any
+    ToolCallID   string
+    ToolName     string
+    Input        any
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 
 type ToolResultPart struct {
-    ToolCallID string
-    ToolName   string
-    Result     any
-    IsError    bool   // optional
+    ToolCallID   string
+    ToolName     string
+    Result       any
+    IsError      bool   // optional
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 ```
 
 `Message` supports full JSON serialization with automatic type discrimination.
+
+#### CacheControl
+
+`CacheControl` marks a content block as a prompt-caching breakpoint. It is
+honored only by the Anthropic provider; other providers ignore it. See
+[Prompt Caching](./providers.md#prompt-caching) for placement guidance.
+
+```go
+type CacheControl struct {
+    Type string  // "ephemeral"
+    TTL  string  // "" (5-minute default) | "1h"
+}
+```
 
 ---
 
@@ -335,6 +353,7 @@ type Tool struct {
     Parameters      any              // JSON Schema
     Execute         ToolExecuteFunc
     RequireApproval bool
+    CacheControl    *CacheControl    // optional, Anthropic only — caches tool definitions
 }
 
 type ToolExecuteFunc func(ctx *ToolExecContext, input any) (any, error)
@@ -499,8 +518,11 @@ type Usage struct {
 }
 
 type InputTokenDetail struct {
-    CacheReadTokens    int
-    CacheCreationTokens int
+    NoCacheTokens      int
+    CacheReadTokens    int  // tokens served from cache
+    CacheWriteTokens   int  // tokens written to cache
+    CacheWrite5mTokens int  // Anthropic: written to the 5-minute cache
+    CacheWrite1hTokens int  // Anthropic: written to the 1-hour cache (ttl="1h")
 }
 
 type OutputTokenDetail struct {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -543,6 +543,36 @@ provider := messages.New(
 
 When enabled, the model's internal reasoning appears in `result.Reasoning` (non-streaming) or as `ReasoningStartPart` / `ReasoningDeltaPart` / `ReasoningEndPart` events (streaming).
 
+### Prompt Caching
+
+Claude supports [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching): attach a `*sdk.CacheControl` breakpoint to a content block, and Anthropic caches the entire prefix up to and including it. Caching is a prefix match — a byte change anywhere before a breakpoint invalidates it — so place breakpoints at the end of stable content. Up to 4 breakpoints per request.
+
+`CacheControl` is honored on system, user, assistant, and tool-result content blocks, and on tool definitions. Other providers ignore it.
+
+```go
+// Cache a large, stable system prompt and the tool list.
+msgs := []sdk.Message{
+    {Role: sdk.MessageRoleSystem, Content: []sdk.MessagePart{
+        sdk.TextPart{Text: largeSystemPrompt, CacheControl: &sdk.CacheControl{Type: "ephemeral"}},
+    }},
+    sdk.UserMessage("..."),
+}
+
+tools := []sdk.Tool{
+    {Name: "search", Parameters: searchSchema},
+    // Breakpoint on the last tool caches all tool definitions above it.
+    {Name: "calc", Parameters: calcSchema, CacheControl: &sdk.CacheControl{Type: "ephemeral"}},
+}
+```
+
+For multi-turn and agentic flows, move the breakpoint forward to the last block of the most recently settled turn so the growing prefix is reused on the next request — a trailing tool result, or the assistant's text / tool call:
+
+```go
+sdk.ToolResultPart{ToolCallID: id, Result: out, CacheControl: &sdk.CacheControl{Type: "ephemeral"}}
+```
+
+Set `TTL: "1h"` for a 1-hour cache (higher write rate; the default empty TTL is 5 minutes). Cache activity is reported on `result.Usage`: `CachedInputTokens` (read), and under `InputTokenDetails`, `CacheReadTokens` / `CacheWriteTokens` with the per-TTL split in `CacheWrite5mTokens` / `CacheWrite1hTokens`.
+
 ### Supported Features
 
 | Feature | Supported |
@@ -552,6 +582,7 @@ When enabled, the model's internal reasoning appears in `result.Reasoning` (non-
 | Tool/function calling | ✅ |
 | Vision (image inputs) | ✅ |
 | Extended thinking | ✅ |
+| Prompt caching (`cache_control`) | ✅ |
 | Token usage reporting | ✅ |
 | Cached token details | ✅ |
 | ListModels / Test / TestModel | ✅ |

--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -496,7 +496,11 @@ func convertAssistantMessage(msg sdk.Message) anthropicMessage {
 	for _, part := range msg.Content {
 		switch p := part.(type) {
 		case sdk.TextPart:
-			blocks = append(blocks, contentBlock{Type: blockTypeText, Text: p.Text})
+			block := contentBlock{Type: blockTypeText, Text: p.Text}
+			if p.CacheControl != nil {
+				block.CacheControl = &cacheControl{Type: p.CacheControl.Type, TTL: p.CacheControl.TTL}
+			}
+			blocks = append(blocks, block)
 		case sdk.ReasoningPart:
 			sig := extractAnthropicSignature(p.ProviderMetadata)
 			if sig == "" {
@@ -522,12 +526,16 @@ func convertAssistantMessage(msg sdk.Message) anthropicMessage {
 			if input == nil {
 				input = map[string]any{}
 			}
-			blocks = append(blocks, contentBlock{
+			block := contentBlock{
 				Type:  blockTypeToolUse,
 				ID:    id,
 				Name:  p.ToolName,
 				Input: input,
-			})
+			}
+			if p.CacheControl != nil {
+				block.CacheControl = &cacheControl{Type: p.CacheControl.Type, TTL: p.CacheControl.TTL}
+			}
+			blocks = append(blocks, block)
 		}
 	}
 
@@ -544,6 +552,9 @@ func convertToolResults(parts []sdk.MessagePart) []contentBlock {
 				ToolUseID: trp.ToolCallID,
 				Content:   string(content),
 				IsError:   trp.IsError,
+			}
+			if trp.CacheControl != nil {
+				block.CacheControl = &cacheControl{Type: trp.CacheControl.Type, TTL: trp.CacheControl.TTL}
 			}
 			blocks = append(blocks, block)
 		}

--- a/provider/anthropic/messages/messages_test.go
+++ b/provider/anthropic/messages/messages_test.go
@@ -1185,6 +1185,256 @@ func TestDoGenerate_CacheControl_Tools(t *testing.T) {
 	}
 }
 
+func TestDoGenerate_CacheControl_ToolResultBlock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Type         string `json:"type"`
+					ToolUseID    string `json:"tool_use_id,omitempty"`
+					CacheControl *struct {
+						Type string `json:"type"`
+						TTL  string `json:"ttl,omitempty"`
+					} `json:"cache_control,omitempty"`
+				} `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		var result *struct {
+			Type         string
+			CacheControl *struct {
+				Type string `json:"type"`
+				TTL  string `json:"ttl,omitempty"`
+			}
+		}
+		for _, msg := range body.Messages {
+			for _, block := range msg.Content {
+				if block.Type == "tool_result" && block.ToolUseID == "toolu_1" {
+					result = &struct {
+						Type         string
+						CacheControl *struct {
+							Type string `json:"type"`
+							TTL  string `json:"ttl,omitempty"`
+						}
+					}{Type: block.Type, CacheControl: block.CacheControl}
+				}
+			}
+		}
+		if result == nil {
+			t.Fatal("expected a tool_result block for toolu_1, got none")
+		}
+		if result.CacheControl == nil {
+			t.Fatal("expected cache_control on tool_result block, got nil")
+		}
+		if result.CacheControl.Type != "ephemeral" {
+			t.Errorf("tool_result cache_control type: got %q, want ephemeral", result.CacheControl.Type)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_cc_tr", "type": "message", "model": "claude-sonnet-4-20250514", "role": "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "Done"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 40, "output_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := messages.New(messages.WithAPIKey("k"), messages.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "claude-sonnet-4-20250514"},
+		Messages: []sdk.Message{
+			sdk.UserMessage("search for cats"),
+			{
+				Role: sdk.MessageRoleAssistant,
+				Content: []sdk.MessagePart{
+					sdk.ToolCallPart{ToolCallID: "toolu_1", ToolName: "search", Input: map[string]any{"q": "cats"}},
+				},
+			},
+			{
+				Role: sdk.MessageRoleTool,
+				Content: []sdk.MessagePart{
+					sdk.ToolResultPart{
+						ToolCallID:   "toolu_1",
+						ToolName:     "search",
+						Result:       "found 10 results",
+						CacheControl: &sdk.CacheControl{Type: "ephemeral"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func TestDoGenerate_CacheControl_AssistantToolUse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Type         string `json:"type"`
+					CacheControl *struct {
+						Type string `json:"type"`
+						TTL  string `json:"ttl,omitempty"`
+					} `json:"cache_control,omitempty"`
+				} `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		var text, toolUse *struct {
+			Type         string `json:"type"`
+			CacheControl *struct {
+				Type string `json:"type"`
+				TTL  string `json:"ttl,omitempty"`
+			} `json:"cache_control,omitempty"`
+		}
+		for i := range body.Messages {
+			if body.Messages[i].Role != "assistant" {
+				continue
+			}
+			for j := range body.Messages[i].Content {
+				b := &body.Messages[i].Content[j]
+				switch b.Type {
+				case "text":
+					text = b
+				case "tool_use":
+					toolUse = b
+				}
+			}
+		}
+		if text == nil || toolUse == nil {
+			t.Fatalf("expected assistant text and tool_use blocks; text=%v toolUse=%v", text, toolUse)
+		}
+		if text.CacheControl != nil {
+			t.Error("assistant text block should not have cache_control")
+		}
+		if toolUse.CacheControl == nil {
+			t.Fatal("expected cache_control on assistant tool_use block, got nil")
+		}
+		if toolUse.CacheControl.Type != "ephemeral" {
+			t.Errorf("tool_use cache_control type: got %q, want ephemeral", toolUse.CacheControl.Type)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_cc_atu", "type": "message", "model": "claude-sonnet-4-20250514", "role": "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "ok"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 20, "output_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	p := messages.New(messages.WithAPIKey("k"), messages.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "claude-sonnet-4-20250514"},
+		Messages: []sdk.Message{
+			sdk.UserMessage("look it up"),
+			{
+				Role: sdk.MessageRoleAssistant,
+				Content: []sdk.MessagePart{
+					sdk.TextPart{Text: "Let me search."},
+					sdk.ToolCallPart{
+						ToolCallID:   "toolu_9",
+						ToolName:     "search",
+						Input:        map[string]any{"q": "x"},
+						CacheControl: &sdk.CacheControl{Type: "ephemeral"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func TestDoGenerate_CacheControl_AssistantText(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Type         string `json:"type"`
+					CacheControl *struct {
+						Type string `json:"type"`
+						TTL  string `json:"ttl,omitempty"`
+					} `json:"cache_control,omitempty"`
+				} `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		var assistantText *struct {
+			Type         string `json:"type"`
+			CacheControl *struct {
+				Type string `json:"type"`
+				TTL  string `json:"ttl,omitempty"`
+			} `json:"cache_control,omitempty"`
+		}
+		for i := range body.Messages {
+			if body.Messages[i].Role != "assistant" {
+				continue
+			}
+			for j := range body.Messages[i].Content {
+				if body.Messages[i].Content[j].Type == "text" {
+					assistantText = &body.Messages[i].Content[j]
+				}
+			}
+		}
+		if assistantText == nil {
+			t.Fatal("expected an assistant text block, got none")
+		}
+		if assistantText.CacheControl == nil {
+			t.Fatal("expected cache_control on assistant text block, got nil")
+		}
+		if assistantText.CacheControl.TTL != "1h" {
+			t.Errorf("assistant text cache_control ttl: got %q, want 1h", assistantText.CacheControl.TTL)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_cc_at", "type": "message", "model": "claude-sonnet-4-20250514", "role": "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "ok"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 15, "output_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	p := messages.New(messages.WithAPIKey("k"), messages.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "claude-sonnet-4-20250514"},
+		Messages: []sdk.Message{
+			sdk.UserMessage("hi"),
+			{
+				Role: sdk.MessageRoleAssistant,
+				Content: []sdk.MessagePart{
+					sdk.TextPart{
+						Text:         "A long, stable assistant answer worth caching.",
+						CacheControl: &sdk.CacheControl{Type: "ephemeral", TTL: "1h"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
 func TestDoGenerate_CacheControl_DetailedUsage(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/sdk/message.go
+++ b/sdk/message.go
@@ -84,6 +84,7 @@ type ToolCallPart struct {
 	ToolCallID       string         `json:"toolCallId"`
 	ToolName         string         `json:"toolName"`
 	Input            any            `json:"input"`
+	CacheControl     *CacheControl  `json:"cacheControl,omitempty"`
 	ProviderMetadata map[string]any `json:"providerMetadata,omitempty"`
 }
 
@@ -92,10 +93,11 @@ func (p ToolCallPart) PartType() MessagePartType { return MessagePartTypeToolCal
 // --- Tool Result (in tool messages) ---
 
 type ToolResultPart struct {
-	ToolCallID string `json:"toolCallId"`
-	ToolName   string `json:"toolName"`
-	Result     any    `json:"result"`
-	IsError    bool   `json:"isError,omitempty"`
+	ToolCallID   string        `json:"toolCallId"`
+	ToolName     string        `json:"toolName"`
+	Result       any           `json:"result"`
+	IsError      bool          `json:"isError,omitempty"`
+	CacheControl *CacheControl `json:"cacheControl,omitempty"`
 }
 
 func (p ToolResultPart) PartType() MessagePartType { return MessagePartTypeToolResult }

--- a/sdk/step_helpers.go
+++ b/sdk/step_helpers.go
@@ -57,7 +57,12 @@ func buildStepMessages(text, reasoning string, reasoningMeta map[string]any, too
 		assistantParts = append(assistantParts, TextPart{Text: text})
 	}
 	for _, tc := range toolCalls {
-		assistantParts = append(assistantParts, ToolCallPart(tc))
+		assistantParts = append(assistantParts, ToolCallPart{
+			ToolCallID:       tc.ToolCallID,
+			ToolName:         tc.ToolName,
+			Input:            tc.Input,
+			ProviderMetadata: tc.ProviderMetadata,
+		})
 	}
 
 	msgs := []Message{{Role: MessageRoleAssistant, Content: assistantParts, Usage: usage}}

--- a/skill/reference.md
+++ b/skill/reference.md
@@ -121,7 +121,8 @@ type MessagePart interface {
 }
 
 type TextPart struct {
-    Text string
+    Text         string
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 
 type ReasoningPart struct {
@@ -130,27 +131,37 @@ type ReasoningPart struct {
 }
 
 type ImagePart struct {
-    Image     string
-    MediaType string
+    Image        string
+    MediaType    string
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 
 type FilePart struct {
-    Data      string
-    MediaType string
-    Filename  string
+    Data         string
+    MediaType    string
+    Filename     string
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 
 type ToolCallPart struct {
-    ToolCallID string
-    ToolName   string
-    Input      any
+    ToolCallID   string
+    ToolName     string
+    Input        any
+    CacheControl *CacheControl  // optional, Anthropic only
 }
 
 type ToolResultPart struct {
-    ToolCallID string
-    ToolName   string
-    Result     any
-    IsError    bool
+    ToolCallID   string
+    ToolName     string
+    Result       any
+    IsError      bool
+    CacheControl *CacheControl  // optional, Anthropic only
+}
+
+// CacheControl marks a content block as an Anthropic prompt-caching breakpoint.
+type CacheControl struct {
+    Type string  // "ephemeral"
+    TTL  string  // "" (5-minute default) | "1h"
 }
 
 type Message struct {
@@ -294,6 +305,7 @@ type Tool struct {
     Parameters      any
     Execute         ToolExecuteFunc
     RequireApproval bool
+    CacheControl    *CacheControl  // optional, Anthropic only
 }
 
 func NewTool[T any](
@@ -536,8 +548,11 @@ type Usage struct {
 }
 
 type InputTokenDetail struct {
-    CacheReadTokens     int
-    CacheCreationTokens int
+    NoCacheTokens      int
+    CacheReadTokens    int
+    CacheWriteTokens   int
+    CacheWrite5mTokens int  // Anthropic: 5-minute cache writes
+    CacheWrite1hTokens int  // Anthropic: 1-hour cache writes (ttl="1h")
 }
 
 type OutputTokenDetail struct {


### PR DESCRIPTION
## What

Extend [Anthropic prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) to the content blocks that form the **prefix boundary in agentic and multi-turn flows**, so a cache breakpoint can move forward as the conversation grows.

Today `cache_control` is accepted on system blocks, user text/image/file blocks, and tool definitions. It is **not** accepted on:

- `tool_result` blocks (the natural breakpoint after each tool round-trip), and
- assistant `text` / `tool_use` blocks (the breakpoint in multi-turn chat).

That gap means the static prefix (system + tools + first user docs) can be cached, but the breakpoint can't advance — which is exactly where incremental context assembly earns its savings.

## Changes

- `sdk`: add `CacheControl` to `ToolResultPart` and `ToolCallPart`.
- `provider/anthropic/messages`: emit `cache_control` for assistant `text`, assistant `tool_use`, and `tool_result` content blocks.
- `sdk`: replace the implicit `ToolCallPart(tc)` struct conversion in `buildStepMessages` with explicit field assignment, so `ToolCall` and `ToolCallPart` no longer have to share an identical layout.
- `docs`: document the prompt-caching input feature (provider guide + API/skill references) — it was previously undocumented — and correct the stale `InputTokenDetail` (`CacheCreationTokens` → `CacheWriteTokens` + 5m/1h split).

The SDK stays a thin pass-through: breakpoint placement and the 4-breakpoint budget remain the caller's responsibility.

## Testing

- New table-style tests: `tool_result`, assistant `tool_use`, and assistant `text` (incl. a 1h-TTL case), written test-first (red → green).
- `go test ./...` passes; `golangci-lint run` reports 0 issues.