### PR TITLE
fix(sdk): aggregate cache write ttl usage

### DIFF
--- a/sdk/step_helpers.go
+++ b/sdk/step_helpers.go
@@ -40,6 +40,8 @@ func addUsage(total, step *Usage) Usage {
 	result.InputTokenDetails.NoCacheTokens += step.InputTokenDetails.NoCacheTokens
 	result.InputTokenDetails.CacheReadTokens += step.InputTokenDetails.CacheReadTokens
 	result.InputTokenDetails.CacheWriteTokens += step.InputTokenDetails.CacheWriteTokens
+	result.InputTokenDetails.CacheWrite5mTokens += step.InputTokenDetails.CacheWrite5mTokens
+	result.InputTokenDetails.CacheWrite1hTokens += step.InputTokenDetails.CacheWrite1hTokens
 	result.OutputTokenDetails.TextTokens += step.OutputTokenDetails.TextTokens
 	result.OutputTokenDetails.ReasoningTokens += step.OutputTokenDetails.ReasoningTokens
 	return result

--- a/sdk/step_helpers_test.go
+++ b/sdk/step_helpers_test.go
@@ -2,6 +2,35 @@ package sdk
 
 import "testing"
 
+func TestAddUsageAccumulatesCacheWriteTTLDetails(t *testing.T) {
+	total := Usage{
+		InputTokenDetails: InputTokenDetail{
+			CacheWriteTokens:   100,
+			CacheWrite5mTokens: 70,
+			CacheWrite1hTokens: 30,
+		},
+	}
+	step := Usage{
+		InputTokenDetails: InputTokenDetail{
+			CacheWriteTokens:   200,
+			CacheWrite5mTokens: 120,
+			CacheWrite1hTokens: 80,
+		},
+	}
+
+	got := addUsage(&total, &step)
+
+	if got.InputTokenDetails.CacheWriteTokens != 300 {
+		t.Fatalf("CacheWriteTokens = %d, want 300", got.InputTokenDetails.CacheWriteTokens)
+	}
+	if got.InputTokenDetails.CacheWrite5mTokens != 190 {
+		t.Fatalf("CacheWrite5mTokens = %d, want 190", got.InputTokenDetails.CacheWrite5mTokens)
+	}
+	if got.InputTokenDetails.CacheWrite1hTokens != 110 {
+		t.Fatalf("CacheWrite1hTokens = %d, want 110", got.InputTokenDetails.CacheWrite1hTokens)
+	}
+}
+
 func TestBuildStepMessagesPreservesToolCallProviderMetadata(t *testing.T) {
 	meta := map[string]any{"google": map[string]any{"thoughtSignature": "sig-1"}}
 	msgs := buildStepMessages("", "", nil, []ToolCall{{


### PR DESCRIPTION
## Summary

- Add `CacheWrite5mTokens` and `CacheWrite1hTokens` to the SDK `addUsage` accumulator.
- Add a regression test covering TTL-specific cache write usage aggregation.

## Root Cause

Anthropic usage conversion already populated the 5-minute and 1-hour cache write token fields, but the SDK step accumulator only summed the aggregate `CacheWriteTokens` field. Multi-step generation could therefore preserve total cache writes while dropping the TTL split fields from accumulated usage.

## Validation

- `go test ./sdk`
- `go test ./provider/anthropic/messages`
