### PR TITLE
feat(openai): support prompt_cache_key for Chat Completions and Responses API

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -223,6 +223,7 @@ type GenerateParams struct {
     PresencePenalty  *float64
     Seed             *int
     ReasoningEffort  *string
+    PromptCacheKey   *string
 }
 ```
 
@@ -313,6 +314,7 @@ All options are of type `GenerateOption` (`func(*generateConfig)`).
 | `WithPresencePenalty(p float64)` | Presence penalty |
 | `WithSeed(s int)` | Random seed for reproducibility |
 | `WithReasoningEffort(effort string)` | Reasoning effort level |
+| `WithPromptCacheKey(key string)` | Cache routing hint for OpenAI prompt caching (Chat Completions & Responses API) |
 
 #### Orchestration Options
 

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -224,6 +224,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *chatRequest {
 		PresencePenalty:     params.PresencePenalty,
 		Seed:                params.Seed,
 		ReasoningEffort:     normalizeReasoningEffort(params.ReasoningEffort),
+		PromptCacheKey:      params.PromptCacheKey,
 	}
 	if len(params.StopSequences) > 0 {
 		req.Stop = params.StopSequences

--- a/provider/openai/completions/completions_test.go
+++ b/provider/openai/completions/completions_test.go
@@ -83,6 +83,93 @@ func TestDoGenerate(t *testing.T) {
 	}
 }
 
+func TestDoGenerate_PromptCacheKey(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": 1700000000,
+			"model":   "gpt-4o-mini",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "Hello!"},
+			}},
+			"usage": map[string]any{
+				"prompt_tokens":     5,
+				"completion_tokens": 2,
+				"total_tokens":      7,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("test-key"),
+		completions.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:          &sdk.Model{ID: "gpt-4o-mini"},
+		Messages:       []sdk.Message{sdk.UserMessage("Hi")},
+		PromptCacheKey: stringPtr("some-key"),
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	if body["prompt_cache_key"] != "some-key" {
+		t.Errorf("expected prompt_cache_key %q, got %v", "some-key", body["prompt_cache_key"])
+	}
+}
+
+func TestDoGenerate_PromptCacheKeyOmittedWhenUnset(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": 1700000000,
+			"model":   "gpt-4o-mini",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "Hello!"},
+			}},
+			"usage": map[string]any{
+				"prompt_tokens":     5,
+				"completion_tokens": 2,
+				"total_tokens":      7,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("test-key"),
+		completions.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    &sdk.Model{ID: "gpt-4o-mini"},
+		Messages: []sdk.Message{sdk.UserMessage("Hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	if _, ok := body["prompt_cache_key"]; ok {
+		t.Errorf("expected prompt_cache_key to be omitted, got %v", body["prompt_cache_key"])
+	}
+}
+
 func TestDoGenerate_WithBedrockCredentials(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got == "" || got[:16] != "AWS4-HMAC-SHA256" {

--- a/provider/openai/completions/types.go
+++ b/provider/openai/completions/types.go
@@ -16,6 +16,7 @@ type chatRequest struct {
 	PresencePenalty     *float64           `json:"presence_penalty,omitempty"`
 	Seed                *int               `json:"seed,omitempty"`
 	ReasoningEffort     *string            `json:"reasoning_effort,omitempty"`
+	PromptCacheKey      *string            `json:"prompt_cache_key,omitempty"`
 	Thinking            *chatThinking      `json:"thinking,omitempty"`
 	ReasoningSplit      bool               `json:"reasoning_split,omitempty"`
 	Stream              bool               `json:"stream,omitempty"`

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -203,6 +203,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *responsesRequest {
 		Temperature:     params.Temperature,
 		TopP:            params.TopP,
 		MaxOutputTokens: params.MaxTokens,
+		PromptCacheKey:  params.PromptCacheKey,
 	}
 
 	if len(params.Tools) > 0 {

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -97,6 +97,102 @@ func TestResponsesDoGenerate(t *testing.T) {
 	}
 }
 
+func TestResponsesDoGenerate_PromptCacheKey(t *testing.T) {
+	var body struct {
+		PromptCacheKey *string `json:"prompt_cache_key"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "resp_test123",
+			"created_at": 1700000000,
+			"model":      "gpt-4o-mini",
+			"output": []map[string]any{{
+				"type": "message",
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{{
+					"type":        "output_text",
+					"text":        "Hello!",
+					"annotations": []any{},
+				}},
+			}},
+			"usage": map[string]any{
+				"input_tokens":  5,
+				"output_tokens": 2,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := responses.New(
+		responses.WithAPIKey("test-key"),
+		responses.WithBaseURL(srv.URL),
+	)
+
+	key := "some-key"
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:          p.ChatModel("gpt-4o-mini"),
+		Messages:       []sdk.Message{sdk.UserMessage("Hi")},
+		PromptCacheKey: &key,
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+
+	if body.PromptCacheKey == nil || *body.PromptCacheKey != "some-key" {
+		t.Errorf("prompt_cache_key: got %v, want %q", body.PromptCacheKey, "some-key")
+	}
+}
+
+func TestResponsesDoGenerate_PromptCacheKeyOmittedWhenUnset(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "resp_test123",
+			"created_at": 1700000000,
+			"model":      "gpt-4o-mini",
+			"output": []map[string]any{{
+				"type": "message",
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{{
+					"type":        "output_text",
+					"text":        "Hello!",
+					"annotations": []any{},
+				}},
+			}},
+			"usage": map[string]any{
+				"input_tokens":  5,
+				"output_tokens": 2,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := responses.New(
+		responses.WithAPIKey("test-key"),
+		responses.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    p.ChatModel("gpt-4o-mini"),
+		Messages: []sdk.Message{sdk.UserMessage("Hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+
+	if _, ok := body["prompt_cache_key"]; ok {
+		t.Errorf("expected prompt_cache_key to be omitted, got %v", body["prompt_cache_key"])
+	}
+}
+
 func TestResponsesDoGenerate_MapsMaxReasoningEffortToXHigh(t *testing.T) {
 	var body struct {
 		Reasoning *struct {

--- a/provider/openai/responses/types.go
+++ b/provider/openai/responses/types.go
@@ -10,6 +10,7 @@ type responsesRequest struct {
 	Temperature     *float64            `json:"temperature,omitempty"`
 	TopP            *float64            `json:"top_p,omitempty"`
 	MaxOutputTokens *int                `json:"max_output_tokens,omitempty"`
+	PromptCacheKey  *string             `json:"prompt_cache_key,omitempty"`
 	Tools           []responsesTool     `json:"tools,omitempty"`
 	ToolChoice      any                 `json:"tool_choice,omitempty"`
 	Text            *responsesTextFmt   `json:"text,omitempty"`

--- a/sdk/generate.go
+++ b/sdk/generate.go
@@ -45,6 +45,7 @@ type GenerateParams struct {
 	PresencePenalty  *float64 `json:"presencePenalty,omitempty"`
 	Seed             *int     `json:"seed,omitempty"`
 	ReasoningEffort  *string  `json:"reasoningEffort,omitempty"`
+	PromptCacheKey   *string  `json:"promptCacheKey,omitempty"`
 }
 
 // StepResult represents the outcome of a single step (one LLM call + tool execution round).

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -79,6 +79,10 @@ func WithReasoningEffort(effort string) GenerateOption {
 	return func(c *generateConfig) { c.Params.ReasoningEffort = &effort }
 }
 
+func WithPromptCacheKey(key string) GenerateOption {
+	return func(c *generateConfig) { c.Params.PromptCacheKey = &key }
+}
+
 // --- Client-level orchestration options ---
 
 // WithMaxSteps sets the maximum number of LLM calls in the tool-execution loop.


### PR DESCRIPTION

## Summary
- Add `PromptCacheKey *string` to `sdk.GenerateParams` plus a `WithPromptCacheKey(key string)` option, so callers can pass OpenAI's `prompt_cache_key` routing hint to increase prompt-cache hit rates.
- Wire it through to both `provider/openai/completions` (Chat Completions `chatRequest.prompt_cache_key`) and `provider/openai/responses`
(Responses API `responsesRequest.prompt_cache_key`), covering both `DoGenerate` and `DoStream` since they share `buildRequest`.
- Scoped to these two providers only; `provider/openai/codex` (ChatGPT-backend auth) is intentionally untouched.

## Test plan
- [x] New TDD tests: `TestDoGenerate_PromptCacheKey` / `TestDoGenerate_PromptCacheKeyOmittedWhenUnset` (completions),
`TestResponsesDoGenerate_PromptCacheKey` / `TestResponsesDoGenerate_PromptCacheKeyOmittedWhenUnset` (responses) — verified failing before
implementation, passing after
- [x] `go build ./...`, `go vet ./...`, `go test -short -count=1 ./...` all pass
- [x] `golangci-lint run ./...` clean 
- [x] `docs/api-reference.md` updated with the new field/option