### PR TITLE
feat: add Alibaba Cloud DashScope image generation provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A lightweight, idiomatic AI SDK for Go — inspired by [Vercel AI SDK](https://s
 - **Multi-step execution** — automatic tool-call loop with configurable `MaxSteps`
 - **Rich message types** — text, images, files, reasoning content, tool calls/results
 - **Embeddings** — generate embeddings with `Embed` / `EmbedMany`, supports OpenAI and Google providers
-- **Image generation** — generate and edit images with `GenerateImage` / `EditImage`, supports dall-e-2, dall-e-3, and gpt-image-1
+- **Image generation** — generate and edit images with `GenerateImage` / `EditImage`, supports OpenAI (dall-e, gpt-image) and Alibaba Cloud DashScope (Qwen-Image, Wan) models
 - **Video generation** — create, poll, and download video jobs with OpenRouter and Ark/ModelArk providers
 - **Speech synthesis** — generate speech with `GenerateSpeech` / `StreamSpeech`, supports Edge TTS with an open provider model
 - **Approval flow** — optional human-in-the-loop approval for sensitive tool calls
@@ -305,6 +305,24 @@ result, err := sdk.EditImage(ctx,
 )
 ```
 
+Alibaba Cloud Model Studio (DashScope) image models work through the same API:
+
+```go
+import "github.com/memohai/twilight-ai/provider/alibabacloud/images"
+
+provider := images.New(images.WithAPIKey("sk-..."))
+model := provider.GenerationModel("qwen-image-max")
+
+result, err := sdk.GenerateImage(ctx,
+    sdk.WithImageGenerationModel(model),
+    sdk.WithImagePrompt("A sunset over mountains, oil painting style"),
+    sdk.WithImageSize("1024x1024"),
+)
+// result.Data[0].URL contains the generated image URL
+```
+
+The DashScope provider routes Qwen-Image and Wan models to the right endpoint automatically and transparently polls async generation tasks. See [Images](docs/images.md) for details.
+
 ### Embeddings
 
 Generate vector embeddings for text using OpenAI or Google:
@@ -417,7 +435,7 @@ if testResult.Supported {
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation, setup, and first request |
 | [Providers](docs/providers.md) | Provider interface, OpenAI, Anthropic, and Google Gemini |
-| [Images](docs/images.md) | Generate and edit images with OpenAI image models |
+| [Images](docs/images.md) | Generate and edit images with OpenAI and Alibaba Cloud DashScope image models |
 | [Embeddings](docs/embeddings.md) | Generate vector embeddings with OpenAI and Google |
 | [Speech](docs/speech.md) | Speech synthesis with Edge TTS and custom providers |
 | [Tool Calling](docs/tools.md) | Defining local tools, MCP tools, multi-step execution, approval flow |
@@ -436,6 +454,7 @@ if testResult.Supported {
 | Anthropic | `messages.New()` | `/messages` | ✅ Stable |
 | Google Gemini | `generativeai.New()` | Generative AI API | ✅ Stable |
 | OpenAI Images | `images.New()` | `/images/generations`, `/images/edits` | ✅ Stable |
+| Alibaba Cloud DashScope Images | `images.New()` | DashScope text2image / multimodal-generation | ✅ Stable |
 | OpenAI Embeddings | `embedding.New()` | `/embeddings` | ✅ Stable |
 | Google Embeddings | `embedding.New()` | `embedContent` / `batchEmbedContents` | ✅ Stable |
 | Edge TTS | `speech.New()` | Bing WebSocket | ✅ Stable |

--- a/docs/images.md
+++ b/docs/images.md
@@ -95,7 +95,7 @@ provider := images.New(
 
 ### Alibaba Cloud DashScope Images
 
-The `provider/alibabacloud/images` package supports Alibaba Cloud Model Studio (DashScope) image models — Qwen-Image and Wan.
+The `provider/alibabacloud/images` package supports Alibaba Cloud Model Studio (DashScope) image models — Qwen-Image, Wan, Z-Image, and third-party models such as FLUX and Stable Diffusion.
 
 ```go
 import "github.com/memohai/twilight-ai/provider/alibabacloud/images"
@@ -113,7 +113,7 @@ result, err := sdk.GenerateImage(ctx,
 // result.Data[0].URL contains the generated image URL (valid for 24 hours)
 ```
 
-The provider routes each model to the correct DashScope endpoint automatically: `qwen-image` / `qwen-image-plus` and legacy Wan models (`wanx-*`, `wan2.0`–`wan2.5`) use the async text2image task API with polling, newer Wan models use the async image-generation task API, and the remaining Qwen-Image models (`qwen-image-max`, `qwen-image-2.0*`, dated snapshots) use the synchronous multimodal API. Polling behavior is configurable via `images.WithPollInterval` and `images.WithPollTimeout`.
+The provider routes each model to the correct DashScope endpoint automatically: `qwen-image` / `qwen-image-plus`, legacy Wan models (`wanx-*`, `wan2.0`–`wan2.5`), and third-party models (`flux-*`, `stable-diffusion-*`) use the async text2image task API with polling; newer Wan models use the async image-generation task API; the remaining Qwen-Image models (`qwen-image-max`, `qwen-image-2.0*`, dated snapshots) and `z-image*` use the synchronous multimodal API. Polling behavior is configurable via `images.WithPollInterval` and `images.WithPollTimeout`.
 
 DashScope models honor the `Prompt`, `N`, and `Size` options; the other generation options are OpenAI-specific and ignored. Image editing (`sdk.EditImage`) is not supported by this provider.
 

--- a/docs/images.md
+++ b/docs/images.md
@@ -93,6 +93,30 @@ provider := images.New(
 )
 ```
 
+### Alibaba Cloud DashScope Images
+
+The `provider/alibabacloud/images` package supports Alibaba Cloud Model Studio (DashScope) image models — Qwen-Image and Wan.
+
+```go
+import "github.com/memohai/twilight-ai/provider/alibabacloud/images"
+
+provider := images.New(
+    images.WithAPIKey("sk-..."), // DashScope / Model Studio API key
+)
+
+model := provider.GenerationModel("qwen-image-max")
+result, err := sdk.GenerateImage(ctx,
+    sdk.WithImageGenerationModel(model),
+    sdk.WithImagePrompt("A sunset over mountains"),
+    sdk.WithImageSize("1024x1024"),
+)
+// result.Data[0].URL contains the generated image URL (valid for 24 hours)
+```
+
+The provider routes each model to the correct DashScope endpoint automatically: `qwen-image` / `qwen-image-plus` and legacy Wan models (`wanx-*`, `wan2.0`–`wan2.5`) use the async text2image task API with polling, newer Wan models use the async image-generation task API, and the remaining Qwen-Image models (`qwen-image-max`, `qwen-image-2.0*`, dated snapshots) use the synchronous multimodal API. Polling behavior is configurable via `images.WithPollInterval` and `images.WithPollTimeout`.
+
+DashScope models honor the `Prompt`, `N`, and `Size` options; the other generation options are OpenAI-specific and ignored. Image editing (`sdk.EditImage`) is not supported by this provider.
+
 ## Generation Options
 
 All generation options are of type `ImageGenerateOption`:

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -784,6 +784,58 @@ provider := images.New(
 
 See [Images](images.md) for complete documentation.
 
+### Alibaba Cloud DashScope Images Provider
+
+The `provider/alibabacloud/images` package provides image generation via Alibaba Cloud Model Studio (DashScope), supporting Qwen-Image and Wan image models.
+
+#### Basic Usage
+
+```go
+import (
+    "github.com/memohai/twilight-ai/provider/alibabacloud/images"
+    "github.com/memohai/twilight-ai/sdk"
+)
+
+provider := images.New(
+    images.WithAPIKey("sk-..."),
+)
+
+model := provider.GenerationModel("qwen-image-max")
+result, err := sdk.GenerateImage(ctx,
+    sdk.WithImageGenerationModel(model),
+    sdk.WithImagePrompt("A sunset over mountains"),
+    sdk.WithImageSize("1024x1024"),
+)
+// result.Data[0].URL contains the generated image URL
+```
+
+#### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `WithAPIKey(key)` | `""` | DashScope / Model Studio API key sent as `Authorization: Bearer <key>` |
+| `WithBaseURL(url)` | `https://dashscope.aliyuncs.com/api/v1` | Base URL; also accepts Model Studio compatible-mode URLs, which are normalized to the native `/api/v1` base |
+| `WithHTTPClient(client)` | `&http.Client{}` | Custom HTTP client |
+| `WithPollInterval(d)` | `3s` | Polling interval for async image tasks |
+| `WithPollTimeout(d)` | `5m` | Maximum time to wait for an async image task |
+
+#### Endpoint Routing
+
+DashScope exposes several image APIs; the provider selects the endpoint from the model ID:
+
+| Models | Endpoint | Mode |
+|--------|----------|------|
+| `qwen-image`, `qwen-image-plus` | `/services/aigc/text2image/image-synthesis` | Async task + polling |
+| `wanx-*`, `wan2.0`–`wan2.5` | `/services/aigc/text2image/image-synthesis` | Async task + polling |
+| Other `qwen-image*` (e.g. `qwen-image-max`, `qwen-image-2.0-pro`, dated snapshots) | `/services/aigc/multimodal-generation/generation` | Synchronous |
+| Other `wan*` (e.g. `wan2.6-t2i` and newer) | `/services/aigc/image-generation/generation` | Async task + polling |
+
+Async tasks are polled via `GET /tasks/{task_id}` until they succeed, fail, or the poll timeout is reached.
+
+#### Parameters
+
+DashScope image models honor `Prompt`, `N`, and `Size` (converted from `"1024x1024"` to DashScope's `"1024*1024"` form). Other `ImageGenerationParams` fields are OpenAI-specific and ignored. Results are returned as image URLs, which expire after 24 hours — download them promptly.
+
 ---
 
 ## Embedding Providers
@@ -1367,7 +1419,7 @@ text, err := sdk.GenerateText(ctx,
 
 ## Next Steps
 
-- [Images](images.md) — generate and edit images with OpenAI image models
+- [Images](images.md) — generate and edit images with OpenAI and Alibaba Cloud DashScope image models
 - [Embeddings](embeddings.md) — generate vector embeddings with OpenAI and Google
 - [Speech](speech.md) — speech synthesis with Edge TTS and custom providers
 - [Tool Calling](tools.md) — define tools and enable multi-step execution

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -827,7 +827,9 @@ DashScope exposes several image APIs; the provider selects the endpoint from the
 |--------|----------|------|
 | `qwen-image`, `qwen-image-plus` | `/services/aigc/text2image/image-synthesis` | Async task + polling |
 | `wanx-*`, `wan2.0`–`wan2.5` | `/services/aigc/text2image/image-synthesis` | Async task + polling |
+| `flux-*`, `stable-diffusion-*` | `/services/aigc/text2image/image-synthesis` | Async task + polling |
 | Other `qwen-image*` (e.g. `qwen-image-max`, `qwen-image-2.0-pro`, dated snapshots) | `/services/aigc/multimodal-generation/generation` | Synchronous |
+| `z-image*` (e.g. `z-image-turbo`) | `/services/aigc/multimodal-generation/generation` | Synchronous |
 | Other `wan*` (e.g. `wan2.6-t2i` and newer) | `/services/aigc/image-generation/generation` | Async task + polling |
 
 Async tasks are polled via `GET /tasks/{task_id}` until they succeed, fail, or the poll timeout is reached.

--- a/provider/alibabacloud/images/images.go
+++ b/provider/alibabacloud/images/images.go
@@ -104,7 +104,7 @@ func (p *Provider) DoGenerate(ctx context.Context, params *sdk.ImageGenerationPa
 	if params.Model == nil {
 		return nil, fmt.Errorf("alibabacloud images: generation model is required")
 	}
-	if isQwenMultimodalModel(params.Model.ID) {
+	if usesSyncMultimodal(params.Model.ID) {
 		return p.generateQwenMultimodal(ctx, params)
 	}
 
@@ -316,12 +316,25 @@ func isQwenLegacyImageModel(modelID string) bool {
 	return modelID == "qwen-image" || modelID == "qwen-image-plus"
 }
 
-func isQwenMultimodalModel(modelID string) bool {
+// usesSyncMultimodal reports whether the model is served exclusively by the
+// synchronous multimodal-generation endpoint: Qwen-Image models other than the
+// two async-capable legacy IDs, and Z-Image models.
+func usesSyncMultimodal(modelID string) bool {
 	modelID = strings.ToLower(strings.TrimSpace(modelID))
+	if strings.HasPrefix(modelID, "z-image") {
+		return true
+	}
 	return strings.HasPrefix(modelID, "qwen-image") && !isQwenLegacyImageModel(modelID)
 }
 
+// usesPromptInputText2Image reports whether the model uses the legacy async
+// text2image endpoint with prompt-string input: qwen-image/qwen-image-plus,
+// Wan models up to wan2.5, and third-party FLUX / Stable Diffusion models.
 func usesPromptInputText2Image(modelID string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(modelID))
+	if strings.HasPrefix(normalized, "flux") || strings.HasPrefix(normalized, "stable-diffusion") {
+		return true
+	}
 	return isQwenLegacyImageModel(modelID) || isLegacyWanText2ImageModel(modelID)
 }
 

--- a/provider/alibabacloud/images/images.go
+++ b/provider/alibabacloud/images/images.go
@@ -1,0 +1,378 @@
+// Package images provides an Alibaba Cloud Model Studio DashScope image provider.
+package images
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/memohai/twilight-ai/internal/utils"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+const (
+	defaultBaseURL      = "https://dashscope.aliyuncs.com/api/v1"
+	defaultPollInterval = 3 * time.Second
+	defaultPollTimeout  = 5 * time.Minute
+	wanGenerationPath   = "/services/aigc/image-generation/generation"
+	text2ImagePath      = "/services/aigc/text2image/image-synthesis"
+	qwenMultimodalPath  = "/services/aigc/multimodal-generation/generation"
+)
+
+// Provider implements sdk.ImageGenerationProvider for Alibaba Cloud Model Studio
+// DashScope image generation models such as Qwen-Image and Wan image models.
+type Provider struct {
+	apiKey       string
+	baseURL      string
+	httpClient   *http.Client
+	pollInterval time.Duration
+	pollTimeout  time.Duration
+}
+
+// Option configures the Provider.
+type Option func(*Provider)
+
+// WithAPIKey sets the DashScope or Model Studio API key.
+func WithAPIKey(apiKey string) Option {
+	return func(p *Provider) { p.apiKey = apiKey }
+}
+
+// WithBaseURL overrides the DashScope HTTP API base URL.
+//
+// The provider accepts both native DashScope bases such as
+// https://dashscope.aliyuncs.com/api/v1 and Model Studio compatible-mode bases
+// such as https://{workspace}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1.
+func WithBaseURL(baseURL string) Option {
+	return func(p *Provider) { p.baseURL = normalizeBaseURL(baseURL) }
+}
+
+// WithHTTPClient sets the HTTP client used for requests.
+func WithHTTPClient(client *http.Client) Option {
+	return func(p *Provider) {
+		if client != nil {
+			p.httpClient = client
+		}
+	}
+}
+
+// WithPollInterval sets the async task polling interval.
+func WithPollInterval(interval time.Duration) Option {
+	return func(p *Provider) {
+		if interval > 0 {
+			p.pollInterval = interval
+		}
+	}
+}
+
+// WithPollTimeout sets the maximum time to wait for an async image task.
+func WithPollTimeout(timeout time.Duration) Option {
+	return func(p *Provider) {
+		if timeout > 0 {
+			p.pollTimeout = timeout
+		}
+	}
+}
+
+// New creates a new DashScope image provider.
+func New(options ...Option) *Provider {
+	p := &Provider{
+		baseURL:      defaultBaseURL,
+		httpClient:   &http.Client{},
+		pollInterval: defaultPollInterval,
+		pollTimeout:  defaultPollTimeout,
+	}
+	for _, opt := range options {
+		opt(p)
+	}
+	return p
+}
+
+// GenerationModel creates an ImageGenerationModel bound to this provider.
+func (p *Provider) GenerationModel(id string) *sdk.ImageGenerationModel {
+	return &sdk.ImageGenerationModel{
+		ID:       id,
+		Provider: p,
+	}
+}
+
+// DoGenerate implements sdk.ImageGenerationProvider.
+func (p *Provider) DoGenerate(ctx context.Context, params *sdk.ImageGenerationParams) (*sdk.ImageResult, error) {
+	if params.Model == nil {
+		return nil, fmt.Errorf("alibabacloud images: generation model is required")
+	}
+	if isQwenMultimodalModel(params.Model.ID) {
+		return p.generateQwenMultimodal(ctx, params)
+	}
+
+	resp, err := p.createTask(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(resp.Code) != "" {
+		return nil, fmt.Errorf("alibabacloud images: generation request failed: %s: %s", resp.Code, resp.Message)
+	}
+	if hasImages(resp.Output.Choices) || hasResultImages(resp.Output.Results) {
+		return toImageResult(resp), nil
+	}
+	if strings.EqualFold(resp.Output.TaskStatus, taskStatusSucceeded) {
+		return nil, fmt.Errorf("alibabacloud images: generation request succeeded without image output")
+	}
+	taskID := strings.TrimSpace(resp.Output.TaskID)
+	if taskID == "" {
+		return nil, fmt.Errorf("alibabacloud images: generation response did not include a task_id")
+	}
+	return p.waitTask(ctx, taskID)
+}
+
+func (p *Provider) createTask(ctx context.Context, params *sdk.ImageGenerationParams) (*dashScopeResponse, error) {
+	path := wanGenerationPath
+	var body any = dashScopeImageRequest{
+		Model:      params.Model.ID,
+		Input:      promptMessagesInput(params.Prompt),
+		Parameters: imageParameters(params),
+	}
+	if usesPromptInputText2Image(params.Model.ID) {
+		path = text2ImagePath
+		body = dashScopePromptInputRequest{
+			Model: params.Model.ID,
+			Input: dashScopePromptInput{
+				Prompt: params.Prompt,
+			},
+			Parameters: imageParameters(params),
+		}
+	}
+
+	resp, err := utils.FetchJSON[dashScopeResponse](ctx, p.httpClient, &utils.RequestOptions{
+		Method:  http.MethodPost,
+		BaseURL: p.baseURL,
+		Path:    path,
+		Headers: map[string]string{
+			"Authorization":     utils.BearerToken(p.apiKey),
+			"X-DashScope-Async": "enable",
+		},
+		Body: body,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("alibabacloud images: create task request failed: %w", err)
+	}
+	return resp, nil
+}
+
+func (p *Provider) generateQwenMultimodal(ctx context.Context, params *sdk.ImageGenerationParams) (*sdk.ImageResult, error) {
+	req := dashScopeImageRequest{
+		Model:      params.Model.ID,
+		Input:      promptMessagesInput(params.Prompt),
+		Parameters: imageParameters(params),
+	}
+	resp, err := utils.FetchJSON[dashScopeResponse](ctx, p.httpClient, &utils.RequestOptions{
+		Method:  http.MethodPost,
+		BaseURL: p.baseURL,
+		Path:    qwenMultimodalPath,
+		Headers: utils.AuthHeader(p.apiKey),
+		Body:    req,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("alibabacloud images: qwen multimodal generation request failed: %w", err)
+	}
+	if strings.TrimSpace(resp.Code) != "" {
+		return nil, fmt.Errorf("alibabacloud images: qwen multimodal generation failed: %s: %s", resp.Code, resp.Message)
+	}
+	if !hasImages(resp.Output.Choices) && !hasResultImages(resp.Output.Results) {
+		return nil, fmt.Errorf("alibabacloud images: qwen multimodal generation response did not include image output")
+	}
+	return toImageResult(resp), nil
+}
+
+func (p *Provider) waitTask(ctx context.Context, taskID string) (*sdk.ImageResult, error) {
+	waitCtx := ctx
+	cancel := func() {}
+	if p.pollTimeout > 0 {
+		waitCtx, cancel = context.WithTimeout(ctx, p.pollTimeout)
+	}
+	defer cancel()
+
+	for {
+		resp, err := p.getTask(waitCtx, taskID)
+		if err != nil {
+			return nil, err
+		}
+		if code := firstNonEmpty(resp.Code, resp.Output.Code); code != "" {
+			return nil, fmt.Errorf("alibabacloud images: task %s failed: %s: %s", taskID, code, firstNonEmpty(resp.Message, resp.Output.Message))
+		}
+
+		switch strings.ToUpper(strings.TrimSpace(resp.Output.TaskStatus)) {
+		case taskStatusSucceeded:
+			if !hasImages(resp.Output.Choices) && !hasResultImages(resp.Output.Results) {
+				return nil, fmt.Errorf("alibabacloud images: task %s succeeded without image output", taskID)
+			}
+			return toImageResult(resp), nil
+		case taskStatusFailed, taskStatusUnknown, taskStatusCanceled:
+			if message := firstNonEmpty(resp.Message, resp.Output.Message); message != "" {
+				return nil, fmt.Errorf("alibabacloud images: task %s finished with status %s: %s", taskID, resp.Output.TaskStatus, message)
+			}
+			return nil, fmt.Errorf("alibabacloud images: task %s finished with status %s", taskID, resp.Output.TaskStatus)
+		}
+
+		timer := time.NewTimer(p.pollInterval)
+		select {
+		case <-waitCtx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("alibabacloud images: task %s did not finish before timeout: %w", taskID, waitCtx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func (p *Provider) getTask(ctx context.Context, taskID string) (*dashScopeResponse, error) {
+	resp, err := utils.FetchJSON[dashScopeResponse](ctx, p.httpClient, &utils.RequestOptions{
+		Method:  http.MethodGet,
+		BaseURL: p.baseURL,
+		Path:    "/tasks/" + taskID,
+		Headers: utils.AuthHeader(p.apiKey),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("alibabacloud images: get task request failed: %w", err)
+	}
+	return resp, nil
+}
+
+func toImageResult(resp *dashScopeResponse) *sdk.ImageResult {
+	result := &sdk.ImageResult{}
+	if resp == nil {
+		return result
+	}
+	if resp.Usage != nil {
+		result.Usage = sdk.ImageUsage{
+			TotalTokens:  resp.Usage.TotalTokens,
+			InputTokens:  resp.Usage.InputTokens,
+			OutputTokens: resp.Usage.OutputTokens,
+		}
+	}
+	for _, choice := range resp.Output.Choices {
+		for _, part := range choice.Message.Content {
+			if imageURL := strings.TrimSpace(part.Image); imageURL != "" {
+				result.Data = append(result.Data, sdk.ImageData{URL: imageURL})
+			}
+		}
+	}
+	for _, item := range resp.Output.Results {
+		if imageURL := strings.TrimSpace(item.URL); imageURL != "" {
+			result.Data = append(result.Data, sdk.ImageData{URL: imageURL})
+		}
+	}
+	return result
+}
+
+func hasImages(choices []dashScopeImageChoice) bool {
+	for _, choice := range choices {
+		for _, part := range choice.Message.Content {
+			if strings.TrimSpace(part.Image) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasResultImages(results []dashScopeImageResult) bool {
+	for _, item := range results {
+		if strings.TrimSpace(item.URL) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func promptMessagesInput(prompt string) dashScopeImageInput {
+	return dashScopeImageInput{
+		Messages: []dashScopeImageMessage{{
+			Role:    "user",
+			Content: []dashScopeImageContent{{Text: prompt}},
+		}},
+	}
+}
+
+func imageParameters(params *sdk.ImageGenerationParams) dashScopeImageParameters {
+	return dashScopeImageParameters{
+		N:    params.N,
+		Size: dashScopeImageSize(params.Size),
+	}
+}
+
+func dashScopeImageSize(size string) string {
+	size = strings.TrimSpace(size)
+	if size == "" {
+		return ""
+	}
+	return strings.ReplaceAll(size, "x", "*")
+}
+
+func isQwenLegacyImageModel(modelID string) bool {
+	modelID = strings.ToLower(strings.TrimSpace(modelID))
+	return modelID == "qwen-image" || modelID == "qwen-image-plus"
+}
+
+func isQwenMultimodalModel(modelID string) bool {
+	modelID = strings.ToLower(strings.TrimSpace(modelID))
+	return strings.HasPrefix(modelID, "qwen-image") && !isQwenLegacyImageModel(modelID)
+}
+
+func usesPromptInputText2Image(modelID string) bool {
+	return isQwenLegacyImageModel(modelID) || isLegacyWanText2ImageModel(modelID)
+}
+
+func isLegacyWanText2ImageModel(modelID string) bool {
+	modelID = strings.ToLower(strings.TrimSpace(modelID))
+	if strings.HasPrefix(modelID, "wanx") {
+		return true
+	}
+	if !strings.HasPrefix(modelID, "wan2.") {
+		return false
+	}
+	remainder := strings.TrimPrefix(modelID, "wan2.")
+	end := 0
+	for end < len(remainder) && remainder[end] >= '0' && remainder[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return false
+	}
+	minor, err := strconv.Atoi(remainder[:end])
+	return err == nil && minor <= 5
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func normalizeBaseURL(baseURL string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if trimmed == "" {
+		return defaultBaseURL
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return trimmed
+	}
+	switch {
+	case strings.Contains(parsed.Path, "/compatible-mode/v1"):
+		idx := strings.Index(parsed.Path, "/compatible-mode/v1")
+		parsed.Path = parsed.Path[:idx] + "/api/v1"
+	case strings.Contains(parsed.Path, "/api/v1"):
+		parsed.Path = parsed.Path[:strings.Index(parsed.Path, "/api/v1")+len("/api/v1")]
+	case parsed.Path == "" || parsed.Path == "/":
+		parsed.Path = "/api/v1"
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/")
+}

--- a/provider/alibabacloud/images/images_test.go
+++ b/provider/alibabacloud/images/images_test.go
@@ -389,6 +389,123 @@ func TestGenerateDatedQwenPlusUsesSynchronousEndpoint(t *testing.T) {
 	}
 }
 
+func TestGenerateZImageUsesSynchronousEndpoint(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/multimodal-generation/generation":
+			if got := r.Header.Get("X-DashScope-Async"); got != "" {
+				t.Fatalf("X-DashScope-Async = %q, want empty", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "z-image-turbo" {
+				t.Fatalf("model = %v, want z-image-turbo", got)
+			}
+			input := body["input"].(map[string]any)
+			if _, ok := input["messages"]; !ok {
+				t.Fatalf("input.messages missing for z-image model: %v", input)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"output": {
+					"choices": [{
+						"finish_reason": "stop",
+						"message": {
+							"role": "assistant",
+							"content": [{"image":"https://example.com/z-image.png","type":"image"}]
+						}
+					}]
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider := New(
+		WithAPIKey("dashscope-key"),
+		WithBaseURL(server.URL+"/api/v1"),
+		WithHTTPClient(server.Client()),
+	)
+	result, err := sdk.GenerateImage(context.Background(),
+		sdk.WithImageGenerationModel(provider.GenerationModel("z-image-turbo")),
+		sdk.WithImagePrompt("a red cube"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if len(result.Data) != 1 || result.Data[0].URL != "https://example.com/z-image.png" {
+		t.Fatalf("result data = %+v, want z-image URL", result.Data)
+	}
+}
+
+func TestGenerateThirdPartyModelsUseText2ImageTask(t *testing.T) {
+	t.Parallel()
+
+	for _, modelID := range []string{"flux-schnell", "stable-diffusion-3.5-large-turbo"} {
+		t.Run(modelID, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v1/services/aigc/text2image/image-synthesis":
+					if got := r.Header.Get("X-DashScope-Async"); got != "enable" {
+						t.Fatalf("X-DashScope-Async = %q, want enable", got)
+					}
+					var body map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Fatalf("decode request body: %v", err)
+					}
+					if got := body["model"]; got != modelID {
+						t.Fatalf("model = %v, want %s", got, modelID)
+					}
+					input := body["input"].(map[string]any)
+					if got := input["prompt"]; got != "a red cube" {
+						t.Fatalf("prompt = %v, want a red cube", got)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"output":{"task_id":"tp-task","task_status":"PENDING"}}`))
+				case "/api/v1/tasks/tp-task":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{
+						"output": {
+							"task_id": "tp-task",
+							"task_status": "SUCCEEDED",
+							"results": [{"url":"https://example.com/third-party.png"}]
+						}
+					}`))
+				default:
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			provider := New(
+				WithAPIKey("dashscope-key"),
+				WithBaseURL(server.URL+"/api/v1"),
+				WithHTTPClient(server.Client()),
+				WithPollInterval(time.Millisecond),
+				WithPollTimeout(time.Second),
+			)
+			result, err := sdk.GenerateImage(context.Background(),
+				sdk.WithImageGenerationModel(provider.GenerationModel(modelID)),
+				sdk.WithImagePrompt("a red cube"),
+			)
+			if err != nil {
+				t.Fatalf("GenerateImage() error = %v", err)
+			}
+			if len(result.Data) != 1 || result.Data[0].URL != "https://example.com/third-party.png" {
+				t.Fatalf("result data = %+v, want third-party image URL", result.Data)
+			}
+		})
+	}
+}
+
 func TestGenerateImageReturnsTaskFailure(t *testing.T) {
 	t.Parallel()
 

--- a/provider/alibabacloud/images/images_test.go
+++ b/provider/alibabacloud/images/images_test.go
@@ -1,0 +1,532 @@
+package images
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+func TestGenerateImageCreatesWanAsyncTaskAndPollsResult(t *testing.T) {
+	t.Parallel()
+
+	var polls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/image-generation/generation":
+			if got := r.Method; got != http.MethodPost {
+				t.Fatalf("method = %s, want POST", got)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer dashscope-key" {
+				t.Fatalf("authorization = %q, want bearer key", got)
+			}
+			if got := r.Header.Get("X-DashScope-Async"); got != "enable" {
+				t.Fatalf("X-DashScope-Async = %q, want enable", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "wan2.7-image-pro" {
+				t.Fatalf("model = %v, want wan2.7-image-pro", got)
+			}
+			input := body["input"].(map[string]any)
+			messages := input["messages"].([]any)
+			message := messages[0].(map[string]any)
+			content := message["content"].([]any)
+			textPart := content[0].(map[string]any)
+			if got := message["role"]; got != "user" {
+				t.Fatalf("role = %v, want user", got)
+			}
+			if got := textPart["text"]; got != "a red cube" {
+				t.Fatalf("text = %v, want a red cube", got)
+			}
+			parameters := body["parameters"].(map[string]any)
+			if got := parameters["size"]; got != "1024*1024" {
+				t.Fatalf("size = %v, want 1024*1024", got)
+			}
+			if got := parameters["n"]; got != float64(1) {
+				t.Fatalf("n = %v, want 1", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"output":{"task_id":"task-1","task_status":"PENDING"},"request_id":"req-1"}`))
+		case "/api/v1/tasks/task-1":
+			if got := r.Method; got != http.MethodGet {
+				t.Fatalf("method = %s, want GET", got)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer dashscope-key" {
+				t.Fatalf("authorization = %q, want bearer key", got)
+			}
+			polls++
+			w.Header().Set("Content-Type", "application/json")
+			if polls == 1 {
+				_, _ = w.Write([]byte(`{"output":{"task_id":"task-1","task_status":"RUNNING"}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"output": {
+					"task_id": "task-1",
+					"task_status": "SUCCEEDED",
+					"choices": [{
+						"finish_reason": "stop",
+						"message": {
+							"role": "assistant",
+							"content": [{"image":"https://example.com/result.png","type":"image"}]
+						}
+					}]
+				},
+				"usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider := New(
+		WithAPIKey("dashscope-key"),
+		WithBaseURL(server.URL+"/compatible-mode/v1"),
+		WithHTTPClient(server.Client()),
+		WithPollInterval(time.Millisecond),
+		WithPollTimeout(time.Second),
+	)
+	result, err := sdk.GenerateImage(context.Background(),
+		sdk.WithImageGenerationModel(provider.GenerationModel("wan2.7-image-pro")),
+		sdk.WithImagePrompt("a red cube"),
+		sdk.WithImageSize("1024x1024"),
+		sdk.WithImageN(1),
+	)
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if len(result.Data) != 1 || result.Data[0].URL != "https://example.com/result.png" {
+		t.Fatalf("result data = %+v, want result image URL", result.Data)
+	}
+	if result.Usage.TotalTokens != 5 || result.Usage.InputTokens != 2 || result.Usage.OutputTokens != 3 {
+		t.Fatalf("usage = %+v, want token usage", result.Usage)
+	}
+	if polls != 2 {
+		t.Fatalf("polls = %d, want 2", polls)
+	}
+}
+
+func TestGenerateQwenLegacyImageCreatesText2ImageTaskAndParsesResults(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/text2image/image-synthesis":
+			if got := r.Method; got != http.MethodPost {
+				t.Fatalf("method = %s, want POST", got)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer dashscope-key" {
+				t.Fatalf("authorization = %q, want bearer key", got)
+			}
+			if got := r.Header.Get("X-DashScope-Async"); got != "enable" {
+				t.Fatalf("X-DashScope-Async = %q, want enable", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "qwen-image" {
+				t.Fatalf("model = %v, want qwen-image", got)
+			}
+			input := body["input"].(map[string]any)
+			if got := input["prompt"]; got != "a red cube" {
+				t.Fatalf("prompt = %v, want a red cube", got)
+			}
+			parameters := body["parameters"].(map[string]any)
+			if got := parameters["size"]; got != "1024*1024" {
+				t.Fatalf("size = %v, want 1024*1024", got)
+			}
+			if got := parameters["n"]; got != float64(1) {
+				t.Fatalf("n = %v, want 1", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"output":{"task_id":"qwen-task","task_status":"PENDING"},"request_id":"req-qwen"}`))
+		case "/api/v1/tasks/qwen-task":
+			if got := r.Method; got != http.MethodGet {
+				t.Fatalf("method = %s, want GET", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"output": {
+					"task_id": "qwen-task",
+					"task_status": "SUCCEEDED",
+					"results": [{"url":"https://example.com/qwen.png"}]
+				},
+				"usage": {"image_count": 1}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider := New(
+		WithAPIKey("dashscope-key"),
+		WithBaseURL(server.URL+"/compatible-mode/v1"),
+		WithHTTPClient(server.Client()),
+		WithPollInterval(time.Millisecond),
+		WithPollTimeout(time.Second),
+	)
+	result, err := sdk.GenerateImage(context.Background(),
+		sdk.WithImageGenerationModel(provider.GenerationModel("qwen-image")),
+		sdk.WithImagePrompt("a red cube"),
+		sdk.WithImageSize("1024x1024"),
+		sdk.WithImageN(1),
+	)
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if len(result.Data) != 1 || result.Data[0].URL != "https://example.com/qwen.png" {
+		t.Fatalf("result data = %+v, want qwen image URL", result.Data)
+	}
+}
+
+func TestGenerateLegacyWanImageCreatesText2ImageTask(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/text2image/image-synthesis":
+			if got := r.Method; got != http.MethodPost {
+				t.Fatalf("method = %s, want POST", got)
+			}
+			if got := r.Header.Get("X-DashScope-Async"); got != "enable" {
+				t.Fatalf("X-DashScope-Async = %q, want enable", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "wanx-v1" {
+				t.Fatalf("model = %v, want wanx-v1", got)
+			}
+			input := body["input"].(map[string]any)
+			if got := input["prompt"]; got != "a red cube" {
+				t.Fatalf("prompt = %v, want a red cube", got)
+			}
+			if _, ok := input["messages"]; ok {
+				t.Fatalf("messages input was sent for legacy Wan model: %v", input["messages"])
+			}
+			parameters := body["parameters"].(map[string]any)
+			if got := parameters["size"]; got != "1024*1024" {
+				t.Fatalf("size = %v, want 1024*1024", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"output":{"task_id":"wanx-task","task_status":"PENDING"}}`))
+		case "/api/v1/tasks/wanx-task":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"output": {
+					"task_id": "wanx-task",
+					"task_status": "SUCCEEDED",
+					"results": [{"url":"https://example.com/wanx.png"}]
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider := New(
+		WithAPIKey("dashscope-key"),
+		WithBaseURL(server.URL+"/api/v1"),
+		WithHTTPClient(server.Client()),
+		WithPollInterval(time.Millisecond),
+		WithPollTimeout(time.Second),
+	)
+	result, err := sdk.GenerateImage(context.Background(),
+		sdk.WithImageGenerationModel(provider.GenerationModel("wanx-v1")),
+		sdk.WithImagePrompt("a red cube"),
+		sdk.WithImageSize("1024x1024"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if len(result.Data) != 1 || result.Data[0].URL != "https://example.com/wanx.png" {
+		t.Fatalf("result data = %+v, want legacy Wan image URL", result.Data)
+	}
+}
+
+func TestGenerateQwenMultimodalUsesSynchronousEndpoint(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/multimodal-generation/generation":
+			if got := r.Method; got != http.MethodPost {
+				t.Fatalf("method = %s, want POST", got)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer dashscope-key" {
+				t.Fatalf("authorization = %q, want bearer key", got)
+			}
+			if got := r.Header.Get("X-DashScope-Async"); got != "" {
+				t.Fatalf("X-DashScope-Async = %q, want empty", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "qwen-image-edit" {
+				t.Fatalf("model = %v, want qwen-image-edit", got)
+			}
+			input := body["input"].(map[string]any)
+			messages := input["messages"].([]any)
+			message := messages[0].(map[string]any)
+			content := message["content"].([]any)
+			textPart := content[0].(map[string]any)
+			if got := textPart["text"]; got != "a red cube" {
+				t.Fatalf("text = %v, want a red cube", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"output": {
+					"choices": [{
+						"finish_reason": "stop",
+						"message": {
+							"role": "assistant",
+							"content": [{"image":"https://example.com/qwen-edit.png","type":"image"}]
+						}
+					}]
+				},
+				"usage": {"input_tokens": 4, "output_tokens": 6, "total_tokens": 10}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider := New(
+		WithAPIKey("dashscope-key"),
+		WithBaseURL(server.URL+"/api/v1"),
+		WithHTTPClient(server.Client()),
+	)
+	result, err := sdk.GenerateImage(context.Background(),
+		sdk.WithImageGenerationModel(provider.GenerationModel("qwen-image-edit")),
+		sdk.WithImagePrompt("a red cube"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if len(result.Data) != 1 || result.Data[0].URL != "https://example.com/qwen-edit.png" {
+		t.Fatalf("result data = %+v, want qwen multimodal image URL", result.Data)
+	}
+	if result.Usage.TotalTokens != 10 || result.Usage.InputTokens != 4 || result.Usage.OutputTokens != 6 {
+		t.Fatalf("usage = %+v, want token usage", result.Usage)
+	}
+}
+
+func TestGenerateDatedQwenPlusUsesSynchronousEndpoint(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/multimodal-generation/generation":
+			if got := r.Method; got != http.MethodPost {
+				t.Fatalf("method = %s, want POST", got)
+			}
+			if got := r.Header.Get("X-DashScope-Async"); got != "" {
+				t.Fatalf("X-DashScope-Async = %q, want empty", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if got := body["model"]; got != "qwen-image-plus-2026-01-09" {
+				t.Fatalf("model = %v, want qwen-image-plus-2026-01-09", got)
+			}
+			input := body["input"].(map[string]any)
+			messages := input["messages"].([]any)
+			message := messages[0].(map[string]any)
+			content := message["content"].([]any)
+			textPart := content[0].(map[string]any)
+			if got := textPart["text"]; got != "a red cube" {
+				t.Fatalf("text = %v, want a red cube", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"output": {
+					"choices": [{
+						"finish_reason": "stop",
+						"message": {
+							"role": "assistant",
+							"content": [{"image":"https://example.com/qwen-plus-dated.png","type":"image"}]
+						}
+					}]
+				}
+			}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider := New(
+		WithAPIKey("dashscope-key"),
+		WithBaseURL(server.URL+"/api/v1"),
+		WithHTTPClient(server.Client()),
+	)
+	result, err := sdk.GenerateImage(context.Background(),
+		sdk.WithImageGenerationModel(provider.GenerationModel("qwen-image-plus-2026-01-09")),
+		sdk.WithImagePrompt("a red cube"),
+	)
+	if err != nil {
+		t.Fatalf("GenerateImage() error = %v", err)
+	}
+	if len(result.Data) != 1 || result.Data[0].URL != "https://example.com/qwen-plus-dated.png" {
+		t.Fatalf("result data = %+v, want dated qwen plus image URL", result.Data)
+	}
+}
+
+func TestGenerateImageReturnsTaskFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/services/aigc/text2image/image-synthesis":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"output":{"task_id":"task-2","task_status":"PENDING"}}`))
+		case "/api/v1/tasks/task-2":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"output":{"task_id":"task-2","task_status":"FAILED","message":"content rejected"}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	provider := New(
+		WithAPIKey("dashscope-key"),
+		WithBaseURL(server.URL+"/api/v1"),
+		WithHTTPClient(server.Client()),
+		WithPollInterval(time.Millisecond),
+		WithPollTimeout(time.Second),
+	)
+	_, err := sdk.GenerateImage(context.Background(),
+		sdk.WithImageGenerationModel(provider.GenerationModel("qwen-image")),
+		sdk.WithImagePrompt("blocked prompt"),
+	)
+	if err == nil || !strings.Contains(err.Error(), "FAILED") || !strings.Contains(err.Error(), "content rejected") {
+		t.Fatalf("GenerateImage() error = %v, want task failure", err)
+	}
+}
+
+func TestNormalizeBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", defaultBaseURL},
+		{"https://dashscope.aliyuncs.com", "https://dashscope.aliyuncs.com/api/v1"},
+		{"https://workspace.cn-beijing.maas.aliyuncs.com/compatible-mode/v1", "https://workspace.cn-beijing.maas.aliyuncs.com/api/v1"},
+		{"https://workspace.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions", "https://workspace.cn-beijing.maas.aliyuncs.com/api/v1"},
+		{"https://workspace.cn-beijing.maas.aliyuncs.com/api/v1/services/aigc/image-generation/generation", "https://workspace.cn-beijing.maas.aliyuncs.com/api/v1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := normalizeBaseURL(tt.input); got != tt.want {
+				t.Fatalf("normalizeBaseURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------- integration tests (real API, skipped unless explicitly enabled) ----------
+
+func envOrSkip(t *testing.T, key string) string {
+	t.Helper()
+	v := os.Getenv(key)
+	if v == "" {
+		t.Skipf("skipping: %s not set", key)
+	}
+	return v
+}
+
+func imageLiveOrSkip(t *testing.T) {
+	t.Helper()
+	if os.Getenv("DASHSCOPE_IMAGE_LIVE") != "1" {
+		t.Skip("skipping: set DASHSCOPE_IMAGE_LIVE=1 to run real image generation tests")
+	}
+}
+
+func newIntegrationProvider(t *testing.T) *Provider {
+	t.Helper()
+	imageLiveOrSkip(t)
+	apiKey := envOrSkip(t, "DASHSCOPE_API_KEY")
+	opts := []Option{WithAPIKey(apiKey)}
+	if base := os.Getenv("DASHSCOPE_BASE_URL"); base != "" {
+		opts = append(opts, WithBaseURL(base))
+	}
+	return New(opts...)
+}
+
+func integrationEnv(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func TestIntegration_GenerateQwenImage(t *testing.T) {
+	provider := newIntegrationProvider(t)
+	modelID := integrationEnv("DASHSCOPE_QWEN_IMAGE_MODEL", "qwen-image")
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultPollTimeout+time.Minute)
+	defer cancel()
+
+	result, err := sdk.GenerateImage(ctx,
+		sdk.WithImageGenerationModel(provider.GenerationModel(modelID)),
+		sdk.WithImagePrompt("A single red cube on a clean white background, no text."),
+		sdk.WithImageN(1),
+	)
+	if err != nil {
+		t.Fatalf("GenerateImage(%s): %v", modelID, err)
+	}
+	assertIntegrationImageURL(t, result)
+}
+
+func TestIntegration_GenerateWanImage(t *testing.T) {
+	provider := newIntegrationProvider(t)
+	modelID := integrationEnv("DASHSCOPE_WAN_IMAGE_MODEL", "wan2.6-t2i")
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultPollTimeout+time.Minute)
+	defer cancel()
+
+	result, err := sdk.GenerateImage(ctx,
+		sdk.WithImageGenerationModel(provider.GenerationModel(modelID)),
+		sdk.WithImagePrompt("A simple watercolor landscape with one tree beside a lake, no text."),
+		sdk.WithImageSize("1024x1024"),
+		sdk.WithImageN(1),
+	)
+	if err != nil {
+		t.Fatalf("GenerateImage(%s): %v", modelID, err)
+	}
+	assertIntegrationImageURL(t, result)
+}
+
+func assertIntegrationImageURL(t *testing.T, result *sdk.ImageResult) {
+	t.Helper()
+	if result == nil {
+		t.Fatal("GenerateImage returned nil result")
+	}
+	if len(result.Data) == 0 {
+		t.Fatal("GenerateImage returned no image data")
+	}
+	if strings.TrimSpace(result.Data[0].URL) == "" && strings.TrimSpace(result.Data[0].B64JSON) == "" {
+		t.Fatalf("first image has no URL or b64_json: %+v", result.Data[0])
+	}
+	t.Logf("image generated: url_set=%t b64_set=%t", strings.TrimSpace(result.Data[0].URL) != "", strings.TrimSpace(result.Data[0].B64JSON) != "")
+}

--- a/provider/alibabacloud/images/types.go
+++ b/provider/alibabacloud/images/types.go
@@ -1,0 +1,81 @@
+package images
+
+const (
+	taskStatusSucceeded = "SUCCEEDED"
+	taskStatusFailed    = "FAILED"
+	taskStatusUnknown   = "UNKNOWN"
+	taskStatusCanceled  = "CANCELED"
+)
+
+type dashScopeImageRequest struct {
+	Model      string                   `json:"model"`
+	Input      dashScopeImageInput      `json:"input"`
+	Parameters dashScopeImageParameters `json:"parameters,omitempty"`
+}
+
+type dashScopePromptInputRequest struct {
+	Model      string                   `json:"model"`
+	Input      dashScopePromptInput     `json:"input"`
+	Parameters dashScopeImageParameters `json:"parameters,omitempty"`
+}
+
+type dashScopeImageInput struct {
+	Messages []dashScopeImageMessage `json:"messages"`
+}
+
+type dashScopePromptInput struct {
+	Prompt string `json:"prompt"`
+}
+
+type dashScopeImageMessage struct {
+	Role    string                  `json:"role"`
+	Content []dashScopeImageContent `json:"content"`
+}
+
+type dashScopeImageContent struct {
+	Text  string `json:"text,omitempty"`
+	Image string `json:"image,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+type dashScopeImageParameters struct {
+	N    *int   `json:"n,omitempty"`
+	Size string `json:"size,omitempty"`
+}
+
+type dashScopeResponse struct {
+	RequestID string          `json:"request_id,omitempty"`
+	Output    dashScopeOutput `json:"output"`
+	Usage     *dashScopeUsage `json:"usage,omitempty"`
+	Code      string          `json:"code,omitempty"`
+	Message   string          `json:"message,omitempty"`
+}
+
+type dashScopeOutput struct {
+	TaskID     string                 `json:"task_id,omitempty"`
+	TaskStatus string                 `json:"task_status,omitempty"`
+	Choices    []dashScopeImageChoice `json:"choices,omitempty"`
+	Results    []dashScopeImageResult `json:"results,omitempty"`
+	Code       string                 `json:"code,omitempty"`
+	Message    string                 `json:"message,omitempty"`
+}
+
+type dashScopeImageChoice struct {
+	FinishReason string                `json:"finish_reason,omitempty"`
+	Message      dashScopeImageMessage `json:"message"`
+}
+
+type dashScopeImageResult struct {
+	URL          string `json:"url,omitempty"`
+	Code         string `json:"code,omitempty"`
+	Message      string `json:"message,omitempty"`
+	OrigPrompt   string `json:"orig_prompt,omitempty"`
+	ActualPrompt string `json:"actual_prompt,omitempty"`
+}
+
+type dashScopeUsage struct {
+	TotalTokens  int `json:"total_tokens,omitempty"`
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
+	ImageCount   int `json:"image_count,omitempty"`
+}


### PR DESCRIPTION
## 概述

新增 `provider/alibabacloud/images` 包，为阿里云百炼（DashScope）的图像生成模型实现 `sdk.ImageGenerationProvider` 接口，通过现有的 `sdk.GenerateImage` API 即可调用。

纯增量改动：不修改任何已有代码，无新增依赖。

## 支持的模型与端点路由

DashScope 不同模型系列使用不同的 API 端点，provider 根据模型 ID 自动路由：

| 模型 | 端点 | 调用方式 |
|---|---|---|
| `qwen-image`、`qwen-image-plus` | `/services/aigc/text2image/image-synthesis` | 异步任务 + 轮询 |
| 旧版万相：`wanx-*`、`wan2.0`–`wan2.5` | `/services/aigc/text2image/image-synthesis` | 异步任务 + 轮询 |
| 三方模型：`flux-*`、`stable-diffusion-*` | `/services/aigc/text2image/image-synthesis` | 异步任务 + 轮询 |
| 新版万相：`wan2.6+`（如 `wan2.6-t2i`、`wan2.7-image-pro`） | `/services/aigc/image-generation/generation` | 异步任务 + 轮询 |
| 其余千问图像模型：`qwen-image-max`、`qwen-image-2.0*` 及带日期快照 | `/services/aigc/multimodal-generation/generation` | 同步 |
| Z-Image：`z-image-turbo` | `/services/aigc/multimodal-generation/generation` | 同步 |

路由规则依据官方文档：异步接口仅 `qwen-image` / `qwen-image-plus` 支持，Z-Image 仅支持同步接口。异步任务通过 `X-DashScope-Async: enable` 创建，经 `GET /tasks/{task_id}` 轮询，间隔与超时可通过 `WithPollInterval` / `WithPollTimeout` 配置（默认 3s / 5min）。

## 其他行为

- `WithBaseURL` 同时接受原生地址（`https://dashscope.aliyuncs.com/api/v1`）和百炼 compatible-mode 地址（`https://{ws}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`），后者会自动归一化为原生 `/api/v1`。
- 支持 `Prompt`、`N`、`Size` 参数（尺寸自动从 `1024x1024` 转为 DashScope 的 `1024*1024` 格式），其余 OpenAI 专属参数忽略。
- 生成结果以图片 URL 返回（有效期 24 小时）。

## 测试验证

- 11 个单元测试覆盖全部路由分支、异步轮询、任务失败处理、base URL 归一化。
- 三个端点均通过真实 DashScope API 验证出图：`qwen-image`（text2image 异步）、`wan2.7-image-pro`（image-generation 异步 + 轮询）、`z-image-turbo`（multimodal 同步）。
- FLUX / Stable Diffusion 路由依据官方文档和单元测试验证（测试账号未开通该系列模型）。
- 附带环境变量门控的集成测试（`DASHSCOPE_IMAGE_LIVE=1` 启用），CI 中默认跳过。