### PR TITLE
fix(openai): preserve max effort for Codex

### DIFF
--- a/provider/openai/codex/codex.go
+++ b/provider/openai/codex/codex.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/memohai/twilight-ai/internal/utils"
-	openaiutil "github.com/memohai/twilight-ai/provider/openai"
 	"github.com/memohai/twilight-ai/sdk"
 )
 
@@ -389,7 +388,8 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *codexRequest {
 	}
 
 	if params.ReasoningEffort != nil && *params.ReasoningEffort != "" {
-		req.Reasoning = &codexReasoning{Effort: openaiutil.NormalizeReasoningEffort(*params.ReasoningEffort)}
+		// The Codex endpoint accepts max even though generic OpenAI endpoints do not.
+		req.Reasoning = &codexReasoning{Effort: *params.ReasoningEffort}
 	}
 	return req
 }

--- a/provider/openai/codex/codex_test.go
+++ b/provider/openai/codex/codex_test.go
@@ -96,7 +96,7 @@ func TestCodexDoGenerate_RequestShapeAndStream(t *testing.T) {
 	}
 }
 
-func TestCodexDoGenerate_MapsMaxReasoningEffortToXHigh(t *testing.T) {
+func TestCodexDoGenerate_PreservesMaxReasoningEffort(t *testing.T) {
 	var body struct {
 		Reasoning *struct {
 			Effort string `json:"effort"`
@@ -104,7 +104,9 @@ func TestCodexDoGenerate_MapsMaxReasoningEffortToXHigh(t *testing.T) {
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
+			t.Errorf("decode body: %v", err)
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("event: response.created\n"))
@@ -130,8 +132,8 @@ func TestCodexDoGenerate_MapsMaxReasoningEffortToXHigh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DoGenerate: %v", err)
 	}
-	if body.Reasoning == nil || body.Reasoning.Effort != "xhigh" {
-		t.Fatalf("reasoning.effort: got %#v, want xhigh", body.Reasoning)
+	if body.Reasoning == nil || body.Reasoning.Effort != "max" {
+		t.Fatalf("reasoning.effort: got %#v, want max", body.Reasoning)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve `max` reasoning effort for the Codex Responses endpoint
- keep generic OpenAI endpoint normalization unchanged
- cover the Codex request shape with a regression test

Required by memohai/Memoh#777.

## Testing

- `go test ./...`