### PR TITLE
feat: support developer and fallback message roles

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -142,17 +142,32 @@ type Message struct {
 | `MessageRoleAssistant` | `"assistant"` |
 | `MessageRoleSystem` | `"system"` |
 | `MessageRoleTool` | `"tool"` |
+| `MessageRoleDeveloper` | `"developer"` |
 
 #### Message Constructors
 
 ```go
 func UserMessage(text string, extra ...MessagePart) Message
 func SystemMessage(text string) Message
+func DeveloperMessage(text string) Message
 func AssistantMessage(text string) Message
 func ToolMessage(results ...ToolResultPart) Message
 ```
 
 `UserMessage` accepts optional extra parts (e.g. `ImagePart`) after the text.
+
+`GenerateParams.System` is the stable root instruction placed before the
+conversation. Use `SystemMessage` when an instruction belongs at a specific
+point in the message timeline. Providers preserve native instruction roles
+when supported; otherwise developer messages become user messages and
+mid-conversation system messages become XML-escaped `<system>` user messages.
+
+```go
+type MessageRoleCapabilities struct {
+    Developer             bool
+    MidConversationSystem bool
+}
+```
 
 #### MessagePart Interface
 
@@ -1217,9 +1232,14 @@ type Option func(*Provider)
 func WithAPIKey(apiKey string) Option
 func WithBaseURL(baseURL string) Option
 func WithHTTPClient(client *http.Client) Option
+func WithMessageRoleCapabilities(capabilities sdk.MessageRoleCapabilities) Option
 func WithDeepSeekChatCompletionsCompat() Option
 func WithMiniMaxChatCompletionsCompat() Option
 ```
+
+OpenAI's defaults enable native developer and mid-conversation system roles.
+Use `WithMessageRoleCapabilities` to disable either role for a compatible
+endpoint that does not implement the full OpenAI message-role contract.
 
 `WithDeepSeekChatCompletionsCompat` keeps the generic `/chat/completions`
 transport while adapting DeepSeek's thinking toggle: `WithReasoningEffort("none")`
@@ -1300,7 +1320,9 @@ func (p *Provider) DoStream(ctx, params) (*sdk.StreamResult, error)
 
 | SDK Message | Responses Input Type |
 |-------------|---------------------|
+| `GenerateParams.System` | Top-level `instructions` |
 | System message | `{ "type": "message", "role": "system" }` |
+| Developer message | `{ "type": "message", "role": "developer" }` |
 | User message (text) | `{ "type": "message", "role": "user" }` |
 | User message (image) | Content part with `{ "type": "input_image" }` |
 | Assistant message | `{ "type": "message", "role": "assistant" }` |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -100,6 +100,7 @@ model := provider.ChatModel("gpt-4o-mini")
 | `WithBedrockCredentials(region, accessKeyID, secretAccessKey, sessionToken)` | disabled | Use AWS SigV4 with static AWS credentials for Bedrock |
 | `WithBaseURL(url)` | `https://api.openai.com/v1` | Base URL for API requests |
 | `WithHTTPClient(client)` | `&http.Client{}` | Custom HTTP client (for proxies, timeouts, etc.) |
+| `WithMessageRoleCapabilities(capabilities)` | developer + mid-system enabled | Override instruction roles for a less-capable OpenAI-compatible endpoint |
 | `WithDeepSeekChatCompletionsCompat()` | disabled | Map `WithReasoningEffort("none")` to DeepSeek's thinking disable toggle |
 | `WithMiniMaxChatCompletionsCompat()` | disabled | Send `reasoning_split: true` and map reasoning effort to MiniMax's thinking toggle |
 
@@ -250,6 +251,10 @@ provider := responses.New(
 )
 model := provider.ChatModel("gpt-4o-mini")
 ```
+
+`GenerateParams.System` is sent through the Responses API's top-level
+`instructions` field. System and developer messages inside `Messages` retain
+their native roles and positions.
 
 ### Options
 
@@ -457,6 +462,7 @@ model := provider.ChatModel(copilot.AutoModel)
 | `WithAPIKey(token)` | `""` | Alias for `WithGitHubToken` for migration convenience |
 | `WithBaseURL(url)` | `https://api.githubcopilot.com` | Base URL for API requests |
 | `WithHTTPClient(client)` | `&http.Client{}` | Custom HTTP client |
+| `WithMessageRoleCapabilities(capabilities)` | both disabled | Enable native developer or mid-conversation system roles only when the configured Copilot endpoint supports them |
 
 ### Model Catalog
 
@@ -526,6 +532,11 @@ model := provider.ChatModel("claude-sonnet-4-20250514")
 | `WithBaseURL(url)` | `https://api.anthropic.com` | Base URL for API requests |
 | `WithHTTPClient(client)` | `&http.Client{}` | Custom HTTP client |
 | `WithThinking(config)` | `nil` | Enable extended thinking for reasoning |
+| `WithMidConversationSystemMessages(enabled)` | `false` | Preserve interleaved system messages for models that document native support |
+
+By default, developer messages become user messages and mid-conversation
+system messages become XML-escaped `<system>` user messages. Leading system
+messages continue to use Anthropic's top-level `system` field.
 
 ### Extended Thinking
 

--- a/internal/messagecompat/messagecompat.go
+++ b/internal/messagecompat/messagecompat.go
@@ -1,0 +1,126 @@
+// Package messagecompat normalizes provider-agnostic SDK messages for the
+// instruction-role capabilities of a concrete provider protocol.
+package messagecompat
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"strings"
+
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+// Normalize clones messages and applies provider-specific instruction-role
+// fallbacks without mutating the caller's message slice.
+func Normalize(messages []sdk.Message, capabilities sdk.MessageRoleCapabilities) ([]sdk.Message, error) {
+	out := make([]sdk.Message, 0, len(messages))
+	conversationStarted := false
+	pendingToolCalls := make(map[string]int)
+	pendingAnonymousToolCalls := 0
+
+	for i, message := range messages {
+		if !message.Role.Valid() {
+			return nil, fmt.Errorf("message %d: %w: %q", i, sdk.ErrInvalidMessageRole, message.Role)
+		}
+
+		if isInstruction(message.Role) {
+			if err := validateInstructionContent(message); err != nil {
+				return nil, fmt.Errorf("message %d: %w", i, err)
+			}
+			if pendingAnonymousToolCalls > 0 || len(pendingToolCalls) > 0 {
+				return nil, fmt.Errorf("message %d: %w", i, sdk.ErrInstructionInsideToolExchange)
+			}
+		}
+
+		normalized := cloneMessage(message)
+		switch message.Role {
+		case sdk.MessageRoleDeveloper:
+			if !capabilities.Developer {
+				normalized.Role = sdk.MessageRoleUser
+			}
+		case sdk.MessageRoleSystem:
+			if conversationStarted && !capabilities.MidConversationSystem {
+				normalized = taggedSystemUser(message)
+			}
+		}
+
+		out = append(out, normalized)
+		if normalized.Role == sdk.MessageRoleUser || normalized.Role == sdk.MessageRoleAssistant || normalized.Role == sdk.MessageRoleTool {
+			conversationStarted = true
+		}
+
+		switch message.Role {
+		case sdk.MessageRoleAssistant:
+			for _, part := range message.Content {
+				call, ok := part.(sdk.ToolCallPart)
+				if !ok {
+					continue
+				}
+				if call.ToolCallID == "" {
+					pendingAnonymousToolCalls++
+					continue
+				}
+				pendingToolCalls[call.ToolCallID]++
+			}
+		case sdk.MessageRoleTool:
+			for _, part := range message.Content {
+				result, ok := part.(sdk.ToolResultPart)
+				if !ok {
+					continue
+				}
+				if count := pendingToolCalls[result.ToolCallID]; count > 1 {
+					pendingToolCalls[result.ToolCallID] = count - 1
+				} else if count == 1 {
+					delete(pendingToolCalls, result.ToolCallID)
+				} else if result.ToolCallID == "" && pendingAnonymousToolCalls > 0 {
+					pendingAnonymousToolCalls--
+				}
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// InstructionText joins the text parts of a validated instruction message.
+func InstructionText(message sdk.Message) string {
+	texts := make([]string, 0, len(message.Content))
+	for _, part := range message.Content {
+		if text, ok := part.(sdk.TextPart); ok {
+			texts = append(texts, text.Text)
+		}
+	}
+	return strings.Join(texts, "\n")
+}
+
+func isInstruction(role sdk.MessageRole) bool {
+	return role == sdk.MessageRoleSystem || role == sdk.MessageRoleDeveloper
+}
+
+func validateInstructionContent(message sdk.Message) error {
+	for _, part := range message.Content {
+		if _, ok := part.(sdk.TextPart); !ok {
+			return fmt.Errorf("%w: role %q contains %q", sdk.ErrInvalidInstructionContent, message.Role, part.PartType())
+		}
+	}
+	return nil
+}
+
+func taggedSystemUser(message sdk.Message) sdk.Message {
+	var escaped bytes.Buffer
+	_ = xml.EscapeText(&escaped, []byte(InstructionText(message)))
+	return sdk.Message{
+		Role: sdk.MessageRoleUser,
+		Content: []sdk.MessagePart{sdk.TextPart{
+			Text: "<system>\n" + escaped.String() + "\n</system>",
+		}},
+		Usage: message.Usage,
+	}
+}
+
+func cloneMessage(message sdk.Message) sdk.Message {
+	cloned := message
+	cloned.Content = append([]sdk.MessagePart(nil), message.Content...)
+	return cloned
+}

--- a/internal/messagecompat/messagecompat_test.go
+++ b/internal/messagecompat/messagecompat_test.go
@@ -1,0 +1,92 @@
+package messagecompat
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+func TestNormalizeFallbacksAndEscapesSystemXML(t *testing.T) {
+	original := []sdk.Message{
+		sdk.SystemMessage("root"),
+		sdk.UserMessage("question"),
+		sdk.SystemMessage("use <safe> & do not close </system>"),
+		sdk.DeveloperMessage("developer instruction"),
+	}
+
+	got, err := Normalize(original, sdk.MessageRoleCapabilities{})
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if got[0].Role != sdk.MessageRoleSystem {
+		t.Fatalf("leading system role: got %q", got[0].Role)
+	}
+	if got[2].Role != sdk.MessageRoleUser {
+		t.Fatalf("mid-conversation system role: got %q", got[2].Role)
+	}
+	wantXML := "<system>\nuse &lt;safe&gt; &amp; do not close &lt;/system&gt;\n</system>"
+	if text := got[2].Content[0].(sdk.TextPart).Text; text != wantXML {
+		t.Fatalf("tagged system content:\n got: %q\nwant: %q", text, wantXML)
+	}
+	if got[3].Role != sdk.MessageRoleUser {
+		t.Fatalf("developer fallback role: got %q", got[3].Role)
+	}
+	if text := got[3].Content[0].(sdk.TextPart).Text; text != "developer instruction" {
+		t.Fatalf("developer fallback content: got %q", text)
+	}
+
+	if original[2].Role != sdk.MessageRoleSystem || original[2].Content[0].(sdk.TextPart).Text != "use <safe> & do not close </system>" {
+		t.Fatal("Normalize mutated the caller's message")
+	}
+}
+
+func TestNormalizePreservesSupportedInstructionRoles(t *testing.T) {
+	messages := []sdk.Message{
+		sdk.UserMessage("question"),
+		sdk.SystemMessage("runtime changed"),
+		sdk.DeveloperMessage("policy"),
+	}
+	got, err := Normalize(messages, sdk.MessageRoleCapabilities{
+		Developer:             true,
+		MidConversationSystem: true,
+	})
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if got[1].Role != sdk.MessageRoleSystem || got[2].Role != sdk.MessageRoleDeveloper {
+		t.Fatalf("roles: got %q, %q", got[1].Role, got[2].Role)
+	}
+}
+
+func TestNormalizeRejectsInstructionInsideToolExchange(t *testing.T) {
+	messages := []sdk.Message{
+		{
+			Role: sdk.MessageRoleAssistant,
+			Content: []sdk.MessagePart{sdk.ToolCallPart{
+				ToolCallID: "call-1",
+				ToolName:   "lookup",
+				Input:      map[string]any{"q": "value"},
+			}},
+		},
+		sdk.SystemMessage("runtime changed"),
+		sdk.ToolMessage(sdk.ToolResultPart{ToolCallID: "call-1", ToolName: "lookup", Result: "ok"}),
+	}
+
+	_, err := Normalize(messages, sdk.MessageRoleCapabilities{})
+	if !errors.Is(err, sdk.ErrInstructionInsideToolExchange) {
+		t.Fatalf("error: got %v, want ErrInstructionInsideToolExchange", err)
+	}
+}
+
+func TestNormalizeRejectsNonTextInstructionContent(t *testing.T) {
+	messages := []sdk.Message{{
+		Role:    sdk.MessageRoleSystem,
+		Content: []sdk.MessagePart{sdk.ImagePart{Image: "https://example.com/image.png"}},
+	}}
+
+	_, err := Normalize(messages, sdk.MessageRoleCapabilities{})
+	if !errors.Is(err, sdk.ErrInvalidInstructionContent) {
+		t.Fatalf("error: got %v, want ErrInvalidInstructionContent", err)
+	}
+}

--- a/provider/anthropic/messages/message_roles_test.go
+++ b/provider/anthropic/messages/message_roles_test.go
@@ -1,0 +1,121 @@
+package messages_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/anthropic/messages"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+type anthropicRoleBody struct {
+	System []struct {
+		Text string `json:"text"`
+	} `json:"system"`
+	Messages []struct {
+		Role    string `json:"role"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"messages"`
+}
+
+func TestUnsupportedInstructionRolesFallbackToUser(t *testing.T) {
+	srv := anthropicRoleServer(t, func(body anthropicRoleBody) {
+		if len(body.System) != 2 || body.System[0].Text != "root policy" || body.System[1].Text != "leading system" {
+			t.Fatalf("system blocks: %+v", body.System)
+		}
+		wantRoles := []string{"user", "assistant", "user"}
+		if len(body.Messages) != len(wantRoles) {
+			t.Fatalf("message count: got %d, want %d", len(body.Messages), len(wantRoles))
+		}
+		for i, want := range wantRoles {
+			if body.Messages[i].Role != want {
+				t.Fatalf("message %d role: got %q, want %q", i, body.Messages[i].Role, want)
+			}
+		}
+		if len(body.Messages[0].Content) != 2 {
+			t.Fatalf("first user content count: got %d", len(body.Messages[0].Content))
+		}
+		wantSystem := "<system>\nruntime &lt;changed&gt; &amp; verified\n</system>"
+		if body.Messages[0].Content[1].Text != wantSystem {
+			t.Fatalf("mid-system fallback:\n got: %q\nwant: %q", body.Messages[0].Content[1].Text, wantSystem)
+		}
+		if body.Messages[2].Content[0].Text != "developer policy" {
+			t.Fatalf("developer fallback content: got %q", body.Messages[2].Content[0].Text)
+		}
+	})
+	defer srv.Close()
+
+	p := messages.New(messages.WithAPIKey("k"), messages.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:  p.ChatModel("claude-test"),
+		System: "root policy",
+		Messages: []sdk.Message{
+			sdk.SystemMessage("leading system"),
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime <changed> & verified"),
+			sdk.AssistantMessage("answer"),
+			sdk.DeveloperMessage("developer policy"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func TestMidConversationSystemCanBeEnabledForSupportedModels(t *testing.T) {
+	srv := anthropicRoleServer(t, func(body anthropicRoleBody) {
+		wantRoles := []string{"user", "system", "assistant"}
+		if len(body.Messages) != len(wantRoles) {
+			t.Fatalf("message count: got %d, want %d", len(body.Messages), len(wantRoles))
+		}
+		for i, want := range wantRoles {
+			if body.Messages[i].Role != want {
+				t.Fatalf("message %d role: got %q, want %q", i, body.Messages[i].Role, want)
+			}
+		}
+		if body.Messages[1].Content[0].Text != "runtime changed" {
+			t.Fatalf("native system content: got %q", body.Messages[1].Content[0].Text)
+		}
+	})
+	defer srv.Close()
+
+	p := messages.New(
+		messages.WithAPIKey("k"),
+		messages.WithBaseURL(srv.URL),
+		messages.WithMidConversationSystemMessages(true),
+	)
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: p.ChatModel("claude-supported"),
+		Messages: []sdk.Message{
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime changed"),
+			sdk.AssistantMessage("answer"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func anthropicRoleServer(t *testing.T, assert func(anthropicRoleBody)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body anthropicRoleBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		assert(body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg-roles", "type": "message", "model": "claude-test", "role": "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "ok"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+}

--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
 	"github.com/memohai/twilight-ai/sdk"
 )
@@ -38,12 +39,13 @@ type ThinkingConfig struct {
 }
 
 type Provider struct {
-	apiKey     string
-	authToken  string
-	baseURL    string
-	httpClient *http.Client
-	headers    map[string]string
-	thinking   *ThinkingConfig
+	apiKey                        string
+	authToken                     string
+	baseURL                       string
+	httpClient                    *http.Client
+	headers                       map[string]string
+	thinking                      *ThinkingConfig
+	supportsMidConversationSystem bool
 }
 
 type Option func(*Provider)
@@ -85,6 +87,15 @@ func WithHeaders(headers map[string]string) Option {
 func WithThinking(cfg ThinkingConfig) Option {
 	return func(p *Provider) {
 		p.thinking = &cfg
+	}
+}
+
+// WithMidConversationSystemMessages enables native system messages inside the
+// Anthropic message timeline. Keep this disabled unless the selected model is
+// documented to support interleaved system messages.
+func WithMidConversationSystemMessages(enabled bool) Option {
+	return func(p *Provider) {
+		p.supportsMidConversationSystem = enabled
 	}
 }
 
@@ -203,7 +214,10 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 		return nil, fmt.Errorf("anthropic: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: build request: %w", err)
+	}
 
 	resp, err := utils.FetchJSON[messagesResponse](ctx, p.httpClient, &utils.RequestOptions{
 		Method:  http.MethodPost,
@@ -225,8 +239,14 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 
 // ---------- buildRequest ----------
 
-func (p *Provider) buildRequest(params *sdk.GenerateParams) *messagesRequest {
-	system, messages := convertMessages(params)
+func (p *Provider) buildRequest(params *sdk.GenerateParams) (*messagesRequest, error) {
+	normalized, err := messagecompat.Normalize(params.Messages, sdk.MessageRoleCapabilities{
+		MidConversationSystem: p.supportsMidConversationSystem,
+	})
+	if err != nil {
+		return nil, err
+	}
+	system, messages := convertMessages(params.System, normalized)
 
 	req := &messagesRequest{
 		Model:       params.Model.ID,
@@ -262,7 +282,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *messagesRequest {
 		}
 	}
 
-	return req
+	return req, nil
 }
 
 func resolveMaxTokens(params *sdk.GenerateParams, thinking *ThinkingConfig) *int {
@@ -353,41 +373,58 @@ func convertToolChoice(choice any) *anthropicToolChoice {
 // block without cache_control. To attach cache_control to a system prompt,
 // pass it as a MessageRoleSystem message with a TextPart that has CacheControl
 // set instead of using the System field.
-func convertMessages(params *sdk.GenerateParams) ([]contentBlock, []anthropicMessage) {
+func convertMessages(systemPrompt string, messages []sdk.Message) ([]contentBlock, []anthropicMessage) {
 	var system []contentBlock
 	var out []anthropicMessage
+	conversationStarted := false
 
-	if params.System != "" {
-		system = append(system, contentBlock{Type: blockTypeText, Text: params.System})
+	if systemPrompt != "" {
+		system = append(system, contentBlock{Type: blockTypeText, Text: systemPrompt})
 	}
 
-	for _, msg := range params.Messages {
+	for _, msg := range messages {
 		switch msg.Role {
 		case sdk.MessageRoleSystem:
-			for _, part := range msg.Content {
-				if tp, ok := part.(sdk.TextPart); ok {
-					block := contentBlock{Type: blockTypeText, Text: tp.Text}
-					if tp.CacheControl != nil {
-						block.CacheControl = &cacheControl{Type: tp.CacheControl.Type, TTL: tp.CacheControl.TTL}
-					}
-					system = append(system, block)
-				}
+			blocks := convertSystemContent(msg.Content)
+			if conversationStarted {
+				out = append(out, anthropicMessage{Role: "system", Content: blocks})
+			} else {
+				system = append(system, blocks...)
 			}
 
 		case sdk.MessageRoleUser:
+			conversationStarted = true
 			blocks := convertUserContent(msg.Content)
 			out = appendUserBlocks(out, blocks)
 
 		case sdk.MessageRoleAssistant:
+			conversationStarted = true
 			out = append(out, convertAssistantMessage(msg))
 
 		case sdk.MessageRoleTool:
+			conversationStarted = true
 			blocks := convertToolResults(msg.Content)
 			out = appendUserBlocks(out, blocks)
 		}
 	}
 
 	return system, out
+}
+
+func convertSystemContent(parts []sdk.MessagePart) []contentBlock {
+	blocks := make([]contentBlock, 0, len(parts))
+	for _, part := range parts {
+		tp, ok := part.(sdk.TextPart)
+		if !ok {
+			continue
+		}
+		block := contentBlock{Type: blockTypeText, Text: tp.Text}
+		if tp.CacheControl != nil {
+			block.CacheControl = &cacheControl{Type: tp.CacheControl.Type, TTL: tp.CacheControl.TTL}
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks
 }
 
 // appendUserBlocks appends content blocks to the last user message if it exists,
@@ -597,7 +634,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 		return nil, fmt.Errorf("anthropic: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: build request: %w", err)
+	}
 	req.Stream = true
 
 	ch := make(chan sdk.StreamPart, 64)

--- a/provider/github/copilot/copilot.go
+++ b/provider/github/copilot/copilot.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
 	"github.com/memohai/twilight-ai/sdk"
 )
@@ -15,9 +16,10 @@ import (
 const defaultBaseURL = "https://api.githubcopilot.com"
 
 type Provider struct {
-	githubToken string
-	baseURL     string
-	httpClient  *http.Client
+	githubToken  string
+	baseURL      string
+	httpClient   *http.Client
+	messageRoles sdk.MessageRoleCapabilities
 }
 
 type Option func(*Provider)
@@ -43,6 +45,15 @@ func WithBaseURL(baseURL string) Option {
 func WithHTTPClient(client *http.Client) Option {
 	return func(p *Provider) {
 		p.httpClient = client
+	}
+}
+
+// WithMessageRoleCapabilities enables instruction roles supported by the
+// configured Copilot endpoint. The default conservatively falls back developer
+// and mid-conversation system messages to user messages.
+func WithMessageRoleCapabilities(capabilities sdk.MessageRoleCapabilities) Option {
+	return func(p *Provider) {
+		p.messageRoles = capabilities
 	}
 }
 
@@ -84,10 +95,13 @@ func (p *Provider) Test(ctx context.Context) *sdk.ProviderTestResult {
 }
 
 func (p *Provider) TestModel(ctx context.Context, modelID string) (*sdk.ModelTestResult, error) {
-	req := p.buildRequest(&sdk.GenerateParams{
+	req, err := p.buildRequest(&sdk.GenerateParams{
 		Model:    p.ChatModel(modelID),
 		Messages: []sdk.Message{sdk.UserMessage("ping")},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("github-copilot: build probe request: %w", err)
+	}
 
 	status, err := utils.ProbeStatus(ctx, p.httpClient, &utils.RequestOptions{
 		Method:  http.MethodPost,
@@ -118,7 +132,10 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 		return nil, fmt.Errorf("github-copilot: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("github-copilot: build request: %w", err)
+	}
 
 	resp, err := utils.FetchJSON[chatResponse](ctx, p.httpClient, &utils.RequestOptions{
 		Method:  http.MethodPost,
@@ -138,10 +155,14 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 	return p.parseResponse(resp)
 }
 
-func (p *Provider) buildRequest(params *sdk.GenerateParams) *chatRequest {
+func (p *Provider) buildRequest(params *sdk.GenerateParams) (*chatRequest, error) {
+	messages, err := messagecompat.Normalize(params.Messages, p.messageRoles)
+	if err != nil {
+		return nil, err
+	}
 	req := &chatRequest{
 		Model:            params.Model.ID,
-		Messages:         convertMessages(params),
+		Messages:         convertMessages(params.System, messages),
 		Temperature:      params.Temperature,
 		TopP:             params.TopP,
 		MaxTokens:        params.MaxTokens,
@@ -166,7 +187,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *chatRequest {
 			JSONSchema: params.ResponseFormat.JSONSchema,
 		}
 	}
-	return req
+	return req, nil
 }
 
 func convertTools(tools []sdk.Tool) []chatTool {
@@ -184,17 +205,17 @@ func convertTools(tools []sdk.Tool) []chatTool {
 	return out
 }
 
-func convertMessages(params *sdk.GenerateParams) []chatMessage {
+func convertMessages(system string, messages []sdk.Message) []chatMessage {
 	var out []chatMessage
 
-	if params.System != "" {
+	if system != "" {
 		out = append(out, chatMessage{
 			Role:    "system",
-			Content: params.System,
+			Content: system,
 		})
 	}
 
-	for _, msg := range params.Messages {
+	for _, msg := range messages {
 		out = append(out, convertMessage(msg)...)
 	}
 	return out
@@ -353,7 +374,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 		return nil, fmt.Errorf("github-copilot: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("github-copilot: build request: %w", err)
+	}
 	req.Stream = true
 	req.StreamOptions = &chatStreamOptions{IncludeUsage: true}
 

--- a/provider/github/copilot/message_roles_test.go
+++ b/provider/github/copilot/message_roles_test.go
@@ -1,0 +1,117 @@
+package copilot_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/github/copilot"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+type copilotWireMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+func TestInstructionRolesFallbackConservatively(t *testing.T) {
+	srv := copilotMessageServer(t, func(messages []copilotWireMessage) {
+		wantRoles := []string{"system", "system", "user", "user", "user"}
+		assertCopilotRoles(t, messages, wantRoles)
+		wantSystem := "<system>\nruntime &lt;changed&gt; &amp; verified\n</system>"
+		if text := copilotRawString(t, messages[3].Content); text != wantSystem {
+			t.Fatalf("mid-system fallback:\n got: %q\nwant: %q", text, wantSystem)
+		}
+		if text := copilotRawString(t, messages[4].Content); text != "developer policy" {
+			t.Fatalf("developer fallback content: got %q", text)
+		}
+	})
+	defer srv.Close()
+
+	p := copilot.New(copilot.WithGitHubToken("token"), copilot.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:  p.ChatModel("copilot-model"),
+		System: "root policy",
+		Messages: []sdk.Message{
+			sdk.SystemMessage("leading system"),
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime <changed> & verified"),
+			sdk.DeveloperMessage("developer policy"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func TestInstructionRolesCanUseConfiguredNativeSupport(t *testing.T) {
+	srv := copilotMessageServer(t, func(messages []copilotWireMessage) {
+		assertCopilotRoles(t, messages, []string{"user", "system", "developer"})
+	})
+	defer srv.Close()
+
+	p := copilot.New(
+		copilot.WithGitHubToken("token"),
+		copilot.WithBaseURL(srv.URL),
+		copilot.WithMessageRoleCapabilities(sdk.MessageRoleCapabilities{
+			Developer:             true,
+			MidConversationSystem: true,
+		}),
+	)
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: p.ChatModel("copilot-model"),
+		Messages: []sdk.Message{
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime changed"),
+			sdk.DeveloperMessage("developer policy"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func copilotMessageServer(t *testing.T, assert func([]copilotWireMessage)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Messages []copilotWireMessage `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		assert(body.Messages)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "copilot-roles", "created": 1700000000, "model": "copilot-model",
+			"choices": []map[string]any{{
+				"index": 0, "finish_reason": "stop",
+				"message": map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+}
+
+func assertCopilotRoles(t *testing.T, messages []copilotWireMessage, want []string) {
+	t.Helper()
+	if len(messages) != len(want) {
+		t.Fatalf("message count: got %d, want %d", len(messages), len(want))
+	}
+	for i, role := range want {
+		if messages[i].Role != role {
+			t.Fatalf("message %d role: got %q, want %q", i, messages[i].Role, role)
+		}
+	}
+}
+
+func copilotRawString(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("decode string content %s: %v", raw, err)
+	}
+	return value
+}

--- a/provider/google/generativeai/generativeai.go
+++ b/provider/google/generativeai/generativeai.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
 	"github.com/memohai/twilight-ai/sdk"
 )
@@ -158,7 +159,10 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 		return nil, fmt.Errorf("google: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("google: build request: %w", err)
+	}
 	modelPath := getModelPath(params.Model.ID)
 
 	resp, err := utils.FetchJSON[generateResponse](ctx, p.httpClient, &utils.RequestOptions{
@@ -181,8 +185,12 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 
 // ---------- buildRequest ----------
 
-func (p *Provider) buildRequest(params *sdk.GenerateParams) *generateRequest {
-	contents, sysInstruction := convertMessages(params)
+func (p *Provider) buildRequest(params *sdk.GenerateParams) (*generateRequest, error) {
+	messages, err := messagecompat.Normalize(params.Messages, sdk.MessageRoleCapabilities{})
+	if err != nil {
+		return nil, err
+	}
+	contents, sysInstruction := convertMessages(params.System, messages)
 
 	req := &generateRequest{
 		Contents:          contents,
@@ -217,22 +225,29 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *generateRequest {
 		req.ToolConfig = toolCfg
 	}
 
-	return req
+	return req, nil
 }
 
 // ---------- message conversion ----------
 
-func convertMessages(params *sdk.GenerateParams) ([]content, *content) { //nolint:gocritic // unnamed results are clear in context
-	contents := make([]content, 0, len(params.Messages))
+func convertMessages(systemPrompt string, messages []sdk.Message) ([]content, *content) { //nolint:gocritic // unnamed results are clear in context
+	contents := make([]content, 0, len(messages))
 	var sysInstruction *content
 
-	if params.System != "" {
+	if systemPrompt != "" {
 		sysInstruction = &content{
-			Parts: []contentPart{{Text: params.System}},
+			Parts: []contentPart{{Text: systemPrompt}},
 		}
 	}
 
-	for _, msg := range params.Messages {
+	for _, msg := range messages {
+		if msg.Role == sdk.MessageRoleSystem {
+			if sysInstruction == nil {
+				sysInstruction = &content{}
+			}
+			sysInstruction.Parts = append(sysInstruction.Parts, contentPart{Text: messagecompat.InstructionText(msg)})
+			continue
+		}
 		contents = append(contents, convertMessage(msg)...)
 	}
 	return contents, sysInstruction
@@ -454,7 +469,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 		return nil, fmt.Errorf("google: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("google: build request: %w", err)
+	}
 	modelPath := getModelPath(params.Model.ID)
 
 	ch := make(chan sdk.StreamPart, 64)

--- a/provider/google/generativeai/message_roles_test.go
+++ b/provider/google/generativeai/message_roles_test.go
@@ -1,0 +1,82 @@
+package generativeai_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/google/generativeai"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+func TestInstructionRolesMapToSystemInstructionAndUserFallbacks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			SystemInstruction *struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"systemInstruction"`
+			Contents []struct {
+				Role  string `json:"role"`
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"contents"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if body.SystemInstruction == nil || len(body.SystemInstruction.Parts) != 2 {
+			t.Fatalf("systemInstruction: %+v", body.SystemInstruction)
+		}
+		if body.SystemInstruction.Parts[0].Text != "root policy" || body.SystemInstruction.Parts[1].Text != "leading system" {
+			t.Fatalf("systemInstruction parts: %+v", body.SystemInstruction.Parts)
+		}
+
+		wantRoles := []string{"user", "user", "model", "user"}
+		if len(body.Contents) != len(wantRoles) {
+			t.Fatalf("content count: got %d, want %d", len(body.Contents), len(wantRoles))
+		}
+		for i, want := range wantRoles {
+			if body.Contents[i].Role != want {
+				t.Fatalf("content %d role: got %q, want %q", i, body.Contents[i].Role, want)
+			}
+		}
+		wantSystem := "<system>\nruntime &lt;changed&gt; &amp; verified\n</system>"
+		if body.Contents[1].Parts[0].Text != wantSystem {
+			t.Fatalf("mid-system fallback:\n got: %q\nwant: %q", body.Contents[1].Parts[0].Text, wantSystem)
+		}
+		if body.Contents[3].Parts[0].Text != "developer policy" {
+			t.Fatalf("developer fallback content: got %q", body.Contents[3].Parts[0].Text)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{{
+				"content":      map[string]any{"role": "model", "parts": []map[string]any{{"text": "ok"}}},
+				"finishReason": "STOP",
+			}},
+			"usageMetadata": map[string]any{"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := generativeai.New(generativeai.WithAPIKey("k"), generativeai.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:  p.ChatModel("gemini-test"),
+		System: "root policy",
+		Messages: []sdk.Message{
+			sdk.SystemMessage("leading system"),
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime <changed> & verified"),
+			sdk.AssistantMessage("answer"),
+			sdk.DeveloperMessage("developer policy"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}

--- a/provider/openai/codex/codex.go
+++ b/provider/openai/codex/codex.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
 	"github.com/memohai/twilight-ai/sdk"
 )
@@ -91,11 +92,14 @@ func (p *Provider) Test(ctx context.Context) *sdk.ProviderTestResult {
 }
 
 func (p *Provider) TestModel(ctx context.Context, modelID string) (*sdk.ModelTestResult, error) {
-	req := p.buildRequest(&sdk.GenerateParams{
+	req, err := p.buildRequest(&sdk.GenerateParams{
 		Model:    p.ChatModel(modelID),
 		System:   "You are a helpful AI assistant.",
 		Messages: []sdk.Message{sdk.UserMessage("ping")},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("openai-codex: build probe request: %w", err)
+	}
 	req.Stream = false
 
 	status, err := utils.ProbeStatus(ctx, p.httpClient, &utils.RequestOptions{
@@ -136,7 +140,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 		return nil, fmt.Errorf("openai-codex: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("openai-codex: build request: %w", err)
+	}
 	req.Stream = true
 
 	ch := make(chan sdk.StreamPart, 64)
@@ -359,8 +366,12 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 	return &sdk.StreamResult{Stream: ch}, nil
 }
 
-func (p *Provider) buildRequest(params *sdk.GenerateParams) *codexRequest {
-	instructions, input := convertToCodexInput(params)
+func (p *Provider) buildRequest(params *sdk.GenerateParams) (*codexRequest, error) {
+	messages, err := messagecompat.Normalize(params.Messages, sdk.MessageRoleCapabilities{})
+	if err != nil {
+		return nil, err
+	}
+	instructions, input := convertToCodexInput(params.System, messages)
 	req := &codexRequest{
 		Model:        params.Model.ID,
 		Instructions: instructions,
@@ -391,7 +402,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *codexRequest {
 		// The Codex endpoint accepts max even though generic OpenAI endpoints do not.
 		req.Reasoning = &codexReasoning{Effort: *params.ReasoningEffort}
 	}
-	return req
+	return req, nil
 }
 
 func convertCodexTools(tools []sdk.Tool) []codexTool {
@@ -407,18 +418,18 @@ func convertCodexTools(tools []sdk.Tool) []codexTool {
 	return out
 }
 
-func convertToCodexInput(params *sdk.GenerateParams) (string, []json.RawMessage) {
+func convertToCodexInput(systemPrompt string, messages []sdk.Message) (string, []json.RawMessage) {
 	var (
 		instructions []string
 		items        []json.RawMessage
 	)
 
-	if params.System != "" {
-		instructions = append(instructions, params.System)
+	if systemPrompt != "" {
+		instructions = append(instructions, systemPrompt)
 	}
-	for _, msg := range params.Messages {
+	for _, msg := range messages {
 		if msg.Role == sdk.MessageRoleSystem {
-			instructions = append(instructions, textFromParts(msg.Content))
+			instructions = append(instructions, messagecompat.InstructionText(msg))
 			continue
 		}
 		items = append(items, convertCodexMessage(msg)...)
@@ -591,16 +602,6 @@ func marshalRaw(v any) json.RawMessage {
 
 func appendRaw(dst []json.RawMessage, v any) []json.RawMessage {
 	return append(dst, marshalRaw(v))
-}
-
-func textFromParts(parts []sdk.MessagePart) string {
-	var out string
-	for _, part := range parts {
-		if tp, ok := part.(sdk.TextPart); ok {
-			out += tp.Text
-		}
-	}
-	return out
 }
 
 func joinNonEmpty(values ...string) string {

--- a/provider/openai/codex/message_roles_test.go
+++ b/provider/openai/codex/message_roles_test.go
@@ -1,0 +1,83 @@
+package codex_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/openai/codex"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+func TestUnsupportedInstructionRolesFallbackWithoutHoisting(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Instructions string            `json:"instructions"`
+			Input        []json.RawMessage `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if body.Instructions != "root policy\n\nleading system" {
+			t.Fatalf("instructions: got %q", body.Instructions)
+		}
+		wantRoles := []string{"user", "user", "assistant", "user"}
+		if len(body.Input) != len(wantRoles) {
+			t.Fatalf("input count: got %d, want %d", len(body.Input), len(wantRoles))
+		}
+		for i, want := range wantRoles {
+			var item struct {
+				Role    string `json:"role"`
+				Content []struct {
+					Text string `json:"text"`
+				} `json:"content"`
+			}
+			if err := json.Unmarshal(body.Input[i], &item); err != nil {
+				t.Fatalf("decode input %d: %v", i, err)
+			}
+			if item.Role != want {
+				t.Fatalf("input %d role: got %q, want %q", i, item.Role, want)
+			}
+			if i == 1 {
+				wantSystem := "<system>\nruntime &lt;changed&gt; &amp; verified\n</system>"
+				if item.Content[0].Text != wantSystem {
+					t.Fatalf("mid-system fallback:\n got: %q\nwant: %q", item.Content[0].Text, wantSystem)
+				}
+			}
+			if i == 3 && item.Content[0].Text != "developer policy" {
+				t.Fatalf("developer fallback content: got %q", item.Content[0].Text)
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("data: {\"response\":{\"id\":\"resp-roles\",\"created_at\":1700000000,\"model\":\"gpt-5\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_item.added\n"))
+		_, _ = w.Write([]byte("data: {\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg-roles\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_text.delta\n"))
+		_, _ = w.Write([]byte("data: {\"item_id\":\"msg-roles\",\"delta\":\"ok\"}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_item.done\n"))
+		_, _ = w.Write([]byte("data: {\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg-roles\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"))
+	}))
+	defer srv.Close()
+
+	p := codex.New(codex.WithAccessToken("token"), codex.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:  p.ChatModel("gpt-5"),
+		System: "root policy",
+		Messages: []sdk.Message{
+			sdk.SystemMessage("leading system"),
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime <changed> & verified"),
+			sdk.AssistantMessage("answer"),
+			sdk.DeveloperMessage("developer policy"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
 	openaiutil "github.com/memohai/twilight-ai/provider/openai"
 	"github.com/memohai/twilight-ai/sdk"
@@ -22,6 +23,7 @@ type Provider struct {
 	httpClient     *http.Client
 	prepareRequest func(*http.Request) error
 	compat         chatCompletionsCompat
+	messageRoles   sdk.MessageRoleCapabilities
 }
 
 type Option func(*Provider)
@@ -83,6 +85,15 @@ func WithHTTPClient(client *http.Client) Option {
 	}
 }
 
+// WithMessageRoleCapabilities overrides the instruction roles supported by an
+// OpenAI-compatible Chat Completions endpoint. The OpenAI default supports
+// developer messages and system messages anywhere in the conversation.
+func WithMessageRoleCapabilities(capabilities sdk.MessageRoleCapabilities) Option {
+	return func(p *Provider) {
+		p.messageRoles = capabilities
+	}
+}
+
 // WithDeepSeekChatCompletionsCompat maps reasoning_effort "none" to DeepSeek's
 // thinking disable toggle while keeping the generic Chat Completions provider.
 func WithDeepSeekChatCompletionsCompat() Option {
@@ -116,6 +127,10 @@ func New(options ...Option) *Provider {
 	provider := &Provider{
 		baseURL:    defaultBaseURL,
 		httpClient: &http.Client{},
+		messageRoles: sdk.MessageRoleCapabilities{
+			Developer:             true,
+			MidConversationSystem: true,
+		},
 	}
 	for _, option := range options {
 		option(provider)
@@ -222,7 +237,10 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 		return nil, fmt.Errorf("openai: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("openai: build request: %w", err)
+	}
 
 	resp, err := utils.FetchJSON[chatResponse](ctx, p.httpClient, &utils.RequestOptions{
 		Method:  http.MethodPost,
@@ -245,10 +263,14 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 
 // ---------- buildRequest ----------
 
-func (p *Provider) buildRequest(params *sdk.GenerateParams) *chatRequest {
+func (p *Provider) buildRequest(params *sdk.GenerateParams) (*chatRequest, error) {
+	messages, err := messagecompat.Normalize(params.Messages, p.messageRoles)
+	if err != nil {
+		return nil, err
+	}
 	req := &chatRequest{
 		Model:               params.Model.ID,
-		Messages:            convertMessages(params),
+		Messages:            convertMessages(params.System, messages),
 		Temperature:         params.Temperature,
 		TopP:                params.TopP,
 		MaxCompletionTokens: params.MaxTokens,
@@ -271,7 +293,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *chatRequest {
 		}
 	}
 	p.applyChatCompletionsCompat(req)
-	return req
+	return req, nil
 }
 
 func normalizeReasoningEffort(effort *string) *string {
@@ -432,17 +454,17 @@ func sanitizeSchemaMapForKimi(schema map[string]any) {
 
 // ---------- message conversion ----------
 
-func convertMessages(params *sdk.GenerateParams) []chatMessage {
+func convertMessages(system string, messages []sdk.Message) []chatMessage {
 	var out []chatMessage
 
-	if params.System != "" {
+	if system != "" {
 		out = append(out, chatMessage{
 			Role:    "system",
-			Content: params.System,
+			Content: system,
 		})
 	}
 
-	for _, msg := range params.Messages {
+	for _, msg := range messages {
 		out = append(out, convertMessage(msg)...)
 	}
 	return out
@@ -614,7 +636,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 		return nil, fmt.Errorf("openai: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("openai: build request: %w", err)
+	}
 	req.Stream = true
 	req.StreamOptions = &chatStreamOptions{IncludeUsage: true}
 

--- a/provider/openai/completions/message_roles_test.go
+++ b/provider/openai/completions/message_roles_test.go
@@ -1,0 +1,118 @@
+package completions_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/openai/completions"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+type completionsWireMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+func TestMessageRolesUseOpenAINativeRolesByDefault(t *testing.T) {
+	srv := completionsMessageServer(t, func(messages []completionsWireMessage) {
+		wantRoles := []string{"system", "user", "system", "developer"}
+		assertCompletionsRoles(t, messages, wantRoles)
+		if text := rawString(t, messages[2].Content); text != "runtime changed" {
+			t.Fatalf("mid-system content: got %q", text)
+		}
+	})
+	defer srv.Close()
+
+	p := completions.New(completions.WithAPIKey("k"), completions.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:  p.ChatModel("gpt-5"),
+		System: "root policy",
+		Messages: []sdk.Message{
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime changed"),
+			sdk.DeveloperMessage("developer policy"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func TestMessageRolesCanFallbackForCompatibleEndpoints(t *testing.T) {
+	srv := completionsMessageServer(t, func(messages []completionsWireMessage) {
+		wantRoles := []string{"system", "user", "user", "user"}
+		assertCompletionsRoles(t, messages, wantRoles)
+		wantSystem := "<system>\nruntime &lt;changed&gt; &amp; verified\n</system>"
+		if text := rawString(t, messages[2].Content); text != wantSystem {
+			t.Fatalf("mid-system fallback:\n got: %q\nwant: %q", text, wantSystem)
+		}
+		if text := rawString(t, messages[3].Content); text != "developer policy" {
+			t.Fatalf("developer fallback content: got %q", text)
+		}
+	})
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithMessageRoleCapabilities(sdk.MessageRoleCapabilities{}),
+	)
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:  p.ChatModel("compatible-model"),
+		System: "root policy",
+		Messages: []sdk.Message{
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime <changed> & verified"),
+			sdk.DeveloperMessage("developer policy"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func completionsMessageServer(t *testing.T, assert func([]completionsWireMessage)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Messages []completionsWireMessage `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		assert(body.Messages)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "chatcmpl-roles", "created": 1700000000, "model": "test",
+			"choices": []map[string]any{{
+				"index": 0, "finish_reason": "stop",
+				"message": map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+}
+
+func assertCompletionsRoles(t *testing.T, messages []completionsWireMessage, want []string) {
+	t.Helper()
+	if len(messages) != len(want) {
+		t.Fatalf("message count: got %d, want %d", len(messages), len(want))
+	}
+	for i, role := range want {
+		if messages[i].Role != role {
+			t.Fatalf("message %d role: got %q, want %q", i, messages[i].Role, role)
+		}
+	}
+}
+
+func rawString(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("decode string content %s: %v", raw, err)
+	}
+	return value
+}

--- a/provider/openai/responses/message_roles_test.go
+++ b/provider/openai/responses/message_roles_test.go
@@ -1,0 +1,105 @@
+package responses_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/openai/responses"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+func TestMessageRolesUseNativeResponsesInstructions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Instructions string            `json:"instructions"`
+			Input        []json.RawMessage `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if body.Instructions != "root policy" {
+			t.Fatalf("instructions: got %q", body.Instructions)
+		}
+		if len(body.Input) != 3 {
+			t.Fatalf("input count: got %d, want 3", len(body.Input))
+		}
+		for i, want := range []string{"user", "system", "developer"} {
+			var item struct {
+				Role string `json:"role"`
+			}
+			if err := json.Unmarshal(body.Input[i], &item); err != nil {
+				t.Fatalf("decode input %d: %v", i, err)
+			}
+			if item.Role != want {
+				t.Fatalf("input %d role: got %q, want %q", i, item.Role, want)
+			}
+		}
+
+		var developer struct {
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(body.Input[2], &developer); err != nil {
+			t.Fatalf("decode developer message: %v", err)
+		}
+		if developer.Content != "developer policy" {
+			t.Fatalf("developer content: got %q", developer.Content)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "resp-roles", "created_at": 1700000000, "model": "gpt-5",
+			"output": []map[string]any{{
+				"type": "message", "id": "msg-roles", "role": "assistant",
+				"content": []map[string]any{{"type": "output_text", "text": "ok"}},
+			}},
+			"usage": map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:  p.ChatModel("gpt-5"),
+		System: "root policy",
+		Messages: []sdk.Message{
+			sdk.UserMessage("question"),
+			sdk.SystemMessage("runtime changed"),
+			sdk.DeveloperMessage("developer policy"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func TestInstructionCannotInterruptToolExchange(t *testing.T) {
+	p := responses.New(responses.WithAPIKey("k"))
+	params := sdk.GenerateParams{
+		Model: p.ChatModel("gpt-5"),
+		Messages: []sdk.Message{
+			{
+				Role: sdk.MessageRoleAssistant,
+				Content: []sdk.MessagePart{sdk.ToolCallPart{
+					ToolCallID: "call-1",
+					ToolName:   "lookup",
+					Input:      map[string]any{"q": "value"},
+				}},
+			},
+			sdk.DeveloperMessage("new policy"),
+			sdk.ToolMessage(sdk.ToolResultPart{ToolCallID: "call-1", ToolName: "lookup", Result: "ok"}),
+		},
+	}
+
+	_, err := p.DoGenerate(context.Background(), params)
+	if !errors.Is(err, sdk.ErrInstructionInsideToolExchange) {
+		t.Fatalf("DoGenerate error: got %v", err)
+	}
+	_, err = p.DoStream(context.Background(), params)
+	if !errors.Is(err, sdk.ErrInstructionInsideToolExchange) {
+		t.Fatalf("DoStream error: got %v", err)
+	}
+}

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
 	openaiutil "github.com/memohai/twilight-ai/provider/openai"
 	"github.com/memohai/twilight-ai/sdk"
@@ -74,11 +75,11 @@ func (p *Provider) Name() string { return "openai-responses" }
 
 func (p *Provider) ListModels(ctx context.Context) ([]sdk.Model, error) {
 	resp, err := utils.FetchJSON[modelsListResponse](ctx, p.httpClient, &utils.RequestOptions{
-		Method:   http.MethodGet,
-		BaseURL:  p.baseURL,
-		Path:     "/models",
-		Headers:  p.authHeaders(),
-		Prepare:  p.prepareRequest,
+		Method:  http.MethodGet,
+		BaseURL: p.baseURL,
+		Path:    "/models",
+		Headers: p.authHeaders(),
+		Prepare: p.prepareRequest,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("openai-responses: list models request failed: %w", err)
@@ -97,12 +98,12 @@ func (p *Provider) ListModels(ctx context.Context) ([]sdk.Model, error) {
 
 func (p *Provider) Test(ctx context.Context) *sdk.ProviderTestResult {
 	_, err := utils.FetchJSON[modelsListResponse](ctx, p.httpClient, &utils.RequestOptions{
-		Method:   http.MethodGet,
-		BaseURL:  p.baseURL,
-		Path:     "/models",
-		Query:    map[string]string{"limit": "1"},
-		Headers:  p.authHeaders(),
-		Prepare:  p.prepareRequest,
+		Method:  http.MethodGet,
+		BaseURL: p.baseURL,
+		Path:    "/models",
+		Query:   map[string]string{"limit": "1"},
+		Headers: p.authHeaders(),
+		Prepare: p.prepareRequest,
 	})
 	if err != nil {
 		return classifyError(err)
@@ -112,11 +113,11 @@ func (p *Provider) Test(ctx context.Context) *sdk.ProviderTestResult {
 
 func (p *Provider) TestModel(ctx context.Context, modelID string) (*sdk.ModelTestResult, error) {
 	_, err := utils.FetchJSON[modelObject](ctx, p.httpClient, &utils.RequestOptions{
-		Method:   http.MethodGet,
-		BaseURL:  p.baseURL,
-		Path:     "/models/" + modelID,
-		Headers:  p.authHeaders(),
-		Prepare:  p.prepareRequest,
+		Method:  http.MethodGet,
+		BaseURL: p.baseURL,
+		Path:    "/models/" + modelID,
+		Headers: p.authHeaders(),
+		Prepare: p.prepareRequest,
 	})
 	if err == nil {
 		return &sdk.ModelTestResult{Supported: true, Message: "supported"}, nil
@@ -127,11 +128,11 @@ func (p *Provider) TestModel(ctx context.Context, modelID string) (*sdk.ModelTes
 	}
 
 	status, probeErr := utils.ProbeStatus(ctx, p.httpClient, &utils.RequestOptions{
-		Method:   http.MethodPost,
-		BaseURL:  p.baseURL,
-		Path:     "/responses",
-		Headers:  p.authHeaders(),
-		Prepare:  p.prepareRequest,
+		Method:  http.MethodPost,
+		BaseURL: p.baseURL,
+		Path:    "/responses",
+		Headers: p.authHeaders(),
+		Prepare: p.prepareRequest,
 		Body: map[string]any{
 			"model":             modelID,
 			"input":             "hi",
@@ -169,15 +170,18 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 		return nil, fmt.Errorf("openai-responses: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("openai-responses: build request: %w", err)
+	}
 
 	resp, err := utils.FetchJSON[responsesResponse](ctx, p.httpClient, &utils.RequestOptions{
-		Method:   http.MethodPost,
-		BaseURL:  p.baseURL,
-		Path:     "/responses",
-		Headers:  p.authHeaders(),
-		Prepare:  p.prepareRequest,
-		Body:     req,
+		Method:  http.MethodPost,
+		BaseURL: p.baseURL,
+		Path:    "/responses",
+		Headers: p.authHeaders(),
+		Prepare: p.prepareRequest,
+		Body:    req,
 	})
 	if err != nil {
 		var apiErr *utils.APIError
@@ -196,10 +200,18 @@ func (p *Provider) DoGenerate(ctx context.Context, params sdk.GenerateParams) (*
 
 // ---------- buildRequest ----------
 
-func (p *Provider) buildRequest(params *sdk.GenerateParams) *responsesRequest {
+func (p *Provider) buildRequest(params *sdk.GenerateParams) (*responsesRequest, error) {
+	messages, err := messagecompat.Normalize(params.Messages, sdk.MessageRoleCapabilities{
+		Developer:             true,
+		MidConversationSystem: true,
+	})
+	if err != nil {
+		return nil, err
+	}
 	req := &responsesRequest{
 		Model:           params.Model.ID,
-		Input:           convertToResponsesInput(params),
+		Instructions:    params.System,
+		Input:           convertToResponsesInput(messages),
 		Temperature:     params.Temperature,
 		TopP:            params.TopP,
 		MaxOutputTokens: params.MaxTokens,
@@ -231,7 +243,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) *responsesRequest {
 		req.Reasoning = &responsesReasoning{Effort: openaiutil.NormalizeReasoningEffort(*params.ReasoningEffort)}
 	}
 
-	return req
+	return req, nil
 }
 
 func convertResponsesTools(tools []sdk.Tool) []responsesTool {
@@ -249,17 +261,10 @@ func convertResponsesTools(tools []sdk.Tool) []responsesTool {
 
 // ---------- input conversion ----------
 
-func convertToResponsesInput(params *sdk.GenerateParams) []json.RawMessage {
-	var items []json.RawMessage
+func convertToResponsesInput(messages []sdk.Message) []json.RawMessage {
+	items := make([]json.RawMessage, 0, len(messages))
 
-	if params.System != "" {
-		items = appendRaw(items, responsesSystemMessage{
-			Role:    "system",
-			Content: params.System,
-		})
-	}
-
-	for _, msg := range params.Messages {
+	for _, msg := range messages {
 		items = append(items, convertResponsesMessage(msg)...)
 	}
 	return items
@@ -270,6 +275,12 @@ func convertResponsesMessage(msg sdk.Message) []json.RawMessage {
 	case sdk.MessageRoleSystem:
 		return []json.RawMessage{marshalRaw(responsesSystemMessage{
 			Role:    "system",
+			Content: textFromParts(msg.Content),
+		})}
+
+	case sdk.MessageRoleDeveloper:
+		return []json.RawMessage{marshalRaw(responsesSystemMessage{
+			Role:    "developer",
 			Content: textFromParts(msg.Content),
 		})}
 
@@ -470,7 +481,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 		return nil, fmt.Errorf("openai-responses: model is required")
 	}
 
-	req := p.buildRequest(&params)
+	req, err := p.buildRequest(&params)
+	if err != nil {
+		return nil, fmt.Errorf("openai-responses: build request: %w", err)
+	}
 	req.Stream = true
 
 	ch := make(chan sdk.StreamPart, 64)
@@ -521,12 +535,12 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 		}
 
 		err := utils.FetchSSE(ctx, p.httpClient, &utils.RequestOptions{
-			Method:   http.MethodPost,
-			BaseURL:  p.baseURL,
-			Path:     "/responses",
-			Headers:  p.authHeaders(),
-			Prepare:  p.prepareRequest,
-			Body:     req,
+			Method:  http.MethodPost,
+			BaseURL: p.baseURL,
+			Path:    "/responses",
+			Headers: p.authHeaders(),
+			Prepare: p.prepareRequest,
+			Body:    req,
 		}, func(ev *utils.SSEEvent) error {
 			eventType := ev.Event
 			if eventType == "" {

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -974,24 +974,16 @@ func TestResponsesDoStream_ErrorEvent(t *testing.T) {
 func TestResponsesInputConversion_SystemMessage(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
-			Input []json.RawMessage `json:"input"`
+			Instructions string            `json:"instructions"`
+			Input        []json.RawMessage `json:"input"`
 		}
 		json.NewDecoder(r.Body).Decode(&body)
 
-		if len(body.Input) < 2 {
-			t.Fatalf("expected at least 2 input items, got %d", len(body.Input))
+		if body.Instructions != "Be helpful" {
+			t.Fatalf("instructions: got %q", body.Instructions)
 		}
-
-		var sys struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		}
-		json.Unmarshal(body.Input[0], &sys)
-		if sys.Role != "system" {
-			t.Errorf("system role: got %q", sys.Role)
-		}
-		if sys.Content != "Be helpful" {
-			t.Errorf("system content: got %q", sys.Content)
+		if len(body.Input) != 1 {
+			t.Fatalf("expected 1 input item, got %d", len(body.Input))
 		}
 
 		var user struct {
@@ -1001,7 +993,7 @@ func TestResponsesInputConversion_SystemMessage(t *testing.T) {
 				Text string `json:"text"`
 			} `json:"content"`
 		}
-		json.Unmarshal(body.Input[1], &user)
+		json.Unmarshal(body.Input[0], &user)
 		if user.Role != "user" {
 			t.Errorf("user role: got %q", user.Role)
 		}

--- a/provider/openai/responses/types.go
+++ b/provider/openai/responses/types.go
@@ -6,6 +6,7 @@ import "encoding/json"
 
 type responsesRequest struct {
 	Model           string              `json:"model"`
+	Instructions    string              `json:"instructions,omitempty"`
 	Input           []json.RawMessage   `json:"input"`
 	Temperature     *float64            `json:"temperature,omitempty"`
 	TopP            *float64            `json:"top_p,omitempty"`

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -463,6 +463,57 @@ func TestClient_GenerateTextResult_PrepareStep(t *testing.T) {
 	}
 }
 
+func TestClient_GenerateTextResult_PreservesDeveloperRoleAcrossToolSteps(t *testing.T) {
+	mp := &mockProvider{handler: func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		if call == 1 {
+			if len(params.Messages) != 2 || params.Messages[0].Role != sdk.MessageRoleDeveloper {
+				t.Fatalf("first step messages: %+v", params.Messages)
+			}
+			return &sdk.GenerateResult{
+				FinishReason: sdk.FinishReasonToolCalls,
+				ToolCalls: []sdk.ToolCall{{
+					ToolCallID: "c1", ToolName: "fetch", Input: nil,
+				}},
+			}, nil
+		}
+
+		wantRoles := []sdk.MessageRole{
+			sdk.MessageRoleDeveloper,
+			sdk.MessageRoleUser,
+			sdk.MessageRoleAssistant,
+			sdk.MessageRoleTool,
+		}
+		if len(params.Messages) != len(wantRoles) {
+			t.Fatalf("second step message count: got %d, want %d", len(params.Messages), len(wantRoles))
+		}
+		for i, want := range wantRoles {
+			if params.Messages[i].Role != want {
+				t.Fatalf("second step message %d role: got %q, want %q", i, params.Messages[i].Role, want)
+			}
+		}
+		return &sdk.GenerateResult{Text: "ok", FinishReason: sdk.FinishReasonStop}, nil
+	}}
+
+	_, err := sdk.GenerateTextResult(context.Background(),
+		sdk.WithModel(mockModel(mp)),
+		sdk.WithMessages([]sdk.Message{
+			sdk.DeveloperMessage("application policy"),
+			sdk.UserMessage("go"),
+		}),
+		sdk.WithTools([]sdk.Tool{{
+			Name:       "fetch",
+			Parameters: &jsonschema.Schema{Type: "object"},
+			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				return "data", nil
+			},
+		}}),
+		sdk.WithMaxSteps(5),
+	)
+	if err != nil {
+		t.Fatalf("GenerateTextResult: %v", err)
+	}
+}
+
 // ---------- unit tests: approval flow ----------
 
 func TestClient_GenerateTextResult_ApprovalApproved(t *testing.T) {

--- a/sdk/generate.go
+++ b/sdk/generate.go
@@ -28,7 +28,10 @@ type ResponseFormat struct {
 }
 
 type GenerateParams struct {
-	Model    *Model    `json:"model,omitempty"`
+	Model *Model `json:"model,omitempty"`
+	// System is the stable root instruction placed before the conversation.
+	// Use SystemMessage when an instruction belongs at a specific point in the
+	// message timeline.
 	System   string    `json:"system,omitempty"`
 	Messages []Message `json:"messages,omitempty"`
 

--- a/sdk/message.go
+++ b/sdk/message.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -12,7 +13,32 @@ const (
 	MessageRoleAssistant MessageRole = "assistant"
 	MessageRoleSystem    MessageRole = "system"
 	MessageRoleTool      MessageRole = "tool"
+	MessageRoleDeveloper MessageRole = "developer"
 )
+
+var (
+	ErrInvalidMessageRole            = errors.New("invalid message role")
+	ErrInvalidInstructionContent     = errors.New("system and developer messages only support text content")
+	ErrInstructionInsideToolExchange = errors.New("system and developer messages cannot interrupt a tool exchange")
+)
+
+// Valid reports whether the role is one of the SDK's supported semantic roles.
+func (r MessageRole) Valid() bool {
+	switch r {
+	case MessageRoleUser, MessageRoleAssistant, MessageRoleSystem, MessageRoleTool, MessageRoleDeveloper:
+		return true
+	default:
+		return false
+	}
+}
+
+// MessageRoleCapabilities describes which instruction roles a provider can
+// serialize without fallback. Providers that do not support a capability map
+// the corresponding instruction to a user message at the wire boundary.
+type MessageRoleCapabilities struct {
+	Developer             bool
+	MidConversationSystem bool
+}
 
 type MessagePartType string
 
@@ -123,6 +149,11 @@ func SystemMessage(text string) Message {
 	return Message{Role: MessageRoleSystem, Content: []MessagePart{TextPart{Text: text}}}
 }
 
+// DeveloperMessage creates a developer message with a single text part.
+func DeveloperMessage(text string) Message {
+	return Message{Role: MessageRoleDeveloper, Content: []MessagePart{TextPart{Text: text}}}
+}
+
 // AssistantMessage creates an assistant message with a single text part.
 func AssistantMessage(text string) Message {
 	return Message{Role: MessageRoleAssistant, Content: []MessagePart{TextPart{Text: text}}}
@@ -140,6 +171,10 @@ func ToolMessage(results ...ToolResultPart) Message {
 // --- JSON ---
 
 func (m Message) MarshalJSON() ([]byte, error) {
+	if !m.Role.Valid() {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidMessageRole, m.Role)
+	}
+
 	// Single TextPart with no metadata and no cache control → emit content as a plain string.
 	var content any
 	if len(m.Content) == 1 {
@@ -179,6 +214,9 @@ func (m *Message) UnmarshalJSON(data []byte) error {
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
+	}
+	if !raw.Role.Valid() {
+		return fmt.Errorf("%w: %q", ErrInvalidMessageRole, raw.Role)
 	}
 	m.Role = raw.Role
 	m.Usage = raw.Usage

--- a/sdk/message_test.go
+++ b/sdk/message_test.go
@@ -1,0 +1,66 @@
+package sdk_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+func TestDeveloperMessageJSONRoundTrip(t *testing.T) {
+	message := sdk.DeveloperMessage("Follow the application policy.")
+	if message.Role != sdk.MessageRoleDeveloper {
+		t.Fatalf("role: got %q", message.Role)
+	}
+
+	data, err := json.Marshal(message)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(data) != `{"role":"developer","content":"Follow the application policy."}` {
+		t.Fatalf("json: got %s", data)
+	}
+
+	var decoded sdk.Message
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded.Role != sdk.MessageRoleDeveloper {
+		t.Fatalf("decoded role: got %q", decoded.Role)
+	}
+}
+
+func TestMessageJSONRejectsUnknownRole(t *testing.T) {
+	_, err := json.Marshal(sdk.Message{
+		Role:    sdk.MessageRole("operator"),
+		Content: []sdk.MessagePart{sdk.TextPart{Text: "policy"}},
+	})
+	if !errors.Is(err, sdk.ErrInvalidMessageRole) {
+		t.Fatalf("Marshal error: got %v, want ErrInvalidMessageRole", err)
+	}
+
+	var message sdk.Message
+	err = json.Unmarshal([]byte(`{"role":"operator","content":"policy"}`), &message)
+	if !errors.Is(err, sdk.ErrInvalidMessageRole) {
+		t.Fatalf("Unmarshal error: got %v, want ErrInvalidMessageRole", err)
+	}
+}
+
+func TestMessageRoleValid(t *testing.T) {
+	valid := []sdk.MessageRole{
+		sdk.MessageRoleUser,
+		sdk.MessageRoleAssistant,
+		sdk.MessageRoleSystem,
+		sdk.MessageRoleTool,
+		sdk.MessageRoleDeveloper,
+	}
+	for _, role := range valid {
+		if !role.Valid() {
+			t.Errorf("role %q should be valid", role)
+		}
+	}
+	if sdk.MessageRole("operator").Valid() {
+		t.Fatal("unknown role should be invalid")
+	}
+}

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -31,6 +31,9 @@ func WithMessages(messages []Message) GenerateOption {
 	return func(c *generateConfig) { c.Params.Messages = messages }
 }
 
+// WithSystem sets the stable root instruction placed before the conversation.
+// Use SystemMessage inside WithMessages for an instruction at a specific point
+// in the message timeline.
 func WithSystem(text string) GenerateOption {
 	return func(c *generateConfig) { c.Params.System = text }
 }

--- a/skill/reference.md
+++ b/skill/reference.md
@@ -103,7 +103,13 @@ const (
     MessageRoleAssistant MessageRole = "assistant"
     MessageRoleSystem    MessageRole = "system"
     MessageRoleTool      MessageRole = "tool"
+    MessageRoleDeveloper MessageRole = "developer"
 )
+
+type MessageRoleCapabilities struct {
+    Developer             bool
+    MidConversationSystem bool
+}
 
 type MessagePartType string
 
@@ -160,6 +166,7 @@ type Message struct {
 
 func UserMessage(text string, extra ...MessagePart) Message
 func SystemMessage(text string) Message
+func DeveloperMessage(text string) Message
 func AssistantMessage(text string) Message
 func ToolMessage(results ...ToolResultPart) Message
 ```
@@ -168,6 +175,10 @@ Notes:
 
 - `UserMessage` accepts a text string plus optional extra parts such as `ImagePart`.
 - `Message` supports JSON marshal and unmarshal with type discrimination.
+- `GenerateParams.System` is the stable root instruction; use `SystemMessage`
+  for an instruction at a specific point in the message timeline.
+- Unsupported developer messages fall back to user messages. Unsupported
+  mid-conversation system messages fall back to XML-escaped `<system>` user messages.
 
 ### Generation
 
@@ -731,6 +742,7 @@ type Option func(*Provider)
 func WithAPIKey(apiKey string) Option
 func WithBaseURL(baseURL string) Option
 func WithHTTPClient(client *http.Client) Option
+func WithMessageRoleCapabilities(capabilities sdk.MessageRoleCapabilities) Option
 func WithDeepSeekChatCompletionsCompat() Option
 func New(options ...Option) *Provider
 
@@ -747,6 +759,8 @@ Default option values:
 
 - `WithBaseURL`: `https://api.openai.com/v1`
 - `WithHTTPClient`: `&http.Client{}`
+- `WithMessageRoleCapabilities`: developer and mid-conversation system are
+  enabled for OpenAI by default; override for less-capable compatible endpoints.
 - `WithDeepSeekChatCompletionsCompat`: disabled. When enabled, `WithReasoningEffort("none")` sends `thinking:{type:"disabled"}` and omits `reasoning_effort`.
 
 Discovery endpoints:
@@ -791,6 +805,8 @@ Discovery endpoints:
 
 Responses-specific behavior:
 
+- `GenerateParams.System` maps to top-level `instructions`
+- system and developer message roles are preserved natively
 - assistant reasoning maps to `GenerateResult.Reasoning`
 - URL citation annotations map to `GenerateResult.Sources`
 - function-call outputs map to tool-call and tool-result structures
@@ -873,6 +889,7 @@ func WithBaseURL(baseURL string) Option
 func WithHTTPClient(client *http.Client) Option
 func WithHeaders(headers map[string]string) Option
 func WithThinking(cfg ThinkingConfig) Option
+func WithMidConversationSystemMessages(enabled bool) Option
 func New(options ...Option) *Provider
 
 func (p *Provider) Name() string
@@ -889,6 +906,8 @@ Default option values:
 - `WithBaseURL`: `https://api.anthropic.com/v1`
 - default API version header: `2023-06-01`
 - `WithHTTPClient`: `&http.Client{}`
+- `WithMidConversationSystemMessages`: disabled; enable only for models that
+  document native interleaved system-message support.
 
 Thinking config notes:
 


### PR DESCRIPTION
## Summary

- add `developer` as a first-class SDK message role with constructor and JSON validation
- distinguish stable root instructions from system messages placed in the message timeline
- add a shared compatibility layer for provider-aware role fallback, XML-safe system wrapping, and tool-exchange adjacency validation
- preserve native system/developer roles in OpenAI Responses and OpenAI Chat Completions
- add conservative fallbacks for Anthropic Messages, Gemini, Codex, and GitHub Copilot, with capability overrides where the endpoint contract can vary
- update API/provider references for the new role and fallback behavior

## Why

Runtime changes and other application instructions may occur after a conversation has started. Previously, some providers hoisted, dropped, or silently ignored these system messages, and the SDK had no semantic `developer` role. This made message ordering provider-dependent and could produce invalid requests when an instruction interrupted a tool-call/result exchange.

## Developer impact

Callers can now use `sdk.DeveloperMessage(...)` and place `sdk.SystemMessage(...)` at the intended point in history. Providers serialize native roles when supported and otherwise apply deterministic user-role fallbacks without mutating caller messages.

## Validation

- `go test -short -count=1 ./...`
- `mise run test-race`
- `mise run lint`
- `mise run build`
- `mise run vet`
- `git diff --check`