### PR TITLE
fix(openai): rewrite Kimi MFJS schema normalization, require explicit compat opt-in

### DIFF
--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -36,21 +36,6 @@ const (
 	chatCompletionsCompatKimi     chatCompletionsCompat = "kimi"
 )
 
-// moonshotBaseURLHosts are substrings of Moonshot/Kimi's API base URLs. Used
-// to auto-detect Kimi compat when the caller configures WithBaseURL directly
-// without also calling WithKimiChatCompletionsCompat.
-var moonshotBaseURLHosts = []string{"api.moonshot.cn", "api.moonshot.ai"}
-
-func isMoonshotBaseURL(baseURL string) bool {
-	lower := strings.ToLower(baseURL)
-	for _, host := range moonshotBaseURLHosts {
-		if strings.Contains(lower, host) {
-			return true
-		}
-	}
-	return false
-}
-
 func WithAPIKey(apiKey string) Option {
 	return func(p *Provider) {
 		p.apiKey = apiKey
@@ -134,11 +119,6 @@ func New(options ...Option) *Provider {
 	}
 	for _, option := range options {
 		option(provider)
-	}
-	// Fall back to Kimi compat when the base URL is unambiguously Moonshot's,
-	// unless the caller already picked a compat mode explicitly.
-	if provider.compat == "" && isMoonshotBaseURL(provider.baseURL) {
-		provider.compat = chatCompletionsCompatKimi
 	}
 	return provider
 }
@@ -293,7 +273,9 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*chatRequest, error
 			JSONSchema: params.ResponseFormat.JSONSchema,
 		}
 	}
-	p.applyChatCompletionsCompat(req)
+	if err := p.applyChatCompletionsCompat(req); err != nil {
+		return nil, err
+	}
 	return req, nil
 }
 
@@ -305,15 +287,15 @@ func normalizeReasoningEffort(effort *string) *string {
 	return &normalized
 }
 
-func (p *Provider) applyChatCompletionsCompat(req *chatRequest) {
+func (p *Provider) applyChatCompletionsCompat(req *chatRequest) error {
 	switch p.compat {
 	case chatCompletionsCompatDeepSeek:
 		if req.ReasoningEffort == nil {
-			return
+			return nil
 		}
 		effort := strings.TrimSpace(*req.ReasoningEffort)
 		if effort == "" {
-			return
+			return nil
 		}
 		switch strings.ToLower(effort) {
 		case "none", "disable", "disabled":
@@ -326,7 +308,7 @@ func (p *Provider) applyChatCompletionsCompat(req *chatRequest) {
 		// reasoning_split is set.
 		req.ReasoningSplit = true
 		if req.ReasoningEffort == nil {
-			return
+			return nil
 		}
 		effort := strings.ToLower(strings.TrimSpace(*req.ReasoningEffort))
 		req.ReasoningEffort = nil
@@ -340,9 +322,14 @@ func (p *Provider) applyChatCompletionsCompat(req *chatRequest) {
 		}
 	case chatCompletionsCompatKimi:
 		for i := range req.Tools {
-			req.Tools[i].Function.Parameters = sanitizeSchemaForKimi(req.Tools[i].Function.Parameters)
+			parameters, err := normalizeSchemaForKimi(req.Tools[i].Function.Parameters)
+			if err != nil {
+				return fmt.Errorf("kimi tool %q schema: %w", req.Tools[i].Function.Name, err)
+			}
+			req.Tools[i].Function.Parameters = parameters
 		}
 	}
+	return nil
 }
 
 func convertTools(tools []sdk.Tool) []chatTool {
@@ -358,99 +345,6 @@ func convertTools(tools []sdk.Tool) []chatTool {
 		})
 	}
 	return out
-}
-
-// sanitizeSchemaForKimi rewrites a tool parameters schema so it satisfies
-// Moonshot/Kimi's "Moonshot flavored JSON Schema" constraint: whenever a
-// schema object uses anyOf, "type" must be declared inside each anyOf branch
-// rather than on the parent schema. Standard JSON Schema (and this SDK's
-// schema inference) commonly puts "type" on the parent, so Kimi rejects such
-// tool definitions with a 400 unless we push "type" down into each branch.
-//
-// v is whatever was set on sdk.Tool.Parameters: typically *jsonschema.Schema
-// or map[string]any (see sdk.resolveSchema). We operate on the generic
-// map[string]any form so this works regardless of which concrete type was
-// supplied, and re-marshal *jsonschema.Schema values through JSON to get
-// there.
-func sanitizeSchemaForKimi(v any) any {
-	m, ok := asSchemaMap(v)
-	if !ok {
-		return v
-	}
-	sanitizeSchemaMapForKimi(m)
-	return m
-}
-
-// asSchemaMap converts v into a map[string]any JSON Schema representation,
-// or returns ok=false if v is nil or not schema-shaped.
-func asSchemaMap(v any) (map[string]any, bool) {
-	if v == nil {
-		return nil, false
-	}
-	if m, ok := v.(map[string]any); ok {
-		return m, true
-	}
-	data, err := json.Marshal(v)
-	if err != nil {
-		return nil, false
-	}
-	var m map[string]any
-	if err := json.Unmarshal(data, &m); err != nil {
-		return nil, false
-	}
-	return m, true
-}
-
-// sanitizeSchemaMapForKimi walks a JSON Schema (as a decoded map) in place,
-// pushing "type" from a schema object down into each of its "anyOf" branches
-// when needed, and recursing into every nested subschema location.
-func sanitizeSchemaMapForKimi(schema map[string]any) {
-	if schema == nil {
-		return
-	}
-
-	if anyOf, ok := schema["anyOf"].([]any); ok {
-		parentType, hasParentType := schema["type"]
-		for _, branch := range anyOf {
-			branchMap, ok := branch.(map[string]any)
-			if !ok {
-				continue
-			}
-			if _, branchHasType := branchMap["type"]; !branchHasType && hasParentType {
-				branchMap["type"] = parentType
-			}
-			sanitizeSchemaMapForKimi(branchMap)
-		}
-		if hasParentType {
-			delete(schema, "type")
-		}
-	}
-
-	for _, key := range []string{"oneOf", "allOf"} {
-		if list, ok := schema[key].([]any); ok {
-			for _, item := range list {
-				if itemMap, ok := item.(map[string]any); ok {
-					sanitizeSchemaMapForKimi(itemMap)
-				}
-			}
-		}
-	}
-
-	if props, ok := schema["properties"].(map[string]any); ok {
-		for _, prop := range props {
-			if propMap, ok := prop.(map[string]any); ok {
-				sanitizeSchemaMapForKimi(propMap)
-			}
-		}
-	}
-
-	if items, ok := schema["items"].(map[string]any); ok {
-		sanitizeSchemaMapForKimi(items)
-	}
-
-	if not, ok := schema["not"].(map[string]any); ok {
-		sanitizeSchemaMapForKimi(not)
-	}
 }
 
 // ---------- message conversion ----------

--- a/provider/openai/completions/completions_test.go
+++ b/provider/openai/completions/completions_test.go
@@ -1899,10 +1899,51 @@ func kimiAnyOfTool() sdk.Tool {
 	}
 }
 
-func decodeToolParameters(t *testing.T, r *http.Request) map[string]any {
+func kimiMemohAttachmentTool() sdk.Tool {
+	return sdk.Tool{
+		Name:        "send_message",
+		Description: "Send attachments",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"attachments": map[string]any{
+					"type": "array",
+					"items": map[string]any{
+						"anyOf": []any{
+							map[string]any{"type": "string"},
+							map[string]any{
+								"type":                 "object",
+								"additionalProperties": false,
+								"anyOf": []any{
+									map[string]any{"required": []string{"path"}},
+									map[string]any{"required": []string{"url"}},
+									map[string]any{"required": []string{"base64"}},
+									map[string]any{"required": []string{"content_hash"}},
+									map[string]any{"required": []string{"platform_key"}},
+								},
+								"properties": map[string]any{
+									"path":         map[string]any{"type": "string"},
+									"url":          map[string]any{"type": "string"},
+									"base64":       map[string]any{"type": "string"},
+									"content_hash": map[string]any{"type": "string"},
+									"platform_key": map[string]any{"type": "string"},
+									"metadata":     map[string]any{"type": "object"},
+								},
+							},
+						},
+					},
+				},
+			},
+			"required": []string{"attachments"},
+		},
+	}
+}
+
+func decodeToolParameters(t *testing.T, r *http.Request) (map[string]any, bool) {
 	t.Helper()
 	var body struct {
-		Tools []struct {
+		Stream bool `json:"stream"`
+		Tools  []struct {
 			Function struct {
 				Parameters map[string]any `json:"parameters"`
 			} `json:"function"`
@@ -1914,7 +1955,7 @@ func decodeToolParameters(t *testing.T, r *http.Request) map[string]any {
 	if len(body.Tools) != 1 {
 		t.Fatalf("expected 1 tool, got %d", len(body.Tools))
 	}
-	return body.Tools[0].Function.Parameters
+	return body.Tools[0].Function.Parameters, body.Stream
 }
 
 // assertKimiSanitizedAnyOf checks that the "attachments.items" schema no
@@ -1941,6 +1982,52 @@ func assertKimiSanitizedAnyOf(t *testing.T, params map[string]any) {
 	}
 }
 
+func assertKimiNormalizedMemohAttachments(t *testing.T, params map[string]any) {
+	t.Helper()
+	items := schemaPath(t, params, "properties", "attachments", "items")
+	outerAnyOf, ok := items["anyOf"].([]any)
+	if !ok || len(outerAnyOf) != 2 {
+		t.Fatalf("attachments.items.anyOf = %#v, want two branches", items["anyOf"])
+	}
+	objectBranch, ok := outerAnyOf[1].(map[string]any)
+	if !ok {
+		t.Fatalf("attachments object branch = %T, want map[string]any", outerAnyOf[1])
+	}
+	for _, key := range []string{"type", "properties", "required", "additionalProperties"} {
+		if _, exists := objectBranch[key]; exists {
+			t.Fatalf("attachments object parent still contains %q: %#v", key, objectBranch)
+		}
+	}
+	innerAnyOf, ok := objectBranch["anyOf"].([]any)
+	if !ok || len(innerAnyOf) != 5 {
+		t.Fatalf("attachments object anyOf = %#v, want five branches", objectBranch["anyOf"])
+	}
+	for index, rawBranch := range innerAnyOf {
+		branch, ok := rawBranch.(map[string]any)
+		if !ok {
+			t.Fatalf("attachments object anyOf[%d] = %T, want map[string]any", index, rawBranch)
+		}
+		if branch["type"] != "object" || branch["additionalProperties"] != false {
+			t.Fatalf("attachments object anyOf[%d] lacks object constraints: %#v", index, branch)
+		}
+		properties, ok := branch["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("attachments object anyOf[%d].properties = %T", index, branch["properties"])
+		}
+		required, ok := branch["required"].([]any)
+		if !ok || len(required) != 1 {
+			t.Fatalf("attachments object anyOf[%d].required = %#v", index, branch["required"])
+		}
+		name, ok := required[0].(string)
+		if !ok {
+			t.Fatalf("attachments object anyOf[%d].required[0] = %#v", index, required[0])
+		}
+		if _, exists := properties[name]; !exists {
+			t.Fatalf("attachments object anyOf[%d] requires undefined property %q", index, name)
+		}
+	}
+}
+
 func schemaPath(t *testing.T, m map[string]any, path ...string) map[string]any {
 	t.Helper()
 	cur := m
@@ -1957,7 +2044,13 @@ func schemaPath(t *testing.T, m map[string]any, path ...string) map[string]any {
 func newEchoToolsServer(t *testing.T, capture *map[string]any) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		*capture = decodeToolParameters(t, r)
+		var stream bool
+		*capture, stream = decodeToolParameters(t, r)
+		if stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: [DONE]\n\n")
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"id":    "chatcmpl-kimi",
@@ -1993,6 +2086,53 @@ func TestDoGenerate_KimiCompatSanitizesAnyOfSchema(t *testing.T) {
 	assertKimiSanitizedAnyOf(t, params)
 }
 
+func TestDoGenerate_KimiCompatNormalizesMemohAttachmentSchema(t *testing.T) {
+	var params map[string]any
+	srv := newEchoToolsServer(t, &params)
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithKimiChatCompletionsCompat(),
+	)
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    &sdk.Model{ID: "kimi-k2"},
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+		Tools:    []sdk.Tool{kimiMemohAttachmentTool()},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	assertKimiNormalizedMemohAttachments(t, params)
+}
+
+func TestDoStream_KimiCompatNormalizesMemohAttachmentSchema(t *testing.T) {
+	var params map[string]any
+	srv := newEchoToolsServer(t, &params)
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL(srv.URL),
+		completions.WithKimiChatCompletionsCompat(),
+	)
+	result, err := p.DoStream(context.Background(), sdk.GenerateParams{
+		Model:    &sdk.Model{ID: "kimi-k2"},
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+		Tools:    []sdk.Tool{kimiMemohAttachmentTool()},
+	})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+	for part := range result.Stream {
+		if errorPart, ok := part.(*sdk.ErrorPart); ok {
+			t.Fatalf("stream error: %v", errorPart.Error)
+		}
+	}
+	assertKimiNormalizedMemohAttachments(t, params)
+}
+
 // redirectingTransport rewrites every outgoing request's scheme/host to
 // point at a local test server while leaving the rest of the request (path,
 // body, etc.) untouched. This lets a test configure WithBaseURL with a real
@@ -2010,54 +2150,36 @@ func (rt *redirectingTransport) RoundTrip(req *http.Request) (*http.Response, er
 	return http.DefaultTransport.RoundTrip(req)
 }
 
-// TestKimiCompatAutoDetectedFromMoonshotBaseURL verifies the fallback: a base
-// URL that looks like Moonshot's (api.moonshot.cn / api.moonshot.ai) enables
-// Kimi compat -- and therefore anyOf schema sanitization -- even without the
-// caller explicitly calling WithKimiChatCompletionsCompat. Other base URLs
-// must leave the schema untouched.
-func TestKimiCompatAutoDetectedFromMoonshotBaseURL(t *testing.T) {
-	cases := []struct {
-		name    string
-		baseURL string
-		want    bool
-	}{
-		{"moonshot cn", "https://api.moonshot.cn/v1", true},
-		{"moonshot ai", "https://api.moonshot.ai/v1", true},
-		{"moonshot cn uppercase host", "https://API.MOONSHOT.CN/v1", true},
-		{"openai", "https://api.openai.com/v1", false},
-		{"deepseek", "https://api.deepseek.com", false},
+// TestKimiCompatRequiresExplicitOption verifies that a Moonshot-looking base
+// URL alone does not select a wire dialect. Callers must opt into Kimi/MFJS
+// behavior explicitly.
+func TestKimiCompatRequiresExplicitOption(t *testing.T) {
+	var params map[string]any
+	srv := newEchoToolsServer(t, &params)
+	defer srv.Close()
+
+	target, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var params map[string]any
-			srv := newEchoToolsServer(t, &params)
-			defer srv.Close()
 
-			target, err := url.Parse(srv.URL)
-			if err != nil {
-				t.Fatalf("parse test server URL: %v", err)
-			}
+	p := completions.New(
+		completions.WithAPIKey("k"),
+		completions.WithBaseURL("https://api.moonshot.cn/v1"),
+		completions.WithHTTPClient(&http.Client{Transport: &redirectingTransport{targetURL: target}}),
+	)
+	_, err = p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    &sdk.Model{ID: "kimi-k2"},
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+		Tools:    []sdk.Tool{kimiAnyOfTool()},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
 
-			p := completions.New(
-				completions.WithAPIKey("k"),
-				completions.WithBaseURL(tc.baseURL),
-				completions.WithHTTPClient(&http.Client{Transport: &redirectingTransport{targetURL: target}}),
-			)
-			_, err = p.DoGenerate(context.Background(), sdk.GenerateParams{
-				Model:    &sdk.Model{ID: "kimi-k2"},
-				Messages: []sdk.Message{sdk.UserMessage("hi")},
-				Tools:    []sdk.Tool{kimiAnyOfTool()},
-			})
-			if err != nil {
-				t.Fatalf("DoGenerate: %v", err)
-			}
-
-			_, hasParentType := schemaPath(t, params, "properties", "attachments", "items")["type"]
-			gotSanitized := !hasParentType
-			if gotSanitized != tc.want {
-				t.Fatalf("baseURL %q: sanitized=%v, want %v", tc.baseURL, gotSanitized, tc.want)
-			}
-		})
+	items := schemaPath(t, params, "properties", "attachments", "items")
+	if items["type"] != "object" {
+		t.Fatalf("Moonshot base URL unexpectedly enabled Kimi compat: %#v", items)
 	}
 }
 

--- a/provider/openai/completions/kimi_schema.go
+++ b/provider/openai/completions/kimi_schema.go
@@ -1,0 +1,371 @@
+package completions
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// normalizeSchemaForKimi converts the supported subset of standard JSON
+// Schema into Moonshot-flavored JSON Schema (MFJS). It always works on a deep
+// copy so a provider request cannot mutate the caller's tool definition.
+func normalizeSchemaForKimi(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if schema == nil {
+		return nil, nil
+	}
+	if err := normalizeKimiSchemaMap(schema, "$"); err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
+func normalizeKimiSchemaMap(schema map[string]any, path string) error {
+	if schema == nil {
+		return nil
+	}
+
+	if rawAnyOf, exists := schema["anyOf"]; exists {
+		anyOf, ok := rawAnyOf.([]any)
+		if !ok {
+			return fmt.Errorf("%s.anyOf: expected an array", path)
+		}
+		if err := normalizeKimiAnyOf(schema, anyOf, path); err != nil {
+			return err
+		}
+		for index, rawBranch := range anyOf {
+			branch, ok := rawBranch.(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s.anyOf[%d]: boolean schemas are not supported", path, index)
+			}
+			if err := normalizeKimiSchemaMap(branch, fmt.Sprintf("%s.anyOf[%d]", path, index)); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, key := range []string{"oneOf", "allOf"} {
+		rawList, exists := schema[key]
+		if !exists {
+			continue
+		}
+		list, ok := rawList.([]any)
+		if !ok {
+			return fmt.Errorf("%s.%s: expected an array", path, key)
+		}
+		for index, rawItem := range list {
+			item, ok := rawItem.(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s.%s[%d]: boolean schemas are not supported", path, key, index)
+			}
+			if err := normalizeKimiSchemaMap(item, fmt.Sprintf("%s.%s[%d]", path, key, index)); err != nil {
+				return err
+			}
+		}
+	}
+
+	if rawNot, exists := schema["not"]; exists {
+		not, ok := rawNot.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s.not: boolean schemas are not supported", path)
+		}
+		if err := normalizeKimiSchemaMap(not, path+".not"); err != nil {
+			return err
+		}
+	}
+
+	if rawProperties, exists := schema["properties"]; exists {
+		properties, ok := rawProperties.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s.properties: expected an object", path)
+		}
+		for name, rawProperty := range properties {
+			property, ok := rawProperty.(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s.properties.%s: boolean schemas are not supported", path, name)
+			}
+			if err := normalizeKimiSchemaMap(property, path+".properties."+name); err != nil {
+				return err
+			}
+		}
+	}
+
+	if rawItems, exists := schema["items"]; exists {
+		switch items := rawItems.(type) {
+		case map[string]any:
+			if err := normalizeKimiSchemaMap(items, path+".items"); err != nil {
+				return err
+			}
+		case []any:
+			for index, rawItem := range items {
+				item, ok := rawItem.(map[string]any)
+				if !ok {
+					return fmt.Errorf("%s.items[%d]: boolean schemas are not supported", path, index)
+				}
+				if err := normalizeKimiSchemaMap(item, fmt.Sprintf("%s.items[%d]", path, index)); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("%s.items: expected an object or array", path)
+		}
+	}
+
+	if rawAdditional, exists := schema["additionalProperties"]; exists {
+		if additional, ok := rawAdditional.(map[string]any); ok {
+			if err := normalizeKimiSchemaMap(additional, path+".additionalProperties"); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, key := range []string{"$defs", "definitions"} {
+		rawDefinitions, exists := schema[key]
+		if !exists {
+			continue
+		}
+		definitions, ok := rawDefinitions.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s.%s: expected an object", path, key)
+		}
+		for name, rawDefinition := range definitions {
+			definition, ok := rawDefinition.(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s.%s.%s: boolean schemas are not supported", path, key, name)
+			}
+			if err := normalizeKimiSchemaMap(definition, path+"."+key+"."+name); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func normalizeKimiAnyOf(schema map[string]any, anyOf []any, path string) error {
+	rawParentType, hasParentType := schema["type"]
+	if !hasParentType {
+		return nil
+	}
+	parentType, ok := rawParentType.(string)
+	if !ok || parentType == "" {
+		return fmt.Errorf("%s.type: expected a single non-empty type", path)
+	}
+
+	hasObjectBundle := hasAnySchemaKeyword(schema, "properties", "required", "additionalProperties")
+	if parentType == "object" && hasObjectBundle {
+		return distributeKimiObjectBundle(schema, anyOf, path)
+	}
+	if hasObjectBundle {
+		return fmt.Errorf("%s: object keywords cannot be combined with type %q around anyOf", path, parentType)
+	}
+
+	for index, rawBranch := range anyOf {
+		branch, ok := rawBranch.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s.anyOf[%d]: boolean schemas are not supported", path, index)
+		}
+		if rawBranchType, exists := branch["type"]; exists {
+			branchType, ok := rawBranchType.(string)
+			if !ok || branchType != parentType {
+				return fmt.Errorf(
+					"%s.anyOf[%d].type: %v conflicts with parent type %q",
+					path,
+					index,
+					rawBranchType,
+					parentType,
+				)
+			}
+		} else {
+			branch["type"] = parentType
+		}
+	}
+	delete(schema, "type")
+	return nil
+}
+
+func distributeKimiObjectBundle(schema map[string]any, anyOf []any, path string) error {
+	for key := range schema {
+		if isKimiObjectBundleKeyword(key) || isSchemaAnnotationKeyword(key) {
+			continue
+		}
+		return fmt.Errorf("%s.%s: cannot safely distribute this keyword into anyOf", path, key)
+	}
+
+	rawProperties, exists := schema["properties"]
+	if !exists {
+		return fmt.Errorf("%s.properties: required when object constraints surround anyOf", path)
+	}
+	properties, ok := rawProperties.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s.properties: expected an object", path)
+	}
+
+	parentRequired, err := schemaStringArray(schema["required"], path+".required")
+	if err != nil {
+		return err
+	}
+	if err := validateRequiredProperties(parentRequired, properties, path+".required"); err != nil {
+		return err
+	}
+
+	rawAdditional, hasAdditional := schema["additionalProperties"]
+	if hasAdditional {
+		if _, ok := rawAdditional.(bool); !ok {
+			return fmt.Errorf("%s.additionalProperties: schema-valued constraints cannot be safely distributed", path)
+		}
+	}
+
+	for index, rawBranch := range anyOf {
+		branchPath := fmt.Sprintf("%s.anyOf[%d]", path, index)
+		branch, ok := rawBranch.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s: boolean schemas are not supported", branchPath)
+		}
+		for key := range branch {
+			if key == "type" || key == "required" || isSchemaAnnotationKeyword(key) {
+				continue
+			}
+			return fmt.Errorf("%s.%s: cannot safely merge this keyword with parent object constraints", branchPath, key)
+		}
+		if rawBranchType, exists := branch["type"]; exists {
+			branchType, ok := rawBranchType.(string)
+			if !ok || branchType != "object" {
+				return fmt.Errorf("%s.type: %v conflicts with parent type %q", branchPath, rawBranchType, "object")
+			}
+		}
+		branchRequired, err := schemaStringArray(branch["required"], branchPath+".required")
+		if err != nil {
+			return err
+		}
+		required := mergeSchemaStrings(parentRequired, branchRequired)
+		if err := validateRequiredProperties(required, properties, branchPath+".required"); err != nil {
+			return err
+		}
+
+		branch["type"] = "object"
+		branch["properties"] = cloneJSONValue(properties)
+		if hasAdditional {
+			branch["additionalProperties"] = rawAdditional
+		}
+		if len(required) > 0 {
+			requiredValues := make([]any, len(required))
+			for index, name := range required {
+				requiredValues[index] = name
+			}
+			branch["required"] = requiredValues
+		} else {
+			delete(branch, "required")
+		}
+	}
+
+	delete(schema, "type")
+	delete(schema, "properties")
+	delete(schema, "required")
+	delete(schema, "additionalProperties")
+	return nil
+}
+
+func hasAnySchemaKeyword(schema map[string]any, keys ...string) bool {
+	for _, key := range keys {
+		if _, exists := schema[key]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+func isKimiObjectBundleKeyword(key string) bool {
+	switch key {
+	case "type", "properties", "required", "additionalProperties", "anyOf":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSchemaAnnotationKeyword(key string) bool {
+	switch key {
+	case "$comment", "title", "description", "default", "examples", "deprecated", "readOnly", "writeOnly":
+		return true
+	default:
+		return false
+	}
+}
+
+func schemaStringArray(value any, path string) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch values := value.(type) {
+	case []any:
+		result := make([]string, 0, len(values))
+		for index, rawValue := range values {
+			item, ok := rawValue.(string)
+			if !ok || item == "" {
+				return nil, fmt.Errorf("%s[%d]: expected a non-empty string", path, index)
+			}
+			result = append(result, item)
+		}
+		return result, nil
+	case []string:
+		return append([]string(nil), values...), nil
+	default:
+		return nil, fmt.Errorf("%s: expected an array of strings", path)
+	}
+}
+
+func mergeSchemaStrings(left, right []string) []string {
+	seen := make(map[string]struct{}, len(left)+len(right))
+	result := make([]string, 0, len(left)+len(right))
+	for _, values := range [][]string{left, right} {
+		for _, value := range values {
+			if _, exists := seen[value]; exists {
+				continue
+			}
+			seen[value] = struct{}{}
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func validateRequiredProperties(required []string, properties map[string]any, path string) error {
+	for _, name := range required {
+		if _, exists := properties[name]; !exists {
+			return fmt.Errorf("%s: required property %q is not defined in properties", path, name)
+		}
+	}
+	return nil
+}
+
+func cloneJSONValue(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(value))
+		for key, item := range value {
+			cloned[key] = cloneJSONValue(item)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(value))
+		for index, item := range value {
+			cloned[index] = cloneJSONValue(item)
+		}
+		return cloned
+	case []string:
+		return append([]string(nil), value...)
+	default:
+		return value
+	}
+}

--- a/provider/openai/completions/kimi_schema.go
+++ b/provider/openai/completions/kimi_schema.go
@@ -17,17 +17,23 @@ func normalizeSchemaForKimi(value any) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal: %w", err)
 	}
-	var schema map[string]any
-	if err := json.Unmarshal(data, &schema); err != nil {
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
-	if schema == nil {
+	switch schema := decoded.(type) {
+	case nil:
 		return nil, nil
+	case map[string]any:
+		if err := normalizeKimiSchemaMap(schema, "$"); err != nil {
+			return nil, err
+		}
+		return schema, nil
+	case bool:
+		return nil, fmt.Errorf("$: boolean schemas are not supported")
+	default:
+		return nil, fmt.Errorf("$: expected a schema object, got %T", decoded)
 	}
-	if err := normalizeKimiSchemaMap(schema, "$"); err != nil {
-		return nil, err
-	}
-	return schema, nil
 }
 
 func normalizeKimiSchemaMap(schema map[string]any, path string) error {
@@ -122,10 +128,14 @@ func normalizeKimiSchemaMap(schema map[string]any, path string) error {
 	}
 
 	if rawAdditional, exists := schema["additionalProperties"]; exists {
-		if additional, ok := rawAdditional.(map[string]any); ok {
+		switch additional := rawAdditional.(type) {
+		case bool:
+		case map[string]any:
 			if err := normalizeKimiSchemaMap(additional, path+".additionalProperties"); err != nil {
 				return err
 			}
+		default:
+			return fmt.Errorf("%s.additionalProperties: expected a boolean or an object", path)
 		}
 	}
 

--- a/provider/openai/completions/kimi_schema_test.go
+++ b/provider/openai/completions/kimi_schema_test.go
@@ -1,0 +1,283 @@
+package completions
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSchemaForKimiDistributesMemohAttachmentObject(t *testing.T) {
+	original := kimiMemohAttachmentSchema()
+	originalCopy := cloneJSONValue(original)
+
+	normalizedValue, err := normalizeSchemaForKimi(original)
+	if err != nil {
+		t.Fatalf("normalizeSchemaForKimi: %v", err)
+	}
+	normalized, ok := normalizedValue.(map[string]any)
+	if !ok {
+		t.Fatalf("normalized schema = %T, want map[string]any", normalizedValue)
+	}
+	if !reflect.DeepEqual(original, originalCopy) {
+		t.Fatal("normalization mutated the input schema")
+	}
+
+	objectBranch := kimiAttachmentObjectBranch(t, normalized)
+	for _, key := range []string{"type", "properties", "required", "additionalProperties"} {
+		if _, exists := objectBranch[key]; exists {
+			t.Fatalf("attachment object parent still contains %q: %#v", key, objectBranch)
+		}
+	}
+	innerAnyOf := schemaAnyOf(t, objectBranch, "attachment object")
+	if len(innerAnyOf) != 5 {
+		t.Fatalf("inner anyOf length = %d, want 5", len(innerAnyOf))
+	}
+
+	for index, rawBranch := range innerAnyOf {
+		branch, ok := rawBranch.(map[string]any)
+		if !ok {
+			t.Fatalf("inner anyOf[%d] = %T, want map[string]any", index, rawBranch)
+		}
+		if branch["type"] != "object" {
+			t.Fatalf("inner anyOf[%d].type = %#v, want object", index, branch["type"])
+		}
+		if branch["additionalProperties"] != false {
+			t.Fatalf("inner anyOf[%d].additionalProperties = %#v, want false", index, branch["additionalProperties"])
+		}
+		properties, ok := branch["properties"].(map[string]any)
+		if !ok {
+			t.Fatalf("inner anyOf[%d].properties = %T, want map[string]any", index, branch["properties"])
+		}
+		for _, name := range []string{"path", "url", "base64", "content_hash", "platform_key", "metadata"} {
+			if _, exists := properties[name]; !exists {
+				t.Fatalf("inner anyOf[%d] is missing property %q", index, name)
+			}
+		}
+		required, err := schemaStringArray(branch["required"], "required")
+		if err != nil {
+			t.Fatalf("inner anyOf[%d].required: %v", index, err)
+		}
+		if len(required) != 1 {
+			t.Fatalf("inner anyOf[%d].required = %#v, want one item", index, required)
+		}
+		if _, exists := properties[required[0]]; !exists {
+			t.Fatalf("inner anyOf[%d] requires undefined property %q", index, required[0])
+		}
+	}
+
+	normalizedAgain, err := normalizeSchemaForKimi(normalized)
+	if err != nil {
+		t.Fatalf("second normalizeSchemaForKimi: %v", err)
+	}
+	if !reflect.DeepEqual(normalized, normalizedAgain) {
+		t.Fatalf("normalization is not idempotent:\nfirst:  %#v\nsecond: %#v", normalized, normalizedAgain)
+	}
+}
+
+func TestNormalizeSchemaForKimiRejectsUnsafeObjectBranchMerge(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path": map[string]any{"type": "string"},
+		},
+		"anyOf": []any{
+			map[string]any{
+				"properties": map[string]any{
+					"url": map[string]any{"type": "string"},
+				},
+				"required": []string{"url"},
+			},
+		},
+	}
+
+	_, err := normalizeSchemaForKimi(schema)
+	if err == nil {
+		t.Fatal("expected unsafe properties merge to fail")
+	}
+	if !strings.Contains(err.Error(), "$.anyOf[0].properties") {
+		t.Fatalf("error %q does not identify the conflicting schema path", err)
+	}
+}
+
+func TestNormalizeSchemaForKimiRejectsRequiredPropertyMissingFromProperties(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"url": map[string]any{"type": "string"},
+		},
+		"anyOf": []any{
+			map[string]any{"required": []string{"path"}},
+		},
+	}
+
+	_, err := normalizeSchemaForKimi(schema)
+	if err == nil {
+		t.Fatal("expected undefined required property to fail")
+	}
+	if !strings.Contains(err.Error(), `required property "path" is not defined in properties`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNormalizeSchemaForKimiRecursesIntoCombinators(t *testing.T) {
+	nestedAnyOf := func() map[string]any {
+		return map[string]any{
+			"type": "string",
+			"anyOf": []any{
+				map[string]any{"minLength": float64(1)},
+				map[string]any{"type": "string", "maxLength": float64(8)},
+			},
+		}
+	}
+	assertNormalized := func(t *testing.T, schema map[string]any, label string) {
+		t.Helper()
+		if _, exists := schema["type"]; exists {
+			t.Fatalf("%s: parent type was not pushed into anyOf branches: %#v", label, schema)
+		}
+		anyOf := schemaAnyOf(t, schema, label)
+		for index, rawBranch := range anyOf {
+			branch, ok := rawBranch.(map[string]any)
+			if !ok {
+				t.Fatalf("%s.anyOf[%d] = %T, want map[string]any", label, index, rawBranch)
+			}
+			if branch["type"] != "string" {
+				t.Fatalf("%s.anyOf[%d].type = %#v, want string", label, index, branch["type"])
+			}
+		}
+	}
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"value": map[string]any{
+				"oneOf": []any{nestedAnyOf()},
+				"allOf": []any{nestedAnyOf()},
+				"not":   nestedAnyOf(),
+			},
+		},
+	}
+
+	normalizedValue, err := normalizeSchemaForKimi(schema)
+	if err != nil {
+		t.Fatalf("normalizeSchemaForKimi: %v", err)
+	}
+	normalized, ok := normalizedValue.(map[string]any)
+	if !ok {
+		t.Fatalf("normalized schema = %T, want map[string]any", normalizedValue)
+	}
+
+	value := schemaPathMap(t, normalized, "properties", "value")
+	for _, key := range []string{"oneOf", "allOf"} {
+		list, ok := value[key].([]any)
+		if !ok || len(list) != 1 {
+			t.Fatalf("value.%s = %#v, want one branch", key, value[key])
+		}
+		branch, ok := list[0].(map[string]any)
+		if !ok {
+			t.Fatalf("value.%s[0] = %T, want map[string]any", key, list[0])
+		}
+		assertNormalized(t, branch, "value."+key+"[0]")
+	}
+	not, ok := value["not"].(map[string]any)
+	if !ok {
+		t.Fatalf("value.not = %T, want map[string]any", value["not"])
+	}
+	assertNormalized(t, not, "value.not")
+}
+
+func TestNormalizeSchemaForKimiRejectsBooleanCombinatorBranches(t *testing.T) {
+	schema := map[string]any{
+		"oneOf": []any{true},
+	}
+
+	_, err := normalizeSchemaForKimi(schema)
+	if err == nil {
+		t.Fatal("expected boolean oneOf branch to fail")
+	}
+	if !strings.Contains(err.Error(), "$.oneOf[0]") {
+		t.Fatalf("error %q does not identify the offending schema path", err)
+	}
+}
+
+func schemaPathMap(t *testing.T, m map[string]any, path ...string) map[string]any {
+	t.Helper()
+	current := m
+	for _, key := range path {
+		next, ok := current[key].(map[string]any)
+		if !ok {
+			t.Fatalf("schema path %v: %q = %T, want map[string]any", path, key, current[key])
+		}
+		current = next
+	}
+	return current
+}
+
+func kimiMemohAttachmentSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"attachments": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"anyOf": []any{
+						map[string]any{"type": "string"},
+						map[string]any{
+							"type":                 "object",
+							"additionalProperties": false,
+							"anyOf": []any{
+								map[string]any{"required": []string{"path"}},
+								map[string]any{"required": []string{"url"}},
+								map[string]any{"required": []string{"base64"}},
+								map[string]any{"required": []string{"content_hash"}},
+								map[string]any{"required": []string{"platform_key"}},
+							},
+							"properties": map[string]any{
+								"path":         map[string]any{"type": "string"},
+								"url":          map[string]any{"type": "string"},
+								"base64":       map[string]any{"type": "string"},
+								"content_hash": map[string]any{"type": "string"},
+								"platform_key": map[string]any{"type": "string"},
+								"metadata":     map[string]any{"type": "object"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"required": []string{"attachments"},
+	}
+}
+
+func kimiAttachmentObjectBranch(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("root properties = %T, want map[string]any", schema["properties"])
+	}
+	attachments, ok := properties["attachments"].(map[string]any)
+	if !ok {
+		t.Fatalf("attachments = %T, want map[string]any", properties["attachments"])
+	}
+	items, ok := attachments["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("attachments.items = %T, want map[string]any", attachments["items"])
+	}
+	outerAnyOf := schemaAnyOf(t, items, "attachments.items")
+	if len(outerAnyOf) != 2 {
+		t.Fatalf("outer anyOf length = %d, want 2", len(outerAnyOf))
+	}
+	objectBranch, ok := outerAnyOf[1].(map[string]any)
+	if !ok {
+		t.Fatalf("outer anyOf[1] = %T, want map[string]any", outerAnyOf[1])
+	}
+	return objectBranch
+}
+
+func schemaAnyOf(t *testing.T, schema map[string]any, label string) []any {
+	t.Helper()
+	anyOf, ok := schema["anyOf"].([]any)
+	if !ok {
+		t.Fatalf("%s.anyOf = %T, want []any", label, schema["anyOf"])
+	}
+	return anyOf
+}

--- a/provider/openai/completions/kimi_schema_test.go
+++ b/provider/openai/completions/kimi_schema_test.go
@@ -199,6 +199,49 @@ func TestNormalizeSchemaForKimiRejectsBooleanCombinatorBranches(t *testing.T) {
 	}
 }
 
+func TestNormalizeSchemaForKimiRejectsNonObjectRootSchema(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   any
+		wantErr string
+	}{
+		{"boolean", true, "$: boolean schemas are not supported"},
+		{"array", []any{"a"}, "$: expected a schema object"},
+		{"string", "not a schema", "$: expected a schema object"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := normalizeSchemaForKimi(tc.value)
+			if err == nil {
+				t.Fatalf("expected %T root schema to fail", tc.value)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNormalizeSchemaForKimiRejectsInvalidAdditionalProperties(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"config": map[string]any{
+				"type":                 "object",
+				"additionalProperties": "yes",
+			},
+		},
+	}
+
+	_, err := normalizeSchemaForKimi(schema)
+	if err == nil {
+		t.Fatal("expected invalid additionalProperties to fail")
+	}
+	if !strings.Contains(err.Error(), "$.properties.config.additionalProperties") {
+		t.Fatalf("error %q does not identify the offending schema path", err)
+	}
+}
+
 func schemaPathMap(t *testing.T, m map[string]any, path ...string) map[string]any {
 	t.Helper()
 	current := m


### PR DESCRIPTION
## 问题背景

Moonshot/Kimi 要求工具参数使用「Moonshot 风味 JSON Schema(MFJS)」:schema 使用 `anyOf` 时,`type` 必须写在每个分支内部,而不能放在父级。旧的 `sanitizeSchemaForKimi` 只是把父级 `type` 下推到各分支。对于对象约束包(`properties`/`required`/`additionalProperties`)与 `anyOf` 同级的 schema(例如 memoh attachment 工具),它会把约束包孤零零留在父级——产出的仍然不是合法的 MFJS,Kimi 依旧返回 400 拒绝该工具定义。

## 改动内容

- **新增 `normalizeSchemaForKimi`**(`kimi_schema.go`):将完整的对象约束包分发进每个 `anyOf` 分支,`required` 取父级与分支的并集,并校验其属性确实定义在 `properties` 中。递归覆盖 `properties`、`items`、`additionalProperties`、`$defs`/`definitions` 以及 `oneOf`/`allOf`/`not`。始终在深拷贝上操作(不会改动调用方的工具定义),且归一化是幂等的。
- **报错取代静默产出错误 schema**:无法安全归一化的结构(布尔 schema、无法安全分发的关键字、类型冲突)会带着 schema 路径报错(如 `$.anyOf[0].properties: ...`),并从 `buildRequest` 连同工具名一起返回,而不是静默发送非法的 MFJS。
- **BREAKING:移除 Moonshot base URL 自动检测。** 不再根据 `api.moonshot.cn` / `api.moonshot.ai` 的 base URL 自动启用 Kimi 兼容模式,调用方必须显式调用 `WithKimiChatCompletionsCompat()`。

## 测试

- 单元测试:memoh attachment 约束包分发、幂等性、不安全合并拒绝、未定义 required 属性拒绝、组合子递归、布尔分支报错。
- 集成测试:`DoGenerate` 与 `DoStream` 两条路径实际发出的请求体均为归一化后的 schema(mock 服务器为此增加了 SSE 支持);`TestKimiCompatRequiresExplicitOption` 锁定「必须显式开启」的新语义。
- `go build ./...`、`go vet`、全量测试(`-count=1`)全部通过。