### PR TITLE
feat: add step commit barrier

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -356,6 +356,7 @@ All options are of type `GenerateOption` (`func(*generateConfig)`).
 | `WithMaxSteps(n int)` | `0` = single call (default), `N` = up to N calls, `-1` = unlimited |
 | `WithOnFinish(fn func(*GenerateResult))` | Called when all steps complete |
 | `WithOnStep(fn func(*StepResult) *GenerateParams)` | Called after each step; return non-nil to override next step |
+| `WithOnStepCommitted(fn func(context.Context, int, *StepResult) error)` | Synchronous commit barrier before accepting a complete step or starting the next model call |
 | `WithPrepareStep(fn func(*GenerateParams) *GenerateParams)` | Called before each step (from step 2); can modify params |
 | `WithApprovalHandler(fn func(ctx, ToolCall) (bool, error))` | Approval for tools with `RequireApproval` |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -366,6 +366,18 @@ sdk.WithOnStep(func(step *sdk.StepResult) *sdk.GenerateParams {
 }),
 ```
 
+### OnStepCommitted
+
+Use a synchronous durability barrier after a complete step is assembled and
+before the next model call begins. Returning an error stops generation and
+leaves that step out of the accumulated result:
+
+```go
+sdk.WithOnStepCommitted(func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
+    return persistStep(ctx, stepIndex, step)
+}),
+```
+
 ### PrepareStep
 
 Called before each step (starting from step 2). Allows modifying params:

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -1009,95 +1009,60 @@ func TestClient_StreamText_OnStepCallback(t *testing.T) {
 	}
 }
 
-func TestClient_GenerateTextResult_OnStepCommittedErrorStopsLoop(t *testing.T) {
-	commitErr := errors.New("checkpoint unavailable")
-	mp := &mockProvider{handler: func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
-		if call != 1 {
-			return nil, fmt.Errorf("provider called after commit failed: call %d", call)
-		}
-		return &sdk.GenerateResult{
-			FinishReason: sdk.FinishReasonToolCalls,
-			ToolCalls: []sdk.ToolCall{{
-				ToolCallID: "c1", ToolName: "noop", Input: nil,
-			}},
-		}, nil
-	}}
-
-	_, err := sdk.GenerateTextResult(context.Background(),
-		sdk.WithModel(mockModel(mp)),
-		sdk.WithMessages([]sdk.Message{sdk.UserMessage("go")}),
-		sdk.WithTools([]sdk.Tool{{
-			Name:       "noop",
-			Parameters: &jsonschema.Schema{Type: "object"},
-			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
-				return "ok", nil
-			},
-		}}),
-		sdk.WithMaxSteps(5),
-		sdk.WithOnStepCommitted(func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
-			if stepIndex != 0 {
-				t.Fatalf("step index: got %d, want 0", stepIndex)
+func TestClient_OnStepCommittedErrorStopsLoop(t *testing.T) {
+	runners := []struct {
+		name string
+		run  func(...sdk.GenerateOption) error
+	}{
+		{"generate", func(opts ...sdk.GenerateOption) error {
+			_, err := sdk.GenerateTextResult(context.Background(), opts...)
+			return err
+		}},
+		{"stream", func(opts ...sdk.GenerateOption) error {
+			sr, err := sdk.StreamText(context.Background(), opts...)
+			if err != nil {
+				return err
 			}
-			if len(step.ToolResults) != 1 {
-				t.Fatalf("commit ran before tool result was assembled: %#v", step.ToolResults)
-			}
-			return commitErr
-		}),
-	)
-	if !errors.Is(err, commitErr) {
-		t.Fatalf("error: got %v, want %v", err, commitErr)
+			_, err = sr.ToResult()
+			return err
+		}},
 	}
-	if mp.calls != 1 {
-		t.Fatalf("provider calls: got %d, want 1", mp.calls)
-	}
-}
 
-func TestClient_StreamText_OnStepCommittedErrorStopsLoop(t *testing.T) {
-	commitErr := errors.New("checkpoint unavailable")
-	mp := &mockProvider{handler: func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
-		if call != 1 {
-			return nil, fmt.Errorf("provider called after commit failed: call %d", call)
-		}
-		return &sdk.GenerateResult{
-			FinishReason: sdk.FinishReasonToolCalls,
-			ToolCalls: []sdk.ToolCall{{
-				ToolCallID: "c1", ToolName: "noop", Input: nil,
-			}},
-		}, nil
-	}}
-
-	sr, err := sdk.StreamText(context.Background(),
-		sdk.WithModel(mockModel(mp)),
-		sdk.WithMessages([]sdk.Message{sdk.UserMessage("go")}),
-		sdk.WithTools([]sdk.Tool{{
-			Name:       "noop",
-			Parameters: &jsonschema.Schema{Type: "object"},
-			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
-				return "ok", nil
-			},
-		}}),
-		sdk.WithMaxSteps(5),
-		sdk.WithOnStepCommitted(func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
-			if len(step.ToolResults) != 1 {
-				return fmt.Errorf("commit ran before tool result was assembled: %#v", step.ToolResults)
+	for _, runner := range runners {
+		t.Run(runner.name, func(t *testing.T) {
+			commitErr := errors.New("checkpoint unavailable")
+			mp := &mockProvider{handler: func(int, sdk.GenerateParams) (*sdk.GenerateResult, error) {
+				return &sdk.GenerateResult{
+					FinishReason: sdk.FinishReasonToolCalls,
+					ToolCalls:    []sdk.ToolCall{{ToolCallID: "c1", ToolName: "noop"}},
+				}, nil
+			}}
+			err := runner.run(
+				sdk.WithModel(mockModel(mp)),
+				sdk.WithTools([]sdk.Tool{{
+					Name: "noop", Parameters: &jsonschema.Schema{Type: "object"},
+					Execute: func(*sdk.ToolExecContext, any) (any, error) { return "ok", nil },
+				}}),
+				sdk.WithMaxSteps(5),
+				sdk.WithOnStepCommitted(func(_ context.Context, i int, step *sdk.StepResult) error {
+					if i != 0 || len(step.ToolResults) != 1 {
+						return fmt.Errorf("unexpected committed step %d: %#v", i, step.ToolResults)
+					}
+					return commitErr
+				}),
+			)
+			if !errors.Is(err, commitErr) {
+				t.Fatalf("error: got %v, want %v", err, commitErr)
 			}
-			return commitErr
-		}),
-	)
-	if err != nil {
-		t.Fatalf("StreamText: %v", err)
-	}
-	_, err = sr.ToResult()
-	if !errors.Is(err, commitErr) {
-		t.Fatalf("stream error: got %v, want %v", err, commitErr)
-	}
-	if mp.calls != 1 {
-		t.Fatalf("provider calls: got %d, want 1", mp.calls)
+			if mp.calls != 1 {
+				t.Fatalf("provider calls: got %d, want 1", mp.calls)
+			}
+		})
 	}
 }
 
 func TestClient_StreamText_DoesNotCommitIncompleteStep(t *testing.T) {
-	mp := &mockProvider{streamHandler: func(call int, params sdk.GenerateParams) (*sdk.StreamResult, error) {
+	mp := &mockProvider{streamHandler: func(int, sdk.GenerateParams) (*sdk.StreamResult, error) {
 		ch := make(chan sdk.StreamPart, 1)
 		ch <- &sdk.TextDeltaPart{ID: "partial", Text: "partial"}
 		close(ch)
@@ -1108,7 +1073,7 @@ func TestClient_StreamText_DoesNotCommitIncompleteStep(t *testing.T) {
 	sr, err := sdk.StreamText(context.Background(),
 		sdk.WithModel(mockModel(mp)),
 		sdk.WithMaxSteps(5),
-		sdk.WithOnStepCommitted(func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
+		sdk.WithOnStepCommitted(func(context.Context, int, *sdk.StepResult) error {
 			committed = true
 			return nil
 		}),
@@ -1122,9 +1087,6 @@ func TestClient_StreamText_DoesNotCommitIncompleteStep(t *testing.T) {
 	}
 	if committed {
 		t.Fatal("incomplete step was committed")
-	}
-	if mp.calls != 1 {
-		t.Fatalf("provider calls: got %d, want 1", mp.calls)
 	}
 }
 

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -2,6 +2,7 @@ package sdk_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -166,8 +167,9 @@ func TestClient_NoModel(t *testing.T) {
 // ---------- mockProvider for unit tests ----------
 
 type mockProvider struct {
-	calls   int
-	handler func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error)
+	calls         int
+	handler       func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error)
+	streamHandler func(call int, params sdk.GenerateParams) (*sdk.StreamResult, error)
 }
 
 func (m *mockProvider) Name() string { return "mock" }
@@ -187,6 +189,10 @@ func (m *mockProvider) DoGenerate(_ context.Context, params sdk.GenerateParams) 
 }
 
 func (m *mockProvider) DoStream(_ context.Context, params sdk.GenerateParams) (*sdk.StreamResult, error) {
+	if m.streamHandler != nil {
+		m.calls++
+		return m.streamHandler(m.calls, params)
+	}
 	result, err := m.DoGenerate(context.Background(), params)
 	if err != nil {
 		return nil, err
@@ -1000,6 +1006,125 @@ func TestClient_StreamText_OnStepCallback(t *testing.T) {
 	defer mu.Unlock()
 	if len(steps) != 2 {
 		t.Fatalf("expected 2 step callbacks, got %d", len(steps))
+	}
+}
+
+func TestClient_GenerateTextResult_OnStepCommittedErrorStopsLoop(t *testing.T) {
+	commitErr := errors.New("checkpoint unavailable")
+	mp := &mockProvider{handler: func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		if call != 1 {
+			return nil, fmt.Errorf("provider called after commit failed: call %d", call)
+		}
+		return &sdk.GenerateResult{
+			FinishReason: sdk.FinishReasonToolCalls,
+			ToolCalls: []sdk.ToolCall{{
+				ToolCallID: "c1", ToolName: "noop", Input: nil,
+			}},
+		}, nil
+	}}
+
+	_, err := sdk.GenerateTextResult(context.Background(),
+		sdk.WithModel(mockModel(mp)),
+		sdk.WithMessages([]sdk.Message{sdk.UserMessage("go")}),
+		sdk.WithTools([]sdk.Tool{{
+			Name:       "noop",
+			Parameters: &jsonschema.Schema{Type: "object"},
+			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				return "ok", nil
+			},
+		}}),
+		sdk.WithMaxSteps(5),
+		sdk.WithOnStepCommitted(func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
+			if stepIndex != 0 {
+				t.Fatalf("step index: got %d, want 0", stepIndex)
+			}
+			if len(step.ToolResults) != 1 {
+				t.Fatalf("commit ran before tool result was assembled: %#v", step.ToolResults)
+			}
+			return commitErr
+		}),
+	)
+	if !errors.Is(err, commitErr) {
+		t.Fatalf("error: got %v, want %v", err, commitErr)
+	}
+	if mp.calls != 1 {
+		t.Fatalf("provider calls: got %d, want 1", mp.calls)
+	}
+}
+
+func TestClient_StreamText_OnStepCommittedErrorStopsLoop(t *testing.T) {
+	commitErr := errors.New("checkpoint unavailable")
+	mp := &mockProvider{handler: func(call int, params sdk.GenerateParams) (*sdk.GenerateResult, error) {
+		if call != 1 {
+			return nil, fmt.Errorf("provider called after commit failed: call %d", call)
+		}
+		return &sdk.GenerateResult{
+			FinishReason: sdk.FinishReasonToolCalls,
+			ToolCalls: []sdk.ToolCall{{
+				ToolCallID: "c1", ToolName: "noop", Input: nil,
+			}},
+		}, nil
+	}}
+
+	sr, err := sdk.StreamText(context.Background(),
+		sdk.WithModel(mockModel(mp)),
+		sdk.WithMessages([]sdk.Message{sdk.UserMessage("go")}),
+		sdk.WithTools([]sdk.Tool{{
+			Name:       "noop",
+			Parameters: &jsonschema.Schema{Type: "object"},
+			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				return "ok", nil
+			},
+		}}),
+		sdk.WithMaxSteps(5),
+		sdk.WithOnStepCommitted(func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
+			if len(step.ToolResults) != 1 {
+				return fmt.Errorf("commit ran before tool result was assembled: %#v", step.ToolResults)
+			}
+			return commitErr
+		}),
+	)
+	if err != nil {
+		t.Fatalf("StreamText: %v", err)
+	}
+	_, err = sr.ToResult()
+	if !errors.Is(err, commitErr) {
+		t.Fatalf("stream error: got %v, want %v", err, commitErr)
+	}
+	if mp.calls != 1 {
+		t.Fatalf("provider calls: got %d, want 1", mp.calls)
+	}
+}
+
+func TestClient_StreamText_DoesNotCommitIncompleteStep(t *testing.T) {
+	mp := &mockProvider{streamHandler: func(call int, params sdk.GenerateParams) (*sdk.StreamResult, error) {
+		ch := make(chan sdk.StreamPart, 1)
+		ch <- &sdk.TextDeltaPart{ID: "partial", Text: "partial"}
+		close(ch)
+		return &sdk.StreamResult{Stream: ch}, nil
+	}}
+	committed := false
+
+	sr, err := sdk.StreamText(context.Background(),
+		sdk.WithModel(mockModel(mp)),
+		sdk.WithMaxSteps(5),
+		sdk.WithOnStepCommitted(func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
+			committed = true
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("StreamText: %v", err)
+	}
+	_, err = sr.ToResult()
+	if err == nil || err.Error() != "twilightai: stream step 0 ended before finish-step" {
+		t.Fatalf("stream error: got %v", err)
+	}
+	if committed {
+		t.Fatal("incomplete step was committed")
+	}
+	if mp.calls != 1 {
+		t.Fatalf("provider calls: got %d, want 1", mp.calls)
 	}
 }
 

--- a/sdk/generate_text.go
+++ b/sdk/generate_text.go
@@ -38,6 +38,9 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 			Response:        result.Response,
 			Messages:        stepMsgs,
 		}
+		if err := applyOnStepCommitted(ctx, cfg, 0, &step); err != nil {
+			return nil, err
+		}
 		result.Steps = []StepResult{step}
 		result.Messages = stepMsgs
 		applyOnStep(cfg, &step)
@@ -86,6 +89,9 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 				Response:        result.Response,
 				Messages:        stepMsgs,
 			}
+			if err := applyOnStepCommitted(ctx, cfg, step, &sr); err != nil {
+				return nil, err
+			}
 			allSteps = append(allSteps, sr)
 			allMessages = append(allMessages, stepMsgs...)
 			applyOnStep(cfg, &sr)
@@ -109,6 +115,9 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 					DeferredToolApproval: &deferred.Approval,
 					Messages:             stepMsgs,
 				}
+				if err := applyOnStepCommitted(ctx, cfg, step, &sr); err != nil {
+					return nil, err
+				}
 				allSteps = append(allSteps, sr)
 				allMessages = append(allMessages, stepMsgs...)
 				applyOnStep(cfg, &sr)
@@ -129,6 +138,9 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 			ToolResults:     toolCallResultsFromParts(toolResults),
 			Response:        result.Response,
 			Messages:        stepMsgs,
+		}
+		if err := applyOnStepCommitted(ctx, cfg, step, &sr); err != nil {
+			return nil, err
 		}
 		allSteps = append(allSteps, sr)
 		allMessages = append(allMessages, stepMsgs...)

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -14,6 +14,7 @@ type generateConfig struct {
 	MaxSteps        int
 	OnFinish        func(*GenerateResult)
 	OnStep          func(*StepResult) *GenerateParams
+	OnStepCommitted func(ctx context.Context, stepIndex int, step *StepResult) error
 	PrepareStep     func(*GenerateParams) *GenerateParams
 	ApprovalHandler func(ctx context.Context, call ToolCall) (ToolApprovalResult, error)
 }
@@ -107,6 +108,15 @@ func WithOnFinish(fn func(*GenerateResult)) GenerateOption {
 // for the next step.
 func WithOnStep(fn func(*StepResult) *GenerateParams) GenerateOption {
 	return func(c *generateConfig) { c.OnStep = fn }
+}
+
+// WithOnStepCommitted registers a synchronous commit barrier invoked after a
+// complete step has been assembled, including tool results or a deferred
+// approval marker, and before the SDK accepts the step or starts the next model
+// call. stepIndex is zero-based. Returning an error stops generation and leaves
+// the step uncommitted.
+func WithOnStepCommitted(fn func(ctx context.Context, stepIndex int, step *StepResult) error) GenerateOption {
+	return func(c *generateConfig) { c.OnStepCommitted = fn }
 }
 
 // WithPrepareStep registers a callback invoked before each step (starting from

--- a/sdk/step_helpers.go
+++ b/sdk/step_helpers.go
@@ -1,6 +1,9 @@
 package sdk
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 func buildConfig(options []GenerateOption) (*generateConfig, Provider, error) {
 	cfg := &generateConfig{}
@@ -82,6 +85,17 @@ func applyOnStep(cfg *generateConfig, stepResult *StepResult) {
 	if override := cfg.OnStep(stepResult); override != nil {
 		cfg.Params = *override
 	}
+}
+
+// applyOnStepCommitted blocks until the caller has durably accepted the step.
+func applyOnStepCommitted(ctx context.Context, cfg *generateConfig, stepIndex int, stepResult *StepResult) error {
+	if cfg.OnStepCommitted == nil {
+		return nil
+	}
+	if err := cfg.OnStepCommitted(ctx, stepIndex, stepResult); err != nil {
+		return fmt.Errorf("twilightai: commit step %d: %w", stepIndex, err)
+	}
+	return nil
 }
 
 // applyPrepareStep calls the PrepareStep callback and applies the returned override if non-nil.

--- a/sdk/stream_text.go
+++ b/sdk/stream_text.go
@@ -18,9 +18,15 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 		return nil, err
 	}
 
-	// Single-step fast path: delegate directly to provider.
-	if cfg.MaxSteps == 0 {
+	// Preserve the direct provider fast path unless the caller requested a
+	// commit barrier, which requires the SDK to assemble and validate the step.
+	if cfg.MaxSteps == 0 && cfg.OnStepCommitted == nil {
 		return prov.DoStream(ctx, cfg.Params)
+	}
+	autoExecuteTools := cfg.MaxSteps != 0
+	maxSteps := cfg.MaxSteps
+	if maxSteps == 0 {
+		maxSteps = 1
 	}
 
 	toolMap := buildToolMap(cfg.Params.Tools)
@@ -45,8 +51,19 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 		var lastRawFinishReason string
 		var allSteps []StepResult
 		var allMessages []Message
+		defer func() {
+			sr.Steps = allSteps
+			sr.Messages = allMessages
+			for i := range allSteps {
+				if allSteps[i].DeferredToolApproval != nil {
+					sr.DeferredToolApproval = allSteps[i].DeferredToolApproval
+					break
+				}
+			}
+			close(ch)
+		}()
 
-		for step := 0; shouldContinueLoop(cfg.MaxSteps, step); step++ {
+		for step := 0; shouldContinueLoop(maxSteps, step); step++ {
 			if step > 0 {
 				messages = applyPrepareStep(cfg, messages)
 			}
@@ -57,16 +74,19 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 			provSR, err := prov.DoStream(ctx, params)
 			if err != nil {
 				send(&ErrorPart{Error: fmt.Errorf("twilightai: stream step %d: %w", step, err)})
-				break
+				return
 			}
 
 			var (
-				stepText          string
-				stepReasoning     string
-				stepReasoningMeta map[string]any
-				stepToolCalls     []ToolCall
-				stepUsage         Usage
-				stepResponse      ResponseMetadata
+				stepText            string
+				stepReasoning       string
+				stepReasoningMeta   map[string]any
+				stepToolCalls       []ToolCall
+				stepUsage           Usage
+				stepResponse        ResponseMetadata
+				stepFinishReason    FinishReason
+				stepRawFinishReason string
+				sawFinishStep       bool
 			)
 
 			for part := range provSR.Stream {
@@ -87,35 +107,48 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 						ProviderMetadata: p.ProviderMetadata,
 					})
 				case *FinishStepPart:
+					sawFinishStep = true
 					stepUsage = p.Usage
 					stepResponse = p.Response
-					lastFinishReason = p.FinishReason
-					lastRawFinishReason = p.RawFinishReason
+					stepFinishReason = p.FinishReason
+					stepRawFinishReason = p.RawFinishReason
 				case *FinishPart:
-					lastFinishReason = p.FinishReason
-					lastRawFinishReason = p.RawFinishReason
+					stepFinishReason = p.FinishReason
+					stepRawFinishReason = p.RawFinishReason
 					continue
 				}
 
 				if !send(part) {
-					break
+					return
 				}
 			}
+			if !sawFinishStep {
+				if ctx.Err() == nil {
+					send(&ErrorPart{Error: fmt.Errorf("twilightai: stream step %d ended before finish-step", step)})
+				}
+				return
+			}
 
+			lastFinishReason = stepFinishReason
+			lastRawFinishReason = stepRawFinishReason
 			totalUsage = addUsage(&totalUsage, &stepUsage)
 
 			// No tool calls or not a tool-calls finish → done
-			if lastFinishReason != FinishReasonToolCalls || len(stepToolCalls) == 0 || !hasExecutableTools(stepToolCalls, toolMap) {
+			if !autoExecuteTools || stepFinishReason != FinishReasonToolCalls || len(stepToolCalls) == 0 || !hasExecutableTools(stepToolCalls, toolMap) {
 				stepMsgs := buildStepMessages(stepText, stepReasoning, stepReasoningMeta, stepToolCalls, nil, &stepUsage)
 				stepR := StepResult{
 					Text:            stepText,
 					Reasoning:       stepReasoning,
-					FinishReason:    lastFinishReason,
-					RawFinishReason: lastRawFinishReason,
+					FinishReason:    stepFinishReason,
+					RawFinishReason: stepRawFinishReason,
 					Usage:           stepUsage,
 					ToolCalls:       stepToolCalls,
 					Response:        stepResponse,
 					Messages:        stepMsgs,
+				}
+				if err := applyOnStepCommitted(ctx, cfg, step, &stepR); err != nil {
+					send(&ErrorPart{Error: err})
+					return
 				}
 				allSteps = append(allSteps, stepR)
 				allMessages = append(allMessages, stepMsgs...)
@@ -133,13 +166,17 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 					stepR := StepResult{
 						Text:                 stepText,
 						Reasoning:            stepReasoning,
-						FinishReason:         lastFinishReason,
-						RawFinishReason:      lastRawFinishReason,
+						FinishReason:         stepFinishReason,
+						RawFinishReason:      stepRawFinishReason,
 						Usage:                stepUsage,
 						ToolCalls:            stepToolCalls,
 						Response:             stepResponse,
 						DeferredToolApproval: &deferred.Approval,
 						Messages:             stepMsgs,
+					}
+					if err := applyOnStepCommitted(ctx, cfg, step, &stepR); err != nil {
+						send(&ErrorPart{Error: err})
+						return
 					}
 					allSteps = append(allSteps, stepR)
 					allMessages = append(allMessages, stepMsgs...)
@@ -147,20 +184,24 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 					break
 				}
 				send(&ErrorPart{Error: err})
-				break
+				return
 			}
 
 			stepMsgs := buildStepMessages(stepText, stepReasoning, stepReasoningMeta, stepToolCalls, toolResults, &stepUsage)
 			stepR := StepResult{
 				Text:            stepText,
 				Reasoning:       stepReasoning,
-				FinishReason:    lastFinishReason,
-				RawFinishReason: lastRawFinishReason,
+				FinishReason:    stepFinishReason,
+				RawFinishReason: stepRawFinishReason,
 				Usage:           stepUsage,
 				ToolCalls:       stepToolCalls,
 				ToolResults:     toolCallResultsFromParts(toolResults),
 				Response:        stepResponse,
 				Messages:        stepMsgs,
+			}
+			if err := applyOnStepCommitted(ctx, cfg, step, &stepR); err != nil {
+				send(&ErrorPart{Error: err})
+				return
 			}
 			allSteps = append(allSteps, stepR)
 			allMessages = append(allMessages, stepMsgs...)
@@ -169,36 +210,31 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 			messages = append(messages, stepMsgs...)
 		}
 
-		// Populate StreamResult fields before closing the channel.
-		// Channel close happens-before the consumer's range-loop exit,
-		// so these are safe to read after consumption.
-		sr.Steps = allSteps
-		sr.Messages = allMessages
-		for i := range allSteps {
-			if allSteps[i].DeferredToolApproval != nil {
-				sr.DeferredToolApproval = allSteps[i].DeferredToolApproval
-				break
-			}
-		}
-
-		send(&FinishPart{
+		if !send(&FinishPart{
 			FinishReason:    lastFinishReason,
 			RawFinishReason: lastRawFinishReason,
 			TotalUsage:      totalUsage,
-		})
+		}) {
+			return
+		}
 
 		if cfg.OnFinish != nil {
+			var deferredToolApproval *ToolApprovalResult
+			for i := range allSteps {
+				if allSteps[i].DeferredToolApproval != nil {
+					deferredToolApproval = allSteps[i].DeferredToolApproval
+					break
+				}
+			}
 			cfg.OnFinish(&GenerateResult{
 				FinishReason:         lastFinishReason,
 				RawFinishReason:      lastRawFinishReason,
 				Usage:                totalUsage,
 				Steps:                allSteps,
 				Messages:             allMessages,
-				DeferredToolApproval: sr.DeferredToolApproval,
+				DeferredToolApproval: deferredToolApproval,
 			})
 		}
-
-		close(ch)
 	}()
 
 	return sr, nil

--- a/skill/reference.md
+++ b/skill/reference.md
@@ -287,6 +287,7 @@ func WithReasoningEffort(effort string) GenerateOption
 func WithMaxSteps(n int) GenerateOption
 func WithOnFinish(fn func(*GenerateResult)) GenerateOption
 func WithOnStep(fn func(*StepResult) *GenerateParams) GenerateOption
+func WithOnStepCommitted(fn func(ctx context.Context, stepIndex int, step *StepResult) error) GenerateOption
 func WithPrepareStep(fn func(*GenerateParams) *GenerateParams) GenerateOption
 func WithApprovalHandler(fn func(ctx context.Context, call ToolCall) (bool, error)) GenerateOption
 ```
@@ -296,6 +297,7 @@ Behavior notes:
 - `WithMaxSteps(0)` is the default single-call mode.
 - `WithMaxSteps(N)` enables automatic tool execution for up to `N` LLM calls.
 - `WithMaxSteps(-1)` means unlimited loop until the model stops requesting tools.
+- `WithOnStepCommitted` runs after a complete step is assembled and before it is accepted into accumulated history or the next model call begins. Returning an error stops generation.
 - `WithToolChoice` accepts `"auto"`, `"none"`, or `"required"`.
 
 ### Tools


### PR DESCRIPTION
## What changed

- add `WithOnStepCommitted`, a synchronous error-returning barrier invoked after a step is fully assembled and before the SDK accepts it or starts the next model call
- apply the barrier consistently to generated and streamed multi-step execution, including completed tool results and deferred approvals
- reject streamed steps that end without a `FinishStepPart`
- retain the direct single-step streaming fast path when no commit barrier is configured
- document the new callback and its ordering contract

## Why

The existing `WithOnStep` callback cannot report persistence failures. The streaming loop could also assemble a `StepResult` after the provider stream closed without a finish-step marker. Callers therefore could not durably persist the last complete step before the next model call while reliably excluding partial output.

## Impact

Callers can now block loop progression until a complete step is durably committed. Returning an error stops generation before another provider call begins and leaves the current step out of the accumulated result.

## Validation

- `go test -race ./sdk`
- `go test ./...`
- `git diff --check`