### PR TITLE
feat(provider): translate FileParts into each provider's native file format

### DIFF
--- a/internal/utils/filedata.go
+++ b/internal/utils/filedata.go
@@ -1,0 +1,54 @@
+package utils
+
+import "strings"
+
+// NormalizeFileData splits a FilePart payload into bare base64 data and a
+// media type. FilePart.Data is bare base64 by convention; data URLs are
+// tolerated and stripped so callers that still pass them keep working.
+//
+// Media type precedence: explicit argument, data URL header, then
+// application/pdf as the fallback — file parts exist for provider-native
+// document input, where PDF is the only interchange format every supported
+// provider accepts, so an unlabeled payload is treated as one.
+func NormalizeFileData(data, mediaType string) (string, string) {
+	data = strings.TrimSpace(data)
+	mediaType = strings.TrimSpace(mediaType)
+
+	if strings.HasPrefix(strings.ToLower(data), "data:") {
+		if idx := strings.Index(data, ","); idx >= 0 {
+			header := data[len("data:"):idx]
+			data = data[idx+1:]
+			if mediaType == "" {
+				if semi := strings.Index(header, ";"); semi >= 0 {
+					mediaType = strings.TrimSpace(header[:semi])
+				} else {
+					mediaType = strings.TrimSpace(header)
+				}
+			}
+		}
+	}
+
+	if mediaType == "" {
+		mediaType = "application/pdf"
+	}
+	return data, mediaType
+}
+
+// FileDataURL renders a normalized file payload as a data URL, the shape the
+// OpenAI-family file inputs expect in file_data fields.
+func FileDataURL(base64Data, mediaType string) string {
+	return "data:" + mediaType + ";base64," + base64Data
+}
+
+// OmittedFileNotice is the marker adapters without native file input emit in
+// place of a FilePart. Silently sending megabytes of base64 as "text" is the
+// failure mode file parts exist to fix, so the omission must be visible to
+// both the model and anyone reading the request.
+func OmittedFileNotice(filename, mediaType string) string {
+	_, mediaType = NormalizeFileData("", mediaType)
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		filename = "attachment"
+	}
+	return "[file attachment omitted: this provider has no native file input; filename=" + filename + ", mediaType=" + mediaType + "]"
+}

--- a/internal/utils/filedata.go
+++ b/internal/utils/filedata.go
@@ -10,7 +10,7 @@ import "strings"
 // application/pdf as the fallback — file parts exist for provider-native
 // document input, where PDF is the only interchange format every supported
 // provider accepts, so an unlabeled payload is treated as one.
-func NormalizeFileData(data, mediaType string) (string, string) {
+func NormalizeFileData(data, mediaType string) (base64Data, effectiveMediaType string) {
 	data = strings.TrimSpace(data)
 	mediaType = strings.TrimSpace(mediaType)
 

--- a/internal/utils/filedata_test.go
+++ b/internal/utils/filedata_test.go
@@ -1,0 +1,80 @@
+package utils
+
+import "testing"
+
+func TestNormalizeFileData(t *testing.T) {
+	cases := []struct {
+		name      string
+		data      string
+		mediaType string
+		wantData  string
+		wantMime  string
+	}{
+		{
+			name:      "bare base64 with explicit media type",
+			data:      "JVBERi0xLjQ=",
+			mediaType: "application/pdf",
+			wantData:  "JVBERi0xLjQ=",
+			wantMime:  "application/pdf",
+		},
+		{
+			name:     "bare base64 defaults to pdf",
+			data:     "JVBERi0xLjQ=",
+			wantData: "JVBERi0xLjQ=",
+			wantMime: "application/pdf",
+		},
+		{
+			name:     "data URL is stripped and mime taken from header",
+			data:     "data:application/pdf;base64,JVBERi0xLjQ=",
+			wantData: "JVBERi0xLjQ=",
+			wantMime: "application/pdf",
+		},
+		{
+			name:      "explicit media type wins over data URL header",
+			data:      "data:application/octet-stream;base64,JVBERi0xLjQ=",
+			mediaType: "application/pdf",
+			wantData:  "JVBERi0xLjQ=",
+			wantMime:  "application/pdf",
+		},
+		{
+			name:     "data URL header without base64 marker",
+			data:     "data:text/plain,aGVsbG8=",
+			wantData: "aGVsbG8=",
+			wantMime: "text/plain",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotData, gotMime := NormalizeFileData(tc.data, tc.mediaType)
+			if gotData != tc.wantData {
+				t.Errorf("data: got %q, want %q", gotData, tc.wantData)
+			}
+			if gotMime != tc.wantMime {
+				t.Errorf("mime: got %q, want %q", gotMime, tc.wantMime)
+			}
+		})
+	}
+}
+
+func TestFileDataURL(t *testing.T) {
+	got := FileDataURL("JVBERi0xLjQ=", "application/pdf")
+	want := "data:application/pdf;base64,JVBERi0xLjQ="
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestOmittedFileNotice(t *testing.T) {
+	got := OmittedFileNotice("report.pdf", "application/pdf")
+	want := "[file attachment omitted: this provider has no native file input; filename=report.pdf, mediaType=application/pdf]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	got = OmittedFileNotice("", "")
+	want = "[file attachment omitted: this provider has no native file input; filename=attachment, mediaType=application/pdf]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/provider/anthropic/messages/file_part_test.go
+++ b/provider/anthropic/messages/file_part_test.go
@@ -1,0 +1,133 @@
+package messages_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/anthropic/messages"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+// TestDoGenerate_FilePartDocumentBlock is the golden test for native PDF
+// input: an sdk.FilePart must reach the wire as an Anthropic document block,
+// never as a text block carrying raw base64.
+func TestDoGenerate_FilePartDocumentBlock(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":          "msg_test123",
+			"type":        "message",
+			"model":       "claude-sonnet-4-20250514",
+			"role":        "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "A PDF."}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 5, "output_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := messages.New(
+		messages.WithAPIKey("test-key"),
+		messages.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "claude-sonnet-4-20250514"},
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleUser,
+			Content: []sdk.MessagePart{
+				sdk.FilePart{Data: "JVBERi0xLjQ=", MediaType: "application/pdf", Filename: "report.pdf"},
+				sdk.TextPart{Text: "Summarize this PDF"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	want := mustJSONValue(t, `[
+		{
+			"type": "document",
+			"source": {"type": "base64", "media_type": "application/pdf", "data": "JVBERi0xLjQ="},
+			"title": "report.pdf"
+		},
+		{"type": "text", "text": "Summarize this PDF"}
+	]`)
+
+	msgs, ok := body["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %#v", body["messages"])
+	}
+	got := msgs[0].(map[string]any)["content"]
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("content mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestDoGenerate_FilePartDataURLTolerated verifies a data URL payload is
+// stripped to bare base64 before hitting the wire.
+func TestDoGenerate_FilePartDataURLTolerated(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":          "msg_test123",
+			"type":        "message",
+			"model":       "claude-sonnet-4-20250514",
+			"role":        "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "ok"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	p := messages.New(
+		messages.WithAPIKey("test-key"),
+		messages.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "claude-sonnet-4-20250514"},
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleUser,
+			Content: []sdk.MessagePart{
+				sdk.FilePart{Data: "data:application/pdf;base64,JVBERi0xLjQ="},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	want := mustJSONValue(t, `[
+		{
+			"type": "document",
+			"source": {"type": "base64", "media_type": "application/pdf", "data": "JVBERi0xLjQ="}
+		}
+	]`)
+
+	msgs := body["messages"].([]any)
+	got := msgs[0].(map[string]any)["content"]
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("content mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func mustJSONValue(t *testing.T, s string) any {
+	t.Helper()
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		t.Fatalf("bad golden JSON: %v", err)
+	}
+	return v
+}

--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -453,14 +453,34 @@ func convertUserContent(parts []sdk.MessagePart) []contentBlock {
 		case sdk.ImagePart:
 			blocks = append(blocks, convertImagePart(p))
 		case sdk.FilePart:
-			block := contentBlock{Type: blockTypeText, Text: p.Data}
-			if p.CacheControl != nil {
-				block.CacheControl = &cacheControl{Type: p.CacheControl.Type, TTL: p.CacheControl.TTL}
-			}
-			blocks = append(blocks, block)
+			blocks = append(blocks, convertFilePart(p))
 		}
 	}
 	return blocks
+}
+
+// convertFilePart converts an sdk.FilePart into an Anthropic document content
+// block for native file input (text layer + per-page rendering happen on the
+// provider side). FilePart data is bare base64 by convention; data URLs are
+// tolerated and stripped.
+func convertFilePart(p sdk.FilePart) contentBlock {
+	data, mediaType := utils.NormalizeFileData(p.Data, p.MediaType)
+
+	var cc *cacheControl
+	if p.CacheControl != nil {
+		cc = &cacheControl{Type: p.CacheControl.Type, TTL: p.CacheControl.TTL}
+	}
+
+	return contentBlock{
+		Type: "document",
+		Source: &imageSource{
+			Type:      "base64",
+			MediaType: mediaType,
+			Data:      data,
+		},
+		Title:        strings.TrimSpace(p.Filename),
+		CacheControl: cc,
+	}
 }
 
 // convertImagePart converts an sdk.ImagePart into an Anthropic content block,

--- a/provider/anthropic/messages/types.go
+++ b/provider/anthropic/messages/types.go
@@ -49,8 +49,9 @@ type contentBlock struct {
 	// text block
 	Text string `json:"text,omitempty"`
 
-	// image block
+	// image / document block
 	Source *imageSource `json:"source,omitempty"`
+	Title  string       `json:"title,omitempty"`
 
 	// thinking block
 	Thinking  string `json:"thinking,omitempty"`

--- a/provider/github/copilot/copilot.go
+++ b/provider/github/copilot/copilot.go
@@ -314,7 +314,11 @@ func convertContent(parts []sdk.MessagePart) any {
 				ImageURL: chatImageURL{URL: p.Image},
 			})
 		case sdk.FilePart:
-			out = append(out, chatContentPartText{Type: "text", Text: p.Data})
+			// Copilot has no confirmed native file input. Emit an explicit
+			// marker instead of the raw payload: silently sending megabytes of
+			// base64 as "text" is exactly the failure mode file parts exist to
+			// fix. Swap this for a native part once upstream support lands.
+			out = append(out, chatContentPartText{Type: "text", Text: utils.OmittedFileNotice(p.Filename, p.MediaType)})
 		}
 	}
 	return out

--- a/provider/github/copilot/file_part_test.go
+++ b/provider/github/copilot/file_part_test.go
@@ -1,0 +1,68 @@
+package copilot_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/github/copilot"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+// TestDoGenerate_FilePartOmittedNotice: Copilot has no confirmed native file
+// input, so an sdk.FilePart must surface as an explicit omission marker —
+// never as raw base64 masquerading as text.
+func TestDoGenerate_FilePartOmittedNotice(t *testing.T) {
+	token := testToken()
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "copilotcmpl-test",
+			"object":  "chat.completion",
+			"created": 1700000000,
+			"model":   "github-managed-model",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "ok"},
+			}},
+			"usage": map[string]any{"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+		})
+	}))
+	defer srv.Close()
+
+	p := copilot.New(
+		copilot.WithGitHubToken(token),
+		copilot.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "gpt-4o"},
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleUser,
+			Content: []sdk.MessagePart{
+				sdk.FilePart{Data: "JVBERi0xLjQ=", MediaType: "application/pdf", Filename: "report.pdf"},
+				sdk.TextPart{Text: "Summarize this PDF"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	body := string(rawBody)
+	if strings.Contains(body, "JVBERi0xLjQ=") {
+		t.Errorf("raw base64 payload leaked into the request body")
+	}
+	wantNotice := "[file attachment omitted: this provider has no native file input; filename=report.pdf, mediaType=application/pdf]"
+	if !strings.Contains(body, wantNotice) {
+		t.Errorf("omission notice missing from request body:\n%s", body)
+	}
+}

--- a/provider/google/generativeai/file_part_test.go
+++ b/provider/google/generativeai/file_part_test.go
@@ -1,0 +1,77 @@
+package generativeai_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/google/generativeai"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+// TestDoGenerate_FilePartInlineData is the golden test for native PDF input
+// on Gemini: an sdk.FilePart must reach the wire as inlineData with bare
+// base64 — a data URL payload is stripped, and an unlabeled payload defaults
+// to application/pdf rather than octet-stream.
+func TestDoGenerate_FilePartInlineData(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"candidates": []map[string]any{{
+				"content": map[string]any{
+					"role":  "model",
+					"parts": []map[string]any{{"text": "A PDF."}},
+				},
+				"finishReason": "STOP",
+			}},
+			"usageMetadata": map[string]any{
+				"promptTokenCount":     5,
+				"candidatesTokenCount": 2,
+				"totalTokenCount":      7,
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := generativeai.New(
+		generativeai.WithAPIKey("test-key"),
+		generativeai.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: p.ChatModel("gemini-2.0-flash"),
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleUser,
+			Content: []sdk.MessagePart{
+				sdk.FilePart{Data: "data:application/pdf;base64,JVBERi0xLjQ="},
+				sdk.TextPart{Text: "Summarize this PDF"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	var want any
+	if err := json.Unmarshal([]byte(`[
+		{"inlineData": {"mimeType": "application/pdf", "data": "JVBERi0xLjQ="}},
+		{"text": "Summarize this PDF"}
+	]`), &want); err != nil {
+		t.Fatalf("bad golden JSON: %v", err)
+	}
+
+	contents, ok := body["contents"].([]any)
+	if !ok || len(contents) != 1 {
+		t.Fatalf("expected 1 content, got %#v", body["contents"])
+	}
+	got := contents[0].(map[string]any)["parts"]
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parts mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/provider/google/generativeai/generativeai.go
+++ b/provider/google/generativeai/generativeai.go
@@ -294,12 +294,9 @@ func convertUserMessage(msg sdk.Message) content {
 				})
 			}
 		case sdk.FilePart:
-			mediaType := p.MediaType
-			if mediaType == "" {
-				mediaType = "application/octet-stream"
-			}
+			data, mediaType := utils.NormalizeFileData(p.Data, p.MediaType)
 			parts = append(parts, contentPart{
-				InlineData: &inlineData{MimeType: mediaType, Data: p.Data},
+				InlineData: &inlineData{MimeType: mediaType, Data: data},
 			})
 		}
 	}

--- a/provider/openai/codex/codex.go
+++ b/provider/openai/codex/codex.go
@@ -463,7 +463,10 @@ func convertCodexUserMessage(msg sdk.Message) []json.RawMessage {
 		case sdk.ImagePart:
 			parts = append(parts, codexUserContentPart{Type: "input_image", ImageURL: p.Image})
 		case sdk.FilePart:
-			parts = append(parts, codexUserContentPart{Type: "input_text", Text: p.Data})
+			// Codex has no confirmed native file input; emit an explicit
+			// marker instead of the raw payload. Swap for a native part once
+			// upstream support is verified.
+			parts = append(parts, codexUserContentPart{Type: "input_text", Text: utils.OmittedFileNotice(p.Filename, p.MediaType)})
 		}
 	}
 	return []json.RawMessage{marshalRaw(codexUserMessage{Role: "user", Content: parts})}

--- a/provider/openai/codex/file_part_test.go
+++ b/provider/openai/codex/file_part_test.go
@@ -1,0 +1,72 @@
+package codex_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/openai/codex"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+// TestDoGenerate_FilePartOmittedNotice: Codex has no confirmed native file
+// input, so an sdk.FilePart must surface as an explicit omission marker —
+// never as raw base64 masquerading as input_text.
+func TestDoGenerate_FilePartOmittedNotice(t *testing.T) {
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("data: {\"response\":{\"id\":\"resp_123\",\"created_at\":1700000000,\"model\":\"gpt-5.2\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_item.added\n"))
+		_, _ = w.Write([]byte("data: {\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_text.delta\n"))
+		_, _ = w.Write([]byte("data: {\"item_id\":\"msg_1\",\"delta\":\"ok\"}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_item.done\n"))
+		_, _ = w.Write([]byte("data: {\"output_index\":0,\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"response\":{\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}}\n\n"))
+	}))
+	defer srv.Close()
+
+	p := codex.New(
+		codex.WithAccessToken("token-123"),
+		codex.WithAccountID("acct_123"),
+		codex.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "gpt-5.2"},
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleUser,
+			Content: []sdk.MessagePart{
+				sdk.FilePart{Data: "JVBERi0xLjQ=", MediaType: "application/pdf", Filename: "report.pdf"},
+				sdk.TextPart{Text: "Summarize this PDF"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	var body struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal(rawBody, &body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	raw := string(rawBody)
+	if strings.Contains(raw, "JVBERi0xLjQ=") {
+		t.Errorf("raw base64 payload leaked into the request body")
+	}
+	wantNotice := "[file attachment omitted: this provider has no native file input; filename=report.pdf, mediaType=application/pdf]"
+	if !strings.Contains(raw, wantNotice) {
+		t.Errorf("omission notice missing from request body:\n%s", raw)
+	}
+}

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -464,7 +464,14 @@ func convertContent(parts []sdk.MessagePart) any {
 				ImageURL: chatImageURL{URL: p.Image},
 			})
 		case sdk.FilePart:
-			out = append(out, chatContentPartText{Type: "text", Text: p.Data})
+			data, mediaType := utils.NormalizeFileData(p.Data, p.MediaType)
+			out = append(out, chatContentPartFile{
+				Type: "file",
+				File: chatFile{
+					Filename: strings.TrimSpace(p.Filename),
+					FileData: utils.FileDataURL(data, mediaType),
+				},
+			})
 		}
 	}
 	return out

--- a/provider/openai/completions/file_part_test.go
+++ b/provider/openai/completions/file_part_test.go
@@ -1,0 +1,77 @@
+package completions_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/openai/completions"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+// TestDoGenerate_FilePartFileContent is the golden test for native PDF input
+// on Chat Completions: an sdk.FilePart must reach the wire as a "file" content
+// part with a data URL, never as a text part carrying raw base64.
+func TestDoGenerate_FilePartFileContent(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": 1700000000,
+			"model":   "gpt-4o-mini",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message":       map[string]any{"role": "assistant", "content": "A PDF."},
+			}},
+			"usage": map[string]any{"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+		})
+	}))
+	defer srv.Close()
+
+	p := completions.New(
+		completions.WithAPIKey("test-key"),
+		completions.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "gpt-4o-mini"},
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleUser,
+			Content: []sdk.MessagePart{
+				sdk.FilePart{Data: "JVBERi0xLjQ=", MediaType: "application/pdf", Filename: "report.pdf"},
+				sdk.TextPart{Text: "Summarize this PDF"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	var want any
+	if err := json.Unmarshal([]byte(`[
+		{
+			"type": "file",
+			"file": {"filename": "report.pdf", "file_data": "data:application/pdf;base64,JVBERi0xLjQ="}
+		},
+		{"type": "text", "text": "Summarize this PDF"}
+	]`), &want); err != nil {
+		t.Fatalf("bad golden JSON: %v", err)
+	}
+
+	msgs, ok := body["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %#v", body["messages"])
+	}
+	got := msgs[0].(map[string]any)["content"]
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("content mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/provider/openai/completions/types.go
+++ b/provider/openai/completions/types.go
@@ -68,6 +68,16 @@ type chatContentPartImage struct {
 	ImageURL chatImageURL `json:"image_url"`
 }
 
+type chatContentPartFile struct {
+	Type string   `json:"type"`
+	File chatFile `json:"file"`
+}
+
+type chatFile struct {
+	Filename string `json:"filename,omitempty"`
+	FileData string `json:"file_data"`
+}
+
 type chatImageURL struct {
 	URL    string `json:"url"`
 	Detail string `json:"detail,omitempty"`

--- a/provider/openai/responses/file_part_test.go
+++ b/provider/openai/responses/file_part_test.go
@@ -1,0 +1,91 @@
+package responses_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/openai/responses"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+// TestResponsesDoGenerate_FilePartInputFile is the golden test for native PDF
+// input on the Responses API: an sdk.FilePart must reach the wire as an
+// "input_file" part with a data URL, never as input_text carrying raw base64.
+func TestResponsesDoGenerate_FilePartInputFile(t *testing.T) {
+	var body struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "resp_test123",
+			"created_at": 1700000000,
+			"model":      "gpt-4o-mini",
+			"output": []map[string]any{{
+				"type": "message",
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{{
+					"type":        "output_text",
+					"text":        "A PDF.",
+					"annotations": []any{},
+				}},
+			}},
+			"usage": map[string]any{"input_tokens": 5, "output_tokens": 2},
+		})
+	}))
+	defer srv.Close()
+
+	p := responses.New(
+		responses.WithAPIKey("test-key"),
+		responses.WithBaseURL(srv.URL),
+	)
+
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: &sdk.Model{ID: "gpt-4o-mini"},
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleUser,
+			Content: []sdk.MessagePart{
+				sdk.FilePart{Data: "JVBERi0xLjQ=", MediaType: "application/pdf", Filename: "report.pdf"},
+				sdk.TextPart{Text: "Summarize this PDF"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate failed: %v", err)
+	}
+
+	if len(body.Input) != 1 {
+		t.Fatalf("expected 1 input item, got %d", len(body.Input))
+	}
+
+	var got any
+	if err := json.Unmarshal(body.Input[0], &got); err != nil {
+		t.Fatalf("decode input item: %v", err)
+	}
+
+	var want any
+	if err := json.Unmarshal([]byte(`{
+		"role": "user",
+		"content": [
+			{
+				"type": "input_file",
+				"filename": "report.pdf",
+				"file_data": "data:application/pdf;base64,JVBERi0xLjQ="
+			},
+			{"type": "input_text", "text": "Summarize this PDF"}
+		]
+	}`), &want); err != nil {
+		t.Fatalf("bad golden JSON: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("input mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/memohai/twilight-ai/internal/messagecompat"
@@ -308,7 +309,12 @@ func convertResponsesUserMessage(msg sdk.Message) []json.RawMessage {
 		case sdk.ImagePart:
 			parts = append(parts, responsesUserContentPart{Type: "input_image", ImageURL: p.Image})
 		case sdk.FilePart:
-			parts = append(parts, responsesUserContentPart{Type: "input_text", Text: p.Data})
+			data, mediaType := utils.NormalizeFileData(p.Data, p.MediaType)
+			parts = append(parts, responsesUserContentPart{
+				Type:     "input_file",
+				Filename: strings.TrimSpace(p.Filename),
+				FileData: utils.FileDataURL(data, mediaType),
+			})
 		}
 	}
 	return []json.RawMessage{marshalRaw(responsesUserMessage{

--- a/provider/openai/responses/types.go
+++ b/provider/openai/responses/types.go
@@ -52,6 +52,8 @@ type responsesUserContentPart struct {
 	Type     string `json:"type"`
 	Text     string `json:"text,omitempty"`
 	ImageURL string `json:"image_url,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	FileData string `json:"file_data,omitempty"`
 }
 
 type responsesUserMessage struct {


### PR DESCRIPTION
# PDF 附件原生直传(PR 总描述稿)

> 提 PR 用:可整段作为 Memoh PR body,twilight PR 取其中对应小节。
> 顺序要求:**先合并 twilight 并发版,Memoh 再 bump go.mod 提 PR**(反了的话勾了能力的模型发文件会退化成 base64 文本)。

---

## 一、问题是什么(twilight-ai#29)

用户在 web 上给 bot 上传一个 PDF,问"这讲了啥",实际发生的是:

```
用户:[上传 报告.pdf] 这个讲了啥?
bot: 执行 pdfinfo /data/media/xx/xxxx.pdf
bot: 执行 pip install pymupdf
bot: 执行 python -c "抽取文本……"
bot: (两分钟后)这个文档大概讲了……
```

**根因**:附件链路在两个地方是断的——

1. **Memoh 不把文件发给模型**。收到附件后只存进 bot 工作区,给模型一个
   文件路径。模型看不到文件本体,只能自己装工具、写脚本解析;
2. **就算发了也到不了**。SDK(twilight-ai)的消息模型里早就有
   `FilePart`(文件部件)类型,但所有厂商适配器都对它视而不见:文件
   部件走到适配层被**静默丢弃**,不报错、不提示,文件凭空消失。

**代价**:

- 慢且不稳:每次都要装解析器、跑脚本,装不上就直接失败;
- 视觉信息全丢:脚本只能抽纯文本,图表、扫描页、版式全看不见;
- 厂商能力白白浪费:Claude/GPT/Gemini 的 API 本来就支持直接接收
  PDF——服务端抽文本 + 逐页渲染成图喂给模型,又快又能"看",我们没用。

**方案一句话**:模型能直接吃 PDF 的,把文件本体随消息发过去;不能吃
的,维持路径降级不变,但要让用户当场知道。

---

## 二、修改链路(总览)

文件要从浏览器走到厂商 API,每一层都有活,改动分布如下:

```
浏览器上传 PDF
   │
   ▼
Memoh 后端                        【本 PR 主体】
   ├─ 新能力位 file-input:这个模型的 API 吃不吃文件?
   │    (模板预置 + LiteLLM 每周同步 + UI 手动勾;与 vision 独立)
   ├─ 路由分流:能吃且 ≤12MB → 文件本体随消息;否则 → 路径降级
   ├─ read 工具:后续轮次可按路径把 PDF 重新喂给模型
   ├─ 落库占位符:文件字节永不进数据库
   └─ 前端:模型不支持时上传当场弹提示
   │
   ▼
twilight-ai(Go LLM SDK)          【前置 PR,先合并发版】
   └─ 各厂商适配器把 FilePart 翻译成各家的文件格式
      (之前:所有适配器静默丢弃)
   │
   ├───────────── 用户自配 provider(直连)──────────────┐
   │                                                      ▼
   │                                    Anthropic / OpenAI / Gemini API
   │                                    (厂商服务端抽文本+渲染页面)
   │                                                      ▲
   └── 平台托管 provider(仅 Cloud)──► llm-relay ────────┘
        对外收 OpenAI 格式             【Cloud 侧第三个 PR】
                                        入站的 file 部件按真实上游再翻译一次:
                                        → Anthropic document 块
                                        → Gemini inlineData
                                        → OpenAI 上游原样透传
                                        (之前:转换时把 file 部件丢弃)
```

> 开源版部署只有上面那条直连道;Memoh Cloud 的平台托管模型多走一跳
> llm-relay——它对外统一收 OpenAI 格式,再按真实上游做第二次格式转换,
> 所以 relay 也必须学会翻译 file 部件,否则文件在这一跳又会消失。

改动后一条消息的两种旅程:

**情形 A:模型支持(勾了 file-input)**
上传 → 路由判定可原生 → PDF 转 base64 作为文件部件随消息发出(同时照
旧落一份到工作区、消息头带路径,供以后重读)→ SDK 翻译成该厂商格式 →
模型一轮内"读+看"完整个文档作答 → 落库只有文本和占位符,没有文件字节。

**情形 B:模型不支持(没勾 / DeepSeek 这类 API 无文件入口 / 超 12MB)**
上传 → 前端当场提示"当前模型不支持读取 PDF……"(超大小暂不提示,见
遗留)→ 文件落工作区、消息给路径 → 模型自己用工具解析(老行为,但用户
知情)。

---

## 三、分仓库详细改动

### twilight-ai(分支 `feat/native-file-parts`)

各适配器的"方言翻译",每家配固化请求格式的 golden 测试:

| 适配器 | FilePart 翻译成 |
|---|---|
| `anthropic/messages` | `document` 内容块(base64,文件名放 `title`) |
| `openai/completions` | `file` 内容部件(`file_data` 放 data URL + `filename`) |
| `openai/responses` | `input_file` 内容部件 |
| `google/generativeai` | `inlineData` 部件 |
| `github/copilot`、`openai/codex` | 上游无文件入口——插入明确的"[文件已省略]"提示,不把几 MB base64 当文本漏出去 |

公共工具 `internal/utils/filedata.go`:`NormalizeFileData` 统一"裸
base64 / data URL"两种输入,返回裸 base64 + 生效媒体类型(缺省
`application/pdf`)。

确立的约定:`FilePart.Data` 全链路放**裸 base64**,包装是适配器的事;
适配器不猜能力,上游不支持就转可见提示,绝不静默丢。

兼容性:纯增量,不带 FilePart 的消息序列化逐字节不变,无公开 API 变更。

### Memoh(分支 `feat/attachment-native-input`)

**① 能力位 `file-input`**(`internal/models/types.go`)
与 `vision` 独立——"模型能看图" ≠ "API 收文件"(DeepSeek 有视觉但无
文件入口)。三个来源:官方模板(openai/anthropic/google.yaml)预置;
`cmd/synccaps` 从 LiteLLM 注册表按 `supports_pdf_input` 每周增量同步
(仅在已有 vision 时插入);web 模型编辑框手动勾选(i18n 中/英/日)。
自定义 provider **刻意默认不勾**:第三方 OpenAI 兼容网关普遍静默丢文件
部件(实测某转发站:带完整 PDF 的请求 `prompt_tokens: 21`,文件根本没
到模型)。

**② 首轮路由**(`internal/agent/application/capability_policy.go`)
- PDF + 勾了能力 + 内联传输 + ≤ **12 MiB** → 原生;
- 小文本(`text/*`、`application/json` ≤ 64 KiB)→ 无条件内联为转义文本;
- 其余 → 工作区路径降级;消息头两种情形都保留 `<attachment path=…>`;
- 单请求预算 **14 MiB**(二进制),超了从最大附件开始降级;
- 数字依据见下面"为什么是 12MB"。

**为什么是 12MB(而不是 20/30MB)**

各厂商现行上限(2026-08 逐条核对官方文档,全表见
`provider-file-input-limits.md`):

| 厂商 | 上限口径 |
|---|---|
| Anthropic | **整请求 32MB**(附件 base64 + 历史 + 系统提示 + 工具定义全算)——现行最紧;走 Bedrock 只有 20MB、Vertex 30MB |
| Gemini | inline 整请求 100MB(2026-01 才从 20MB 提上来,官方文档仍有 20MB 残留文案);PDF 单文件 50MB |
| OpenAI | 请求内文件合计 50MB |

推导(以最紧的 Anthropic 32MB 整请求为约束):

```
限 12MB:12MB 文件 → base64 后 16MB → 32-16 = 留 16MB 给历史+提示词+工具
         → 长对话也稳
若 20MB:20MB → base64 26.7MB → 只剩 5.3MB
         → 聊到十几轮历史变长后突然开始报错,且之后每轮都错
         → 且 base64 后已超 Bedrock 整包 20MB,文件单独放都放不下
```

另外三个压舱理由:agent 每调一次工具整个请求(含文件)就重发一次,
×步数×并发是实打实的带宽/内存放大;12MB 的 PDF 摄入后已是十万 token
量级,再大就顶穿上下文;Gemini 文档自相矛盾期不宜贴线。宁可上传时明确
提示"文件太大",不让用户聊到一半莫名爆炸。更大的文件正路是 Files API
`file_id` 引用(传一次、每轮引用,已列入延后清单)。

**③ 后续轮次重读**(`internal/agent/tool/read_media.go`、`container.go`)
read 工具支持 `application/pdf`(同 12 MiB 上限),以待注入 FilePart
喂回模型,受会话 `SupportsFileInput` 门控;不支持时返回明确报错并禁止
模型自装解析器,而不是倒原始字节。

**④ 落库占位符**(`internal/agent/application/service_messages.go`)
FilePart 落库时替换为占位文本("本轮已展示给模型,字节不持久化,重看
用 read 工具")。历史保持纯文本,token 估算/压缩/水合不受影响。
**无 DB 迁移。**

**⑤ 前端**(`apps/web` chat-pane + compatibilities + i18n)
所选模型没勾能力时上传 PDF 当场弹提示;ACP 会话豁免。

### Memoh-Cloud(独立的第三个 PR,前两个合并后再提)

- llm-relay 格式转换补文件部件:`{"type":"file"}` → Anthropic
  `document` 块 / Gemini `inlineData`,OpenAI 上游原样透传;
- 平台管理台能力词表补 `file-input`(白名单 + 管理台复选框),让能力
  从平台目录经 relay 自动流到各 team 的模型列表。

---

## 四、测试与人工验证

- **单测**:twilight 每家适配器 golden 测试;Memoh 路由分流(能力/大小
  /预算降级)、占位符(写时复制不改输入)、内容转义(正文含
  `</attachment`)、read 门控、synccaps 增量规则;
- **全量**:两仓均已合并最新 main(零冲突),`go test ./...`、web
  vitest(1001 个)、`vue-tsc` 全绿;
- **人工验证(部署实例走通)**:能力提示 toast;不支持模型的路径降级
  (agent 仍靠 shell 工具答出);原生端到端——web 上传 PDF 以文件部件
  抵达 OpenAI 兼容上游,模型一轮按文档内容作答,过程无
  `pdfinfo`/`python` 动作;落库历史可见占位符。
  未覆盖:Anthropic/Gemini 直连(测试机出口受地域限制,仅 golden 兜底)。

---

## 五、边界、遗留与注意事项

**本期只做 PDF**。格式扩展点收敛在 `isNativeDocumentMime` 白名单一处,
其他格式(docx 等)需逐个核实厂商支持面后单独开。

**明确延后**(设计阶段裁决):页数护栏(现只管字节,几百页文本 PDF 靠
厂商报错兜底,建议值 50 页)、PDF 转图处理器、read 页码范围、大文件走
Files API(file_id 引用)、插话消息带附件。

**已知 UX 空白**:超 12MB 静默降级,前端暂无"文件太大"提示(只有
"模型不支持"提示),待补一条 toast。

**提交注意**:
1. 顺序:twilight PR 合并 → 发版 → Memoh `go get` bump → 提 Memoh PR;
2. 两仓 PR 需按新规矩披露人工 QA 状态,上文第四节如实覆盖 happy path;
3. 部署分支(`deploy/srv25-*`、`deploy/cloud25-*`)不推。
