### PR TITLE
perf(provider): use strings.Builder for streamed tool-arg accumulation

### DIFF
--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -815,7 +815,7 @@ func (h *streamHandler) onBlockDelta(event *streamEvent) {
 		h.send(&sdk.ReasoningDeltaPart{ID: h.messageID, Text: delta.Thinking})
 	case "input_json_delta":
 		if sb != nil {
-			sb.args += delta.PartialJSON
+			sb.args.WriteString(delta.PartialJSON)
 			h.send(&sdk.ToolInputDeltaPart{
 				ID:    sb.toolID,
 				Delta: delta.PartialJSON,
@@ -823,7 +823,7 @@ func (h *streamHandler) onBlockDelta(event *streamEvent) {
 		}
 	case "signature_delta":
 		if sb != nil {
-			sb.signature += delta.Signature
+			sb.signature.WriteString(delta.Signature)
 		}
 	}
 }
@@ -844,17 +844,17 @@ func (h *streamHandler) onBlockStop(event *streamEvent) {
 		h.send(&sdk.TextEndPart{ID: h.messageID})
 	case blockTypeThinking:
 		var meta map[string]any
-		if sb.signature != "" {
+		if sb.signature.Len() > 0 {
 			meta = map[string]any{
-				"anthropic": map[string]any{"signature": sb.signature},
+				"anthropic": map[string]any{"signature": sb.signature.String()},
 			}
 		}
 		h.send(&sdk.ReasoningEndPart{ID: h.messageID, ProviderMetadata: meta})
 	case blockTypeToolUse:
 		h.send(&sdk.ToolInputEndPart{ID: sb.toolID})
 		var input any
-		if sb.args != "" {
-			if err := json.Unmarshal([]byte(sb.args), &input); err != nil {
+		if sb.args.Len() > 0 {
+			if err := json.Unmarshal([]byte(sb.args.String()), &input); err != nil {
 				h.send(&sdk.ErrorPart{Error: fmt.Errorf("anthropic: unmarshal tool args for %q: %w", sb.toolName, err)})
 			}
 		}
@@ -894,12 +894,17 @@ func (h *streamHandler) onError(event *streamEvent) {
 	h.send(&sdk.ErrorPart{Error: fmt.Errorf("anthropic: stream error: %s", errMsg)})
 }
 
+// streamingBlock accumulates one content block's deltas. args and signature
+// grow by one small delta per SSE event, so they use strings.Builder — plain
+// string concatenation would copy the accumulated prefix on every event,
+// quadratic in the payload size. Blocks are always held by pointer
+// (activeBlocks map), which the Builders' no-copy requirement relies on.
 type streamingBlock struct {
 	blockType string
 	toolID    string
 	toolName  string
-	args      string
-	signature string
+	args      strings.Builder
+	signature strings.Builder
 }
 
 // ---------- helpers ----------

--- a/provider/github/copilot/copilot.go
+++ b/provider/github/copilot/copilot.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/memohai/twilight-ai/internal/messagecompat"
@@ -444,10 +445,13 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 	return &sdk.StreamResult{Stream: ch}, nil
 }
 
+// streamingToolCall accumulates one function call's argument deltas. args
+// uses strings.Builder because it grows by one small delta per SSE event;
+// instances are always held by pointer (pendingToolCalls map).
 type streamingToolCall struct {
 	id       string
 	name     string
-	args     string
+	args     strings.Builder
 	finished bool
 }
 

--- a/provider/github/copilot/stream.go
+++ b/provider/github/copilot/stream.go
@@ -65,7 +65,7 @@ func (sp *streamProcessor) finishToolCall(stc *streamingToolCall) {
 	}
 	sp.send(&sdk.ToolInputEndPart{ID: stc.id})
 	var input any
-	if err := json.Unmarshal([]byte(stc.args), &input); err != nil {
+	if err := json.Unmarshal([]byte(stc.args.String()), &input); err != nil {
 		sp.send(&sdk.ErrorPart{Error: fmt.Errorf("github-copilot: unmarshal tool call arguments for %q: %w", stc.name, err)})
 	}
 	sp.send(&sdk.StreamToolCallPart{
@@ -148,13 +148,13 @@ func (sp *streamProcessor) processToolCallDeltas(toolCalls []chatToolCallChunk, 
 			})
 		}
 		if tc.Function.Arguments != "" {
-			stc.args += tc.Function.Arguments
+			stc.args.WriteString(tc.Function.Arguments)
 			sp.send(&sdk.ToolInputDeltaPart{
 				ID:    stc.id,
 				Delta: tc.Function.Arguments,
 			})
 
-			if !stc.finished && json.Valid([]byte(stc.args)) {
+			if !stc.finished && json.Valid([]byte(stc.args.String())) {
 				sp.finishToolCall(stc)
 			}
 		}

--- a/provider/openai/codex/codex.go
+++ b/provider/openai/codex/codex.go
@@ -273,7 +273,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 				if stc == nil {
 					return nil
 				}
-				stc.args += chunk.Delta
+				stc.args.WriteString(chunk.Delta)
 				send(&sdk.ToolInputDeltaPart{ID: stc.id, Delta: chunk.Delta})
 
 			case "response.output_item.done":
@@ -299,7 +299,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 						send(&sdk.ToolInputEndPart{ID: stc.id})
 						args := chunk.Item.Arguments
 						if args == "" {
-							args = stc.args
+							args = stc.args.String()
 						}
 						var input any
 						if err := json.Unmarshal([]byte(args), &input); err != nil {

--- a/provider/openai/codex/shared.go
+++ b/provider/openai/codex/shared.go
@@ -23,10 +23,13 @@ const (
 	openAIAuthClaimPath    = "https://api.openai.com/auth"
 )
 
+// streamingToolCall accumulates one function call's argument deltas. args
+// uses strings.Builder because it grows by one small delta per SSE event;
+// instances are always held by pointer (pendingToolCalls map).
 type streamingToolCall struct {
 	id       string
 	name     string
-	args     string
+	args     strings.Builder
 	finished bool
 }
 

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -616,10 +616,13 @@ func (p *Provider) authHeaders() map[string]string {
 	return utils.AuthHeader(p.apiKey)
 }
 
+// streamingToolCall accumulates one function call's argument deltas. args
+// uses strings.Builder because it grows by one small delta per SSE event;
+// instances are always held by pointer (pendingToolCalls map).
 type streamingToolCall struct {
 	id       string
 	name     string
-	args     string
+	args     strings.Builder
 	finished bool
 }
 

--- a/provider/openai/completions/stream.go
+++ b/provider/openai/completions/stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/memohai/twilight-ai/sdk"
@@ -24,7 +25,7 @@ type streamProcessor struct {
 	finishStepPending  bool
 	pendingToolCalls   map[int]*streamingToolCall
 	reasoningDetails   []chatReasoningDetail
-	reasoningText      string
+	reasoningText      strings.Builder
 }
 
 func (sp *streamProcessor) send(part sdk.StreamPart) bool {
@@ -68,7 +69,7 @@ func (sp *streamProcessor) finishToolCall(stc *streamingToolCall) {
 	}
 	sp.send(&sdk.ToolInputEndPart{ID: stc.id})
 	var input any
-	if err := json.Unmarshal([]byte(stc.args), &input); err != nil {
+	if err := json.Unmarshal([]byte(stc.args.String()), &input); err != nil {
 		sp.send(&sdk.ErrorPart{Error: fmt.Errorf("openai: unmarshal tool call arguments for %q: %w", stc.name, err)})
 	}
 	sp.send(&sdk.StreamToolCallPart{
@@ -110,9 +111,11 @@ func (sp *streamProcessor) processReasoning(delta *chatChunkDelta, chunkID strin
 		return
 	}
 	if len(delta.ReasoningDetails) > 0 {
-		reasoningContent = trimReasoningPrefix(reasoningContent, sp.reasoningText)
-		sp.reasoningText += reasoningContent
-		sp.reasoningDetails = reasoningDetailsWithText(delta.ReasoningDetails, sp.reasoningText)
+		// Builder.String() is a zero-copy view, so the per-delta reads below
+		// stay O(1) while appends stay amortized O(1).
+		reasoningContent = trimReasoningPrefix(reasoningContent, sp.reasoningText.String())
+		sp.reasoningText.WriteString(reasoningContent)
+		sp.reasoningDetails = reasoningDetailsWithText(delta.ReasoningDetails, sp.reasoningText.String())
 	}
 	if reasoningContent == "" {
 		return
@@ -178,13 +181,13 @@ func (sp *streamProcessor) processToolCallDeltas(toolCalls []chatToolCallChunk, 
 			})
 		}
 		if tc.Function.Arguments != "" {
-			stc.args += tc.Function.Arguments
+			stc.args.WriteString(tc.Function.Arguments)
 			sp.send(&sdk.ToolInputDeltaPart{
 				ID:    stc.id,
 				Delta: tc.Function.Arguments,
 			})
 
-			if !stc.finished && json.Valid([]byte(stc.args)) {
+			if !stc.finished && json.Valid([]byte(stc.args.String())) {
 				sp.finishToolCall(stc)
 			}
 		}

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -653,7 +653,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 				if stc == nil {
 					return nil
 				}
-				stc.args += chunk.Delta
+				stc.args.WriteString(chunk.Delta)
 				send(&sdk.ToolInputDeltaPart{
 					ID:    stc.id,
 					Delta: chunk.Delta,
@@ -682,7 +682,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 						send(&sdk.ToolInputEndPart{ID: stc.id})
 						args := chunk.Item.Arguments
 						if args == "" {
-							args = stc.args
+							args = stc.args.String()
 						}
 						var input any
 						if err := json.Unmarshal([]byte(args), &input); err != nil {

--- a/provider/openai/responses/shared.go
+++ b/provider/openai/responses/shared.go
@@ -5,15 +5,19 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/memohai/twilight-ai/internal/utils"
 	"github.com/memohai/twilight-ai/sdk"
 )
 
+// streamingToolCall accumulates one function call's argument deltas. args
+// uses strings.Builder because it grows by one small delta per SSE event;
+// instances are always held by pointer (pendingToolCalls map).
 type streamingToolCall struct {
 	id       string
 	name     string
-	args     string
+	args     strings.Builder
 	finished bool
 }
 


### PR DESCRIPTION
## Summary

Streaming handlers accumulated function-call argument JSON (and Anthropic thinking signatures, and completions reasoning text) with string `+=`, one append per SSE delta. Each `+=` copies the accumulated prefix, so total copying grows quadratically with delta count. Tool arguments are the largest per-delta accumulation in the SDK: a tool call carrying a 50KB file arrives as ~2500 deltas at ~20 bytes each.

Measured on that accumulation shape (Apple Silicon, Go 1.24):

| payload / deltas | `+=` time | `+=` alloc | Builder time | Builder alloc |
|---|---|---|---|---|
| 2KB / 100 | 9.2 µs | 105 KB | 0.8 µs | 7 KB |
| 10KB / 500 | 225 µs | 2.5 MB | 4.2 µs | 44 KB |
| 50KB / 2500 | 4.0 ms | 64 MB | 19 µs | 205 KB |
| 200KB / 10000 | 66 ms | 988 MB | 78 µs | 886 KB |

The allocation volume is the dominant cost for a long-running server: it is pure GC pressure on every large tool call.

## Changed accumulation fields

All held by pointer, so the Builder's no-copy requirement holds:

- `anthropic/messages`: `streamingBlock.args`, `streamingBlock.signature`
- `openai/responses`, `openai/codex`, `openai/completions`, `github/copilot`: `streamingToolCall.args`
- `openai/completions`: `streamProcessor.reasoningText` (read per delta by `trimReasoningPrefix`/`reasoningDetailsWithText`; `Builder.String()` is a zero-copy view, so those reads stay O(1))

## Notes

- completions and copilot call `json.Valid` on the accumulated args after every delta to detect completion; that full scan is unchanged by this commit — only the append cost drops.
- No behavior change. 28 packages pass, `go vet` clean.
- Independent of the deferred-approvals stack (no file overlap).