### PR TITLE
refactor(sdk): extract shared multi-step tool loop

### DIFF
--- a/sdk/generate_text.go
+++ b/sdk/generate_text.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"context"
-	"errors"
 )
 
 func (c *Client) GenerateText(ctx context.Context, options ...GenerateOption) (string, error) {
@@ -21,145 +20,41 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 		return nil, err
 	}
 
-	// MaxSteps == 0: single call, no tool auto-execution.
-	if cfg.MaxSteps == 0 {
-		result, err := prov.DoGenerate(ctx, cfg.Params)
-		if err != nil {
-			return nil, err
-		}
-		stepMsgs := buildStepMessages(result.Text, result.Reasoning, result.ReasoningProviderMetadata, result.ToolCalls, nil, &result.Usage)
-		step := StepResult{
-			Text:            result.Text,
-			Reasoning:       result.Reasoning,
-			FinishReason:    result.FinishReason,
-			RawFinishReason: result.RawFinishReason,
-			Usage:           result.Usage,
-			ToolCalls:       result.ToolCalls,
-			Response:        result.Response,
-			Messages:        stepMsgs,
-		}
-		if err := applyOnStepCommitted(ctx, cfg, 0, &step); err != nil {
-			return nil, err
-		}
-		result.Steps = []StepResult{step}
-		result.Messages = stepMsgs
-		applyOnStep(cfg, &step)
-		if cfg.OnFinish != nil {
-			cfg.OnFinish(result)
-		}
-		return result, nil
-	}
-
-	toolMap := buildToolMap(cfg.Params.Tools)
-	messages := make([]Message, len(cfg.Params.Messages))
-	copy(messages, cfg.Params.Messages)
-
-	var (
-		totalUsage  Usage
-		lastResult  *GenerateResult
-		allSteps    []StepResult
-		allMessages []Message
-	)
-
-	for step := 0; shouldContinueLoop(cfg.MaxSteps, step); step++ {
-		if step > 0 {
-			messages = applyPrepareStep(cfg, messages)
-		}
-
-		params := cfg.Params
-		params.Messages = messages
-
+	// The shared loop owns the state machine for every configuration —
+	// MaxSteps == 0 runs it for exactly one call with no tool execution.
+	// This transport only performs blocking provider calls and keeps the raw
+	// provider result so the final return value preserves provider-specific
+	// fields (sources, files, response metadata).
+	var lastResult *GenerateResult
+	doStep := func(_ int, params GenerateParams) (stepOutcome, error) {
 		result, err := prov.DoGenerate(ctx, params)
 		if err != nil {
-			return nil, err
+			return stepOutcome{}, err
 		}
 		lastResult = result
-		totalUsage = addUsage(&totalUsage, &result.Usage)
+		return stepOutcome{
+			text:            result.Text,
+			reasoning:       result.Reasoning,
+			reasoningMeta:   result.ReasoningProviderMetadata,
+			toolCalls:       result.ToolCalls,
+			usage:           result.Usage,
+			response:        result.Response,
+			finishReason:    result.FinishReason,
+			rawFinishReason: result.RawFinishReason,
+		}, nil
+	}
 
-		// No tool calls or not a tool-calls finish → final step
-		if result.FinishReason != FinishReasonToolCalls || len(result.ToolCalls) == 0 || !hasExecutableTools(result.ToolCalls, toolMap) {
-			stepMsgs := buildStepMessages(result.Text, result.Reasoning, result.ReasoningProviderMetadata, result.ToolCalls, nil, &result.Usage)
-			sr := StepResult{
-				Text:            result.Text,
-				Reasoning:       result.Reasoning,
-				FinishReason:    result.FinishReason,
-				RawFinishReason: result.RawFinishReason,
-				Usage:           result.Usage,
-				ToolCalls:       result.ToolCalls,
-				Response:        result.Response,
-				Messages:        stepMsgs,
-			}
-			if err := applyOnStepCommitted(ctx, cfg, step, &sr); err != nil {
-				return nil, err
-			}
-			allSteps = append(allSteps, sr)
-			allMessages = append(allMessages, stepMsgs...)
-			applyOnStep(cfg, &sr)
-			break
-		}
-
-		// Execute tools
-		toolResults, err := executeTools(ctx, result.ToolCalls, toolMap, cfg.ApprovalHandler, nil)
-		if err != nil {
-			var deferred *ToolApprovalDeferredError
-			if errors.As(err, &deferred) {
-				stepMsgs := buildStepMessages(result.Text, result.Reasoning, result.ReasoningProviderMetadata, result.ToolCalls, nil, &result.Usage)
-				sr := StepResult{
-					Text:                 result.Text,
-					Reasoning:            result.Reasoning,
-					FinishReason:         result.FinishReason,
-					RawFinishReason:      result.RawFinishReason,
-					Usage:                result.Usage,
-					ToolCalls:            result.ToolCalls,
-					Response:             result.Response,
-					DeferredToolApproval: &deferred.Approval,
-					Messages:             stepMsgs,
-				}
-				if err := applyOnStepCommitted(ctx, cfg, step, &sr); err != nil {
-					return nil, err
-				}
-				allSteps = append(allSteps, sr)
-				allMessages = append(allMessages, stepMsgs...)
-				applyOnStep(cfg, &sr)
-				result.DeferredToolApproval = &deferred.Approval
-				break
-			}
-			return nil, err
-		}
-
-		stepMsgs := buildStepMessages(result.Text, result.Reasoning, result.ReasoningProviderMetadata, result.ToolCalls, toolResults, &result.Usage)
-		sr := StepResult{
-			Text:            result.Text,
-			Reasoning:       result.Reasoning,
-			FinishReason:    result.FinishReason,
-			RawFinishReason: result.RawFinishReason,
-			Usage:           result.Usage,
-			ToolCalls:       result.ToolCalls,
-			ToolResults:     toolCallResultsFromParts(toolResults),
-			Response:        result.Response,
-			Messages:        stepMsgs,
-		}
-		if err := applyOnStepCommitted(ctx, cfg, step, &sr); err != nil {
-			return nil, err
-		}
-		allSteps = append(allSteps, sr)
-		allMessages = append(allMessages, stepMsgs...)
-		applyOnStep(cfg, &sr)
-
-		messages = append(messages, stepMsgs...)
+	st, err := runToolLoop(ctx, cfg, doStep, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	if lastResult != nil {
-		lastResult.Usage = totalUsage
-		lastResult.Steps = allSteps
-		lastResult.Messages = allMessages
+		lastResult.Usage = st.totalUsage
+		lastResult.Steps = st.steps
+		lastResult.Messages = st.messages
 		if lastResult.DeferredToolApproval == nil {
-			for i := range allSteps {
-				if allSteps[i].DeferredToolApproval != nil {
-					lastResult.DeferredToolApproval = allSteps[i].DeferredToolApproval
-					break
-				}
-			}
+			lastResult.DeferredToolApproval = st.deferredToolApproval()
 		}
 	}
 

--- a/sdk/stream_text.go
+++ b/sdk/stream_text.go
@@ -6,6 +6,11 @@ import (
 	"fmt"
 )
 
+// errLoopAborted signals that the stream consumer went away and the loop
+// should stop without reporting an error. Produced and consumed only by this
+// transport.
+var errLoopAborted = errors.New("twilightai: stream consumer gone")
+
 // StreamText returns a streaming result. When MaxSteps != 0 and tools have
 // Execute handlers, the client orchestrates a multi-step loop, forwarding all
 // stream parts (including ToolProgressPart) through a single channel.
@@ -23,15 +28,11 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 	if cfg.MaxSteps == 0 && cfg.OnStepCommitted == nil {
 		return prov.DoStream(ctx, cfg.Params)
 	}
-	autoExecuteTools := cfg.MaxSteps != 0
-	maxSteps := cfg.MaxSteps
-	if maxSteps == 0 {
-		maxSteps = 1
-	}
 
-	toolMap := buildToolMap(cfg.Params.Tools)
-	messages := make([]Message, len(cfg.Params.Messages))
-	copy(messages, cfg.Params.Messages)
+	// Snapshot the conversation before returning: the caller may reuse or
+	// mutate its slice after StreamText returns, and the loop goroutine must
+	// not race with that.
+	cfg.Params.Messages = append([]Message(nil), cfg.Params.Messages...)
 
 	ch := make(chan StreamPart, 64)
 	sr := &StreamResult{Stream: ch}
@@ -46,61 +47,37 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 			}
 		}
 
-		var totalUsage Usage
-		var lastFinishReason FinishReason
-		var lastRawFinishReason string
-		var allSteps []StepResult
-		var allMessages []Message
+		// The shared loop owns the state machine; this transport performs one
+		// DoStream call per step, forwarding every part to the consumer while
+		// folding them into the step outcome.
+		var st toolLoopState
 		defer func() {
-			sr.Steps = allSteps
-			sr.Messages = allMessages
-			for i := range allSteps {
-				if allSteps[i].DeferredToolApproval != nil {
-					sr.DeferredToolApproval = allSteps[i].DeferredToolApproval
-					break
-				}
-			}
+			sr.Steps = st.steps
+			sr.Messages = st.messages
+			sr.DeferredToolApproval = st.deferredToolApproval()
 			close(ch)
 		}()
 
-		for step := 0; shouldContinueLoop(maxSteps, step); step++ {
-			if step > 0 {
-				messages = applyPrepareStep(cfg, messages)
-			}
-
-			params := cfg.Params
-			params.Messages = messages
-
+		doStep := func(stepIndex int, params GenerateParams) (stepOutcome, error) {
 			provSR, err := prov.DoStream(ctx, params)
 			if err != nil {
-				send(&ErrorPart{Error: fmt.Errorf("twilightai: stream step %d: %w", step, err)})
-				return
+				return stepOutcome{}, fmt.Errorf("twilightai: stream step %d: %w", stepIndex, err)
 			}
 
-			var (
-				stepText            string
-				stepReasoning       string
-				stepReasoningMeta   map[string]any
-				stepToolCalls       []ToolCall
-				stepUsage           Usage
-				stepResponse        ResponseMetadata
-				stepFinishReason    FinishReason
-				stepRawFinishReason string
-				sawFinishStep       bool
-			)
-
+			var out stepOutcome
+			sawFinishStep := false
 			for part := range provSR.Stream {
 				switch p := part.(type) {
 				case *TextDeltaPart:
-					stepText += p.Text
+					out.text += p.Text
 				case *ReasoningDeltaPart:
-					stepReasoning += p.Text
+					out.reasoning += p.Text
 				case *ReasoningEndPart:
 					if p.ProviderMetadata != nil {
-						stepReasoningMeta = p.ProviderMetadata
+						out.reasoningMeta = p.ProviderMetadata
 					}
 				case *StreamToolCallPart:
-					stepToolCalls = append(stepToolCalls, ToolCall{
+					out.toolCalls = append(out.toolCalls, ToolCall{
 						ToolCallID:       p.ToolCallID,
 						ToolName:         p.ToolName,
 						Input:            p.Input,
@@ -108,131 +85,54 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 					})
 				case *FinishStepPart:
 					sawFinishStep = true
-					stepUsage = p.Usage
-					stepResponse = p.Response
-					stepFinishReason = p.FinishReason
-					stepRawFinishReason = p.RawFinishReason
+					out.usage = p.Usage
+					out.response = p.Response
+					out.finishReason = p.FinishReason
+					out.rawFinishReason = p.RawFinishReason
 				case *FinishPart:
-					stepFinishReason = p.FinishReason
-					stepRawFinishReason = p.RawFinishReason
+					out.finishReason = p.FinishReason
+					out.rawFinishReason = p.RawFinishReason
 					continue
 				}
 
 				if !send(part) {
-					return
+					return stepOutcome{}, errLoopAborted
 				}
 			}
 			if !sawFinishStep {
-				if ctx.Err() == nil {
-					send(&ErrorPart{Error: fmt.Errorf("twilightai: stream step %d ended before finish-step", step)})
+				if ctx.Err() != nil {
+					return stepOutcome{}, errLoopAborted
 				}
-				return
+				return stepOutcome{}, fmt.Errorf("twilightai: stream step %d ended before finish-step", stepIndex)
 			}
+			return out, nil
+		}
 
-			lastFinishReason = stepFinishReason
-			lastRawFinishReason = stepRawFinishReason
-			totalUsage = addUsage(&totalUsage, &stepUsage)
-
-			// No tool calls or not a tool-calls finish → done
-			if !autoExecuteTools || stepFinishReason != FinishReasonToolCalls || len(stepToolCalls) == 0 || !hasExecutableTools(stepToolCalls, toolMap) {
-				stepMsgs := buildStepMessages(stepText, stepReasoning, stepReasoningMeta, stepToolCalls, nil, &stepUsage)
-				stepR := StepResult{
-					Text:            stepText,
-					Reasoning:       stepReasoning,
-					FinishReason:    stepFinishReason,
-					RawFinishReason: stepRawFinishReason,
-					Usage:           stepUsage,
-					ToolCalls:       stepToolCalls,
-					Response:        stepResponse,
-					Messages:        stepMsgs,
-				}
-				if err := applyOnStepCommitted(ctx, cfg, step, &stepR); err != nil {
-					send(&ErrorPart{Error: err})
-					return
-				}
-				allSteps = append(allSteps, stepR)
-				allMessages = append(allMessages, stepMsgs...)
-				applyOnStep(cfg, &stepR)
-				break
-			}
-
-			// Execute tools
-			sendProgress := func(part StreamPart) { send(part) }
-			toolResults, err := executeTools(ctx, stepToolCalls, toolMap, cfg.ApprovalHandler, sendProgress)
-			if err != nil {
-				var deferred *ToolApprovalDeferredError
-				if errors.As(err, &deferred) {
-					stepMsgs := buildStepMessages(stepText, stepReasoning, stepReasoningMeta, stepToolCalls, nil, &stepUsage)
-					stepR := StepResult{
-						Text:                 stepText,
-						Reasoning:            stepReasoning,
-						FinishReason:         stepFinishReason,
-						RawFinishReason:      stepRawFinishReason,
-						Usage:                stepUsage,
-						ToolCalls:            stepToolCalls,
-						Response:             stepResponse,
-						DeferredToolApproval: &deferred.Approval,
-						Messages:             stepMsgs,
-					}
-					if err := applyOnStepCommitted(ctx, cfg, step, &stepR); err != nil {
-						send(&ErrorPart{Error: err})
-						return
-					}
-					allSteps = append(allSteps, stepR)
-					allMessages = append(allMessages, stepMsgs...)
-					applyOnStep(cfg, &stepR)
-					break
-				}
+		var err error
+		st, err = runToolLoop(ctx, cfg, doStep, func(part StreamPart) { send(part) })
+		if err != nil {
+			if !errors.Is(err, errLoopAborted) {
 				send(&ErrorPart{Error: err})
-				return
 			}
-
-			stepMsgs := buildStepMessages(stepText, stepReasoning, stepReasoningMeta, stepToolCalls, toolResults, &stepUsage)
-			stepR := StepResult{
-				Text:            stepText,
-				Reasoning:       stepReasoning,
-				FinishReason:    stepFinishReason,
-				RawFinishReason: stepRawFinishReason,
-				Usage:           stepUsage,
-				ToolCalls:       stepToolCalls,
-				ToolResults:     toolCallResultsFromParts(toolResults),
-				Response:        stepResponse,
-				Messages:        stepMsgs,
-			}
-			if err := applyOnStepCommitted(ctx, cfg, step, &stepR); err != nil {
-				send(&ErrorPart{Error: err})
-				return
-			}
-			allSteps = append(allSteps, stepR)
-			allMessages = append(allMessages, stepMsgs...)
-			applyOnStep(cfg, &stepR)
-
-			messages = append(messages, stepMsgs...)
+			return
 		}
 
 		if !send(&FinishPart{
-			FinishReason:    lastFinishReason,
-			RawFinishReason: lastRawFinishReason,
-			TotalUsage:      totalUsage,
+			FinishReason:    st.finishReason,
+			RawFinishReason: st.rawFinishReason,
+			TotalUsage:      st.totalUsage,
 		}) {
 			return
 		}
 
 		if cfg.OnFinish != nil {
-			var deferredToolApproval *ToolApprovalResult
-			for i := range allSteps {
-				if allSteps[i].DeferredToolApproval != nil {
-					deferredToolApproval = allSteps[i].DeferredToolApproval
-					break
-				}
-			}
 			cfg.OnFinish(&GenerateResult{
-				FinishReason:         lastFinishReason,
-				RawFinishReason:      lastRawFinishReason,
-				Usage:                totalUsage,
-				Steps:                allSteps,
-				Messages:             allMessages,
-				DeferredToolApproval: deferredToolApproval,
+				FinishReason:         st.finishReason,
+				RawFinishReason:      st.rawFinishReason,
+				Usage:                st.totalUsage,
+				Steps:                st.steps,
+				Messages:             st.messages,
+				DeferredToolApproval: st.deferredToolApproval(),
 			})
 		}
 	}()

--- a/sdk/tool_loop.go
+++ b/sdk/tool_loop.go
@@ -1,0 +1,160 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+)
+
+// stepOutcome is the transport-agnostic product of one provider call.
+// GenerateTextResult maps a DoGenerate response onto it directly; StreamText
+// folds the part stream into it while forwarding parts to the consumer.
+type stepOutcome struct {
+	text            string
+	reasoning       string
+	reasoningMeta   map[string]any
+	toolCalls       []ToolCall
+	usage           Usage
+	response        ResponseMetadata
+	finishReason    FinishReason
+	rawFinishReason string
+}
+
+// toolLoopState accumulates what a multi-step run produces. When runToolLoop
+// returns an error the state still holds everything committed before the
+// failing step; the streaming entry point exposes it, the blocking entry
+// point discards it (matching their historical behavior).
+type toolLoopState struct {
+	steps           []StepResult
+	messages        []Message
+	totalUsage      Usage
+	finishReason    FinishReason
+	rawFinishReason string
+}
+
+// deferredToolApproval returns the approval of the step that paused the run,
+// or nil if the run finished normally.
+func (st *toolLoopState) deferredToolApproval() *ToolApprovalResult {
+	for i := range st.steps {
+		if st.steps[i].DeferredToolApproval != nil {
+			return st.steps[i].DeferredToolApproval
+		}
+	}
+	return nil
+}
+
+// runToolLoop drives the multi-step tool-execution state machine shared by
+// GenerateTextResult and StreamText: call the model, execute requested tools,
+// feed results back, repeat until a non-tool finish, the step budget, a
+// deferred approval, or an error.
+//
+// The loop derives its behavior from cfg so the two transports cannot
+// diverge: cfg.MaxSteps == 0 means one provider call with no tool
+// auto-execution (the documented single-call mode; it reaches the loop when
+// a commit barrier or other loop-only feature is requested).
+//
+// doStep performs one provider call and folds it into a stepOutcome; the
+// streaming transport forwards parts to its consumer as a side effect and
+// returns an error wrapping context cancellation when the consumer is gone.
+// sendProgress forwards tool-execution parts (nil in blocking mode).
+//
+// Step indices are derived from committed state (len of steps), never from a
+// parallel counter: the index doStep and OnStepCommitted observe is always
+// the position the step will occupy in the result.
+func runToolLoop(
+	ctx context.Context,
+	cfg *generateConfig,
+	doStep func(stepIndex int, params GenerateParams) (stepOutcome, error),
+	sendProgress func(StreamPart),
+) (toolLoopState, error) {
+	var st toolLoopState
+	autoExecuteTools := cfg.MaxSteps != 0
+	maxSteps := cfg.MaxSteps
+	if maxSteps == 0 {
+		maxSteps = 1
+	}
+
+	toolMap := buildToolMap(cfg.Params.Tools)
+	messages := make([]Message, len(cfg.Params.Messages))
+	copy(messages, cfg.Params.Messages)
+
+	for iter := 0; shouldContinueLoop(maxSteps, iter); iter++ {
+		// Prepare before every model call that follows a committed step.
+		if len(st.steps) > 0 {
+			messages = applyPrepareStep(cfg, messages)
+		}
+
+		params := cfg.Params
+		params.Messages = messages
+
+		out, err := doStep(len(st.steps), params)
+		if err != nil {
+			return st, err
+		}
+		st.finishReason = out.finishReason
+		st.rawFinishReason = out.rawFinishReason
+		st.totalUsage = addUsage(&st.totalUsage, &out.usage)
+
+		// No executable tool calls (or execution disabled) → final step.
+		if !autoExecuteTools || out.finishReason != FinishReasonToolCalls || len(out.toolCalls) == 0 || !hasExecutableTools(out.toolCalls, toolMap) {
+			if _, err := st.commitStep(ctx, cfg, &out, nil, nil); err != nil {
+				return st, err
+			}
+			break
+		}
+
+		toolResults, err := executeTools(ctx, out.toolCalls, toolMap, cfg.ApprovalHandler, sendProgress)
+		if err != nil {
+			var deferred *ToolApprovalDeferredError
+			if errors.As(err, &deferred) {
+				if _, err := st.commitStep(ctx, cfg, &out, nil, &deferred.Approval); err != nil {
+					return st, err
+				}
+				break
+			}
+			return st, err
+		}
+
+		stepMsgs, err := st.commitStep(ctx, cfg, &out, toolResults, nil)
+		if err != nil {
+			return st, err
+		}
+		messages = append(messages, stepMsgs...)
+	}
+
+	return st, nil
+}
+
+// commitStep assembles the StepResult for one step, passes it through the
+// commit barrier, and records it. The step's index is its position in the
+// committed sequence. toolResults is nil for final and deferred steps;
+// deferredApproval is set only when the step paused on a tool approval.
+func (st *toolLoopState) commitStep(
+	ctx context.Context,
+	cfg *generateConfig,
+	out *stepOutcome,
+	toolResults []ToolResultPart,
+	deferredApproval *ToolApprovalResult,
+) ([]Message, error) {
+	stepMsgs := buildStepMessages(out.text, out.reasoning, out.reasoningMeta, out.toolCalls, toolResults, &out.usage)
+	sr := StepResult{
+		Text:                 out.text,
+		Reasoning:            out.reasoning,
+		FinishReason:         out.finishReason,
+		RawFinishReason:      out.rawFinishReason,
+		Usage:                out.usage,
+		ToolCalls:            out.toolCalls,
+		Response:             out.response,
+		DeferredToolApproval: deferredApproval,
+		Messages:             stepMsgs,
+	}
+	if len(toolResults) > 0 {
+		sr.ToolResults = toolCallResultsFromParts(toolResults)
+	}
+	if err := applyOnStepCommitted(ctx, cfg, len(st.steps), &sr); err != nil {
+		return nil, err
+	}
+	st.steps = append(st.steps, sr)
+	st.messages = append(st.messages, stepMsgs...)
+	applyOnStep(cfg, &sr)
+	return stepMsgs, nil
+}


### PR DESCRIPTION
## Background

`GenerateTextResult` and `StreamText` each carried a full copy of the multi-step tool loop: prepare-step callbacks, finish detection, tool execution, approval handling, the commit barrier, `StepResult` assembly, and message accumulation. Every semantic change to the loop required symmetric edits in two files, and the copies had already diverged (whether accumulated steps survive an error differs between the two paths).

## Changes

`runToolLoop` (`sdk/tool_loop.go`) owns the state machine; the entry points keep only their transport halves:

- **GenerateTextResult**: `doStep` maps one `DoGenerate` response onto a `stepOutcome`. Its separate `MaxSteps==0` fast path is gone — single-call mode runs through the same commit path, so the default configuration can no longer drift from `MaxSteps==1`.
- **StreamText**: `doStep` folds the provider part stream into a `stepOutcome` while forwarding every part. A departed consumer is expressed as `errLoopAborted`, declared next to its only producer and consumer.

Invariants pinned by the extraction:

1. Step indices derive from committed state (`len(st.steps)`) — no parallel counter exists, so `doStep`, `OnStepCommitted`, and `PrepareStep` observe the same numbering by construction.
2. Loop behavior (maxSteps normalization, tool auto-execution) derives from cfg inside the loop; the two transports cannot pass divergent values.
3. The conversation snapshot happens synchronously before `StreamText` returns (previously the copy ran inside the goroutine, racing with callers that mutate their message slice after the call).

## Behavior

No external behavior change. The pre-existing error-path difference between the two modes (generate discards accumulated steps; stream keeps them and emits an `ErrorPart`) is preserved in the transports. Single-deferred-approval semantics are also preserved — changed by the next PR in this stack.