### PR TITLE
feat(sdk): 安全补全延迟审批暂停会话

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -434,6 +434,20 @@ the paused model call, its output, and all calls still awaiting a decision.
 `BatchID` is set only for a pause produced through `WithApprovalBatchHandler`;
 it is a correlation ID, not an idempotency key.
 
+```go
+func CompleteToolApprovalPause(
+    pause *ToolApprovalPause,
+    results []ToolResultPart,
+) ([]Message, error)
+```
+
+Validates one final result for every pending call and returns a new,
+protocol-complete conversation. The function does not execute tools or call a
+model. Input results may be unordered; the appended tool message follows the
+original assistant tool-call order. Persist and reuse `pause.System` alongside
+the returned messages when continuing with `GenerateTextResult` or
+`StreamText`.
+
 #### ToolCall & ToolResult
 
 ```go

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -361,6 +361,45 @@ A normally paused run reports `FinishReasonPaused` on the overall result (and on
 
 The paused step's `Messages` include the assistant message with all tool calls plus a tool message covering only the already-resolved calls. `Pause.Pending` identifies the unresolved calls. Persisted JSON from older versions used the singular `deferredToolApproval` key, which this version no longer reads.
 
+### Completing a Paused Conversation
+
+Approval decisions, tool execution, and deferred interactions belong to the host. Once the host has obtained one final `ToolResultPart` for every pending call, `CompleteToolApprovalPause` validates the paused state and adds the completing tool message:
+
+```go
+// Load final outcomes from the host's trusted approval/execution records.
+// Those records, rather than pause.Pending, authorize any external side
+// effect and bind it to the host's workspace, fencing, and retry policy.
+results, err := approvalStore.FinalResults(ctx, pause.BatchID)
+if err != nil {
+    return err
+}
+
+completed, err := sdk.CompleteToolApprovalPause(pause, results)
+if err != nil {
+    return err
+}
+persist(pause.System, completed)
+```
+
+The function is pure conversation assembly: it does not execute tools, call a model, emit stream events, or persist data. It verifies that the final assistant tool-call message and existing tool results are well formed; that `Pause.Pending` is exactly the unresolved subset and still matches each call's ID, name, input, and provider metadata; and that the host supplied exactly one result for every pending call. Results may arrive in any order. The completing tool message follows the model's original call order. A result may omit `ToolName`, in which case the SDK fills the canonical name from the assistant call; a conflicting non-empty name is rejected.
+
+This validation protects the conversation assembled for the model. It happens after the host has obtained final results, so it is not an authorization check for side effects. Do not execute a deployment, payment, or other sensitive operation solely from an untrusted or manually assembled `pause.Pending`; authorize it from the host's trusted approval records and stored call identity.
+
+Persist both `pause.System` and `completed`. Continue with the ordinary generation API, explicitly restoring both values:
+
+```go
+stream, err := sdk.StreamText(ctx,
+    sdk.WithModel(model),
+    sdk.WithSystem(pause.System),
+    sdk.WithMessages(completed),
+    sdk.WithTools(tools),
+    sdk.WithMaxSteps(5),
+    sdk.WithApprovalHandler(handler), // future calls may require approval
+)
+```
+
+For deployments, payments, `ask_user`, and other durable workflows, the host owns execution policy, transactions, workspace targeting, fencing, idempotency, and recovery. `CompleteToolApprovalPause` does not provide exactly-once execution: in particular, it cannot close a crash window between an external side effect and persistence of the completed conversation. Its guarantee is narrower — malformed or incomplete tool protocol is rejected before a completed conversation is returned.
+
 ## Streaming with Tools
 
 Tool calling works seamlessly with `StreamText`. Progress updates from tool execution are delivered through the stream:

--- a/sdk/resume.go
+++ b/sdk/resume.go
@@ -1,0 +1,223 @@
+package sdk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// CompleteToolApprovalPause validates final results supplied by the host for
+// every pending call and returns a protocol-complete conversation.
+//
+// This function is deliberately limited to conversation assembly. It does not
+// decide approvals, execute tools, call a model, or persist anything. The host
+// remains responsible for those operations and may therefore apply its own
+// transactional, fencing, and retry guarantees before completing the pause.
+// Results may be provided in any order; the completing tool message follows
+// the original assistant tool-call order.
+func CompleteToolApprovalPause(pause *ToolApprovalPause, results []ToolResultPart) ([]Message, error) {
+	if pause == nil {
+		return nil, completePauseErrorf("pause is nil")
+	}
+	parsed, err := parseToolApprovalPause(pause)
+	if err != nil {
+		return nil, err
+	}
+
+	resultsByID := make(map[string]ToolResultPart, len(results))
+	for i, result := range results {
+		if result.ToolCallID == "" {
+			return nil, completePauseErrorf("results[%d] has an empty tool call ID", i)
+		}
+		if _, duplicate := resultsByID[result.ToolCallID]; duplicate {
+			return nil, completePauseErrorf("results contain duplicate tool call ID %q", result.ToolCallID)
+		}
+		call, pending := parsed.pendingByID[result.ToolCallID]
+		if !pending {
+			if _, resolved := parsed.existingResultIDs[result.ToolCallID]; resolved {
+				return nil, completePauseErrorf("tool call %q already has a result in pause.Messages", result.ToolCallID)
+			}
+			return nil, completePauseErrorf("result refers to unknown pending tool call %q", result.ToolCallID)
+		}
+		if result.ToolName != "" && result.ToolName != call.ToolName {
+			return nil, completePauseErrorf("result for tool call %q names tool %q; want %q", result.ToolCallID, result.ToolName, call.ToolName)
+		}
+		resultsByID[result.ToolCallID] = result
+	}
+
+	ordered := make([]ToolResultPart, len(parsed.pending))
+	for i, call := range parsed.pending {
+		result, ok := resultsByID[call.ToolCallID]
+		if !ok {
+			return nil, completePauseErrorf("missing result for pending tool call %q", call.ToolCallID)
+		}
+		result = cloneSDKValue(result)
+		result.ToolCallID = call.ToolCallID
+		result.ToolName = call.ToolName
+		ordered[i] = result
+	}
+
+	completed := make([]Message, 0, len(pause.Messages)+1)
+	completed = append(completed, clonePauseMessages(pause.Messages)...)
+	completed = append(completed, ToolMessage(ordered...))
+	return completed, nil
+}
+
+type parsedToolApprovalPause struct {
+	pending           []ToolCall
+	pendingByID       map[string]ToolCall
+	existingResultIDs map[string]struct{}
+}
+
+func parseToolApprovalPause(pause *ToolApprovalPause) (*parsedToolApprovalPause, error) {
+	if len(pause.Pending) == 0 {
+		return nil, completePauseErrorf("pause has no pending tool calls")
+	}
+	if len(pause.Messages) == 0 {
+		return nil, completePauseErrorf("pause has no messages")
+	}
+
+	assistantIndex := len(pause.Messages) - 1
+	for assistantIndex >= 0 && pause.Messages[assistantIndex].Role == MessageRoleTool {
+		assistantIndex--
+	}
+	if assistantIndex < 0 || pause.Messages[assistantIndex].Role != MessageRoleAssistant {
+		return nil, completePauseErrorf("pause.Messages must end with an assistant tool-call message followed only by tool messages")
+	}
+
+	calls := make([]ToolCall, 0)
+	callIndexByID := make(map[string]int)
+	for partIndex, part := range pause.Messages[assistantIndex].Content {
+		callPart, ok := part.(ToolCallPart)
+		if !ok {
+			if _, isResult := part.(ToolResultPart); isResult {
+				return nil, completePauseErrorf("assistant message contains a tool result at content index %d", partIndex)
+			}
+			continue
+		}
+		if callPart.ToolCallID == "" {
+			return nil, completePauseErrorf("assistant tool call at content index %d has an empty ID", partIndex)
+		}
+		if callPart.ToolName == "" {
+			return nil, completePauseErrorf("assistant tool call %q has an empty tool name", callPart.ToolCallID)
+		}
+		if _, duplicate := callIndexByID[callPart.ToolCallID]; duplicate {
+			return nil, completePauseErrorf("assistant message contains duplicate tool call ID %q", callPart.ToolCallID)
+		}
+		callIndexByID[callPart.ToolCallID] = len(calls)
+		calls = append(calls, ToolCall{
+			ToolCallID:       callPart.ToolCallID,
+			ToolName:         callPart.ToolName,
+			Input:            callPart.Input,
+			ProviderMetadata: callPart.ProviderMetadata,
+		})
+	}
+	if len(calls) == 0 {
+		return nil, completePauseErrorf("final assistant message contains no tool calls")
+	}
+
+	existingResultIDs := make(map[string]struct{})
+	lastCallIndex := -1
+	for messageIndex := assistantIndex + 1; messageIndex < len(pause.Messages); messageIndex++ {
+		message := pause.Messages[messageIndex]
+		if len(message.Content) == 0 {
+			return nil, completePauseErrorf("tool message at index %d is empty", messageIndex)
+		}
+		for partIndex, part := range message.Content {
+			result, ok := part.(ToolResultPart)
+			if !ok {
+				return nil, completePauseErrorf("tool message at index %d contains a non-tool-result part at content index %d", messageIndex, partIndex)
+			}
+			if result.ToolCallID == "" {
+				return nil, completePauseErrorf("existing tool result at message %d content %d has an empty tool call ID", messageIndex, partIndex)
+			}
+			if _, duplicate := existingResultIDs[result.ToolCallID]; duplicate {
+				return nil, completePauseErrorf("pause.Messages contains duplicate result for tool call %q", result.ToolCallID)
+			}
+			callIndex, known := callIndexByID[result.ToolCallID]
+			if !known {
+				return nil, completePauseErrorf("existing result refers to unknown tool call %q", result.ToolCallID)
+			}
+			call := calls[callIndex]
+			if result.ToolName == "" || result.ToolName != call.ToolName {
+				return nil, completePauseErrorf("existing result for tool call %q names tool %q; want %q", result.ToolCallID, result.ToolName, call.ToolName)
+			}
+			if callIndex <= lastCallIndex {
+				return nil, completePauseErrorf("existing tool results do not follow the assistant tool-call order at %q", result.ToolCallID)
+			}
+			lastCallIndex = callIndex
+			existingResultIDs[result.ToolCallID] = struct{}{}
+		}
+	}
+
+	pending := make([]ToolCall, 0, len(calls)-len(existingResultIDs))
+	for _, call := range calls {
+		if _, resolved := existingResultIDs[call.ToolCallID]; !resolved {
+			pending = append(pending, call)
+		}
+	}
+	if len(pending) != len(pause.Pending) {
+		return nil, completePauseErrorf("pause.Pending lists %d calls but pause.Messages leaves %d unresolved", len(pause.Pending), len(pending))
+	}
+
+	pendingByID := make(map[string]ToolCall, len(pending))
+	for i, call := range pending {
+		recorded := pause.Pending[i]
+		if recorded.Approval.Decision != ToolApprovalDecisionDeferred {
+			return nil, completePauseErrorf("pause.Pending[%d] for tool call %q has decision %q; want %q", i, recorded.ToolCall.ToolCallID, recorded.Approval.Decision, ToolApprovalDecisionDeferred)
+		}
+		if recorded.ToolCall.ToolCallID != call.ToolCallID {
+			return nil, completePauseErrorf("pause.Pending[%d] identifies tool call %q; want %q", i, recorded.ToolCall.ToolCallID, call.ToolCallID)
+		}
+		if recorded.ToolCall.ToolName != call.ToolName {
+			return nil, completePauseErrorf("pause.Pending[%d] for tool call %q names tool %q; want %q", i, call.ToolCallID, recorded.ToolCall.ToolName, call.ToolName)
+		}
+		if err := requireEquivalentJSON(recorded.ToolCall.Input, call.Input); err != nil {
+			return nil, completePauseErrorf("pause.Pending[%d] input for tool call %q does not match pause.Messages: %v", i, call.ToolCallID, err)
+		}
+		if err := requireEquivalentJSON(recorded.ToolCall.ProviderMetadata, call.ProviderMetadata); err != nil {
+			return nil, completePauseErrorf("pause.Pending[%d] provider metadata for tool call %q does not match pause.Messages: %v", i, call.ToolCallID, err)
+		}
+		pendingByID[call.ToolCallID] = call
+	}
+
+	return &parsedToolApprovalPause{
+		pending:           pending,
+		pendingByID:       pendingByID,
+		existingResultIDs: existingResultIDs,
+	}, nil
+}
+
+func requireEquivalentJSON(got, want any) error {
+	gotJSON, err := normalizeJSONValue(got)
+	if err != nil {
+		return fmt.Errorf("recorded value is not JSON-compatible: %w", err)
+	}
+	wantJSON, err := normalizeJSONValue(want)
+	if err != nil {
+		return fmt.Errorf("conversation value is not JSON-compatible: %w", err)
+	}
+	if !reflect.DeepEqual(gotJSON, wantJSON) {
+		return fmt.Errorf("values differ")
+	}
+	return nil
+}
+
+func normalizeJSONValue(value any) (any, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var normalized any
+	if err := decoder.Decode(&normalized); err != nil {
+		return nil, err
+	}
+	return normalized, nil
+}
+
+func completePauseErrorf(format string, args ...any) error {
+	return fmt.Errorf("twilightai: complete tool approval pause: "+format, args...)
+}

--- a/sdk/resume_test.go
+++ b/sdk/resume_test.go
@@ -1,0 +1,549 @@
+package sdk_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+func completionCall(id string) sdk.ToolCall {
+	switch id {
+	case "c1":
+		return sdk.ToolCall{
+			ToolCallID: "c1", ToolName: "lookup",
+			Input:            map[string]any{"service": "api"},
+			ProviderMetadata: map[string]any{"trace": map[string]any{"position": float64(1)}},
+		}
+	case "c2":
+		return sdk.ToolCall{
+			ToolCallID: "c2", ToolName: "deploy",
+			Input:            map[string]any{"env": "prod", "regions": []any{"nrt", "iad"}},
+			ProviderMetadata: map[string]any{"trace": map[string]any{"position": float64(2)}},
+		}
+	case "c3":
+		return sdk.ToolCall{
+			ToolCallID: "c3", ToolName: "ask_user",
+			Input:            map[string]any{"question": "Proceed?"},
+			ProviderMetadata: map[string]any{"trace": map[string]any{"position": float64(3)}},
+		}
+	default:
+		panic("unknown completion call: " + id)
+	}
+}
+
+func completionCallPart(id string) sdk.ToolCallPart {
+	call := completionCall(id)
+	return sdk.ToolCallPart{
+		ToolCallID:       call.ToolCallID,
+		ToolName:         call.ToolName,
+		Input:            call.Input,
+		ProviderMetadata: call.ProviderMetadata,
+	}
+}
+
+func completionDeferred(id string) sdk.DeferredToolApproval {
+	approval := sdk.ToolApprovalResult{
+		Decision:   sdk.ToolApprovalDecisionDeferred,
+		ApprovalID: "approval-" + id,
+	}
+	if id == "c2" {
+		approval.Metadata = map[string]any{"workspace": "release"}
+	}
+	return sdk.DeferredToolApproval{ToolCall: completionCall(id), Approval: approval}
+}
+
+func completionPause() sdk.ToolApprovalPause {
+	return sdk.ToolApprovalPause{
+		BatchID: "apbatch-release",
+		System:  "You coordinate releases.",
+		Messages: []sdk.Message{
+			sdk.UserMessage("deploy and ask for confirmation"),
+			{
+				Role: sdk.MessageRoleAssistant,
+				Content: []sdk.MessagePart{
+					sdk.TextPart{Text: "I will prepare the release."},
+					completionCallPart("c1"),
+					completionCallPart("c2"),
+					completionCallPart("c3"),
+				},
+			},
+			sdk.ToolMessage(sdk.ToolResultPart{
+				ToolCallID: "c1",
+				ToolName:   "lookup",
+				Result:     map[string]any{"version": "v2"},
+			}),
+		},
+		Pending: []sdk.DeferredToolApproval{completionDeferred("c2"), completionDeferred("c3")},
+	}
+}
+
+func completionResults() []sdk.ToolResultPart {
+	return []sdk.ToolResultPart{
+		{
+			ToolCallID:   "c3",
+			Result:       map[string]any{"answer": "yes"},
+			IsError:      true,
+			CacheControl: &sdk.CacheControl{Type: "ephemeral", TTL: "1h"},
+		},
+		{
+			ToolCallID: "c2",
+			ToolName:   "deploy",
+			Result:     map[string]any{"deployment": "dep-42"},
+		},
+	}
+}
+
+func toolResultParts(t *testing.T, message sdk.Message) []sdk.ToolResultPart {
+	t.Helper()
+	if message.Role != sdk.MessageRoleTool {
+		t.Fatalf("message role = %q, want tool", message.Role)
+	}
+	results := make([]sdk.ToolResultPart, len(message.Content))
+	for i, part := range message.Content {
+		result, ok := part.(sdk.ToolResultPart)
+		if !ok {
+			t.Fatalf("message.Content[%d] = %T, want sdk.ToolResultPart", i, part)
+		}
+		results[i] = result
+	}
+	return results
+}
+
+func replaceAssistantCall(pause *sdk.ToolApprovalPause, id string, mutate func(*sdk.ToolCallPart)) {
+	for messageIndex := range pause.Messages {
+		for partIndex, part := range pause.Messages[messageIndex].Content {
+			call, ok := part.(sdk.ToolCallPart)
+			if ok && call.ToolCallID == id {
+				mutate(&call)
+				pause.Messages[messageIndex].Content[partIndex] = call
+				return
+			}
+		}
+	}
+}
+
+func TestCompleteToolApprovalPause_CompletesSupportedLayouts(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*sdk.ToolApprovalPause, *[]sdk.ToolResultPart)
+		wantIDs []string
+		verify  func(*testing.T, []sdk.Message)
+	}{
+		{
+			name:    "resolved prefix and unordered host results",
+			wantIDs: []string{"c2", "c3"},
+			verify: func(t *testing.T, completed []sdk.Message) {
+				existing := toolResultParts(t, completed[len(completed)-2])
+				if len(existing) != 1 || existing[0].ToolCallID != "c1" || existing[0].Result.(map[string]any)["version"] != "v2" {
+					t.Fatalf("existing sibling result changed: %#v", existing)
+				}
+
+				added := toolResultParts(t, completed[len(completed)-1])
+				if added[0].ToolName != "deploy" || added[0].Result.(map[string]any)["deployment"] != "dep-42" {
+					t.Fatalf("deploy result changed: %#v", added[0])
+				}
+				if added[1].ToolName != "ask_user" || !added[1].IsError || added[1].Result.(map[string]any)["answer"] != "yes" {
+					t.Fatalf("ask_user result changed: %#v", added[1])
+				}
+				if added[1].CacheControl == nil || added[1].CacheControl.TTL != "1h" {
+					t.Fatalf("cache control changed: %#v", added[1].CacheControl)
+				}
+			},
+		},
+		{
+			name: "no resolved siblings",
+			prepare: func(pause *sdk.ToolApprovalPause, results *[]sdk.ToolResultPart) {
+				pause.Messages = pause.Messages[:len(pause.Messages)-1]
+				pause.Pending = append([]sdk.DeferredToolApproval{completionDeferred("c1")}, pause.Pending...)
+				*results = append(*results, sdk.ToolResultPart{ToolCallID: "c1"})
+			},
+			wantIDs: []string{"c1", "c2", "c3"},
+			verify: func(t *testing.T, completed []sdk.Message) {
+				result := toolResultParts(t, completed[len(completed)-1])[0]
+				if result.ToolName != "lookup" || result.Result != nil {
+					t.Fatalf("nil result was not preserved: %#v", result)
+				}
+			},
+		},
+		{
+			name: "interleaved resolved sibling",
+			prepare: func(pause *sdk.ToolApprovalPause, results *[]sdk.ToolResultPart) {
+				pause.Messages[len(pause.Messages)-1] = sdk.ToolMessage(sdk.ToolResultPart{
+					ToolCallID: "c2", ToolName: "deploy", Result: map[string]any{"deployment": "dep-42"},
+				})
+				pause.Pending = []sdk.DeferredToolApproval{completionDeferred("c1"), completionDeferred("c3")}
+				*results = []sdk.ToolResultPart{
+					{ToolCallID: "c3", Result: "yes"},
+					{ToolCallID: "c1", Result: map[string]any{"version": "v2"}},
+				}
+			},
+			wantIDs: []string{"c1", "c3"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pause := completionPause()
+			results := completionResults()
+			if test.prepare != nil {
+				test.prepare(&pause, &results)
+			}
+			completed, err := sdk.CompleteToolApprovalPause(&pause, results)
+			if err != nil {
+				t.Fatalf("CompleteToolApprovalPause: %v", err)
+			}
+			if len(completed) != len(pause.Messages)+1 {
+				t.Fatalf("completed messages = %d, want %d", len(completed), len(pause.Messages)+1)
+			}
+			if ids := resultIDs(toolResultParts(t, completed[len(completed)-1])); !reflect.DeepEqual(ids, test.wantIDs) {
+				t.Fatalf("completing result IDs = %v, want %v", ids, test.wantIDs)
+			}
+			if test.verify != nil {
+				test.verify(t, completed)
+			}
+		})
+	}
+}
+
+func TestCompleteToolApprovalPause_RejectsInvalidState(t *testing.T) {
+	t.Run("nil pause", func(t *testing.T) {
+		completed, err := sdk.CompleteToolApprovalPause(nil, completionResults())
+		if err == nil || !strings.Contains(err.Error(), "pause is nil") {
+			t.Fatalf("error = %v, want nil pause error", err)
+		}
+		if completed != nil {
+			t.Fatalf("completed = %#v on validation failure, want nil", completed)
+		}
+	})
+
+	tests := []struct {
+		name    string
+		mutate  func(*sdk.ToolApprovalPause, *[]sdk.ToolResultPart)
+		wantErr string
+	}{
+		// Host result validation.
+		{
+			name: "missing",
+			mutate: func(_ *sdk.ToolApprovalPause, results *[]sdk.ToolResultPart) {
+				*results = (*results)[:1]
+			},
+			wantErr: `missing result for pending tool call "c2"`,
+		},
+		{
+			name: "unknown",
+			mutate: func(_ *sdk.ToolApprovalPause, results *[]sdk.ToolResultPart) {
+				*results = append(*results, sdk.ToolResultPart{ToolCallID: "ghost", ToolName: "deploy"})
+			},
+			wantErr: `unknown pending tool call "ghost"`,
+		},
+		{
+			name: "duplicate",
+			mutate: func(_ *sdk.ToolApprovalPause, results *[]sdk.ToolResultPart) {
+				*results = append(*results, (*results)[0])
+			},
+			wantErr: `duplicate tool call ID "c3"`,
+		},
+		{
+			name: "empty ID",
+			mutate: func(_ *sdk.ToolApprovalPause, results *[]sdk.ToolResultPart) {
+				(*results)[0].ToolCallID = ""
+			},
+			wantErr: "empty tool call ID",
+		},
+		{
+			name: "already resolved sibling",
+			mutate: func(_ *sdk.ToolApprovalPause, results *[]sdk.ToolResultPart) {
+				*results = append(*results, sdk.ToolResultPart{ToolCallID: "c1", ToolName: "lookup"})
+			},
+			wantErr: `tool call "c1" already has a result`,
+		},
+		{
+			name: "wrong tool name",
+			mutate: func(_ *sdk.ToolApprovalPause, results *[]sdk.ToolResultPart) {
+				(*results)[0].ToolName = "deploy"
+			},
+			wantErr: `names tool "deploy"; want "ask_user"`,
+		},
+
+		// Conversation shape validation.
+		{
+			name: "no pending calls",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Pending = nil
+			},
+			wantErr: "pause has no pending tool calls",
+		},
+		{
+			name: "no messages",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages = nil
+			},
+			wantErr: "pause has no messages",
+		},
+		{
+			name: "non-tool tail",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages = append(pause.Messages, sdk.UserMessage("late input"))
+			},
+			wantErr: "must end with an assistant tool-call message followed only by tool messages",
+		},
+		{
+			name: "assistant has no calls",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages = []sdk.Message{sdk.UserMessage("hello"), sdk.AssistantMessage("done")}
+			},
+			wantErr: "final assistant message contains no tool calls",
+		},
+		{
+			name: "assistant call empty ID",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				replaceAssistantCall(pause, "c2", func(call *sdk.ToolCallPart) { call.ToolCallID = "" })
+			},
+			wantErr: "has an empty ID",
+		},
+		{
+			name: "assistant call empty name",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				replaceAssistantCall(pause, "c2", func(call *sdk.ToolCallPart) { call.ToolName = "" })
+			},
+			wantErr: `assistant tool call "c2" has an empty tool name`,
+		},
+		{
+			name: "assistant duplicate call ID",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				replaceAssistantCall(pause, "c3", func(call *sdk.ToolCallPart) { call.ToolCallID = "c2" })
+			},
+			wantErr: `duplicate tool call ID "c2"`,
+		},
+		{
+			name: "empty tool message",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages[len(pause.Messages)-1].Content = nil
+			},
+			wantErr: "tool message at index 2 is empty",
+		},
+		{
+			name: "non-result in tool message",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages[len(pause.Messages)-1].Content = append(pause.Messages[len(pause.Messages)-1].Content, sdk.TextPart{Text: "bad"})
+			},
+			wantErr: "contains a non-tool-result part",
+		},
+		{
+			name: "existing result empty ID",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages[len(pause.Messages)-1] = sdk.ToolMessage(sdk.ToolResultPart{ToolName: "lookup"})
+			},
+			wantErr: "has an empty tool call ID",
+		},
+		{
+			name: "existing result unknown ID",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages[len(pause.Messages)-1] = sdk.ToolMessage(sdk.ToolResultPart{ToolCallID: "ghost", ToolName: "lookup"})
+			},
+			wantErr: `unknown tool call "ghost"`,
+		},
+		{
+			name: "existing result duplicate ID",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				result := sdk.ToolResultPart{ToolCallID: "c1", ToolName: "lookup"}
+				pause.Messages[len(pause.Messages)-1] = sdk.ToolMessage(result, result)
+			},
+			wantErr: `duplicate result for tool call "c1"`,
+		},
+		{
+			name: "existing result wrong name",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages[len(pause.Messages)-1] = sdk.ToolMessage(sdk.ToolResultPart{ToolCallID: "c1", ToolName: "deploy"})
+			},
+			wantErr: `names tool "deploy"; want "lookup"`,
+		},
+		{
+			name: "existing results out of call order",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Messages[len(pause.Messages)-1] = sdk.ToolMessage(
+					sdk.ToolResultPart{ToolCallID: "c2", ToolName: "deploy"},
+					sdk.ToolResultPart{ToolCallID: "c1", ToolName: "lookup"},
+				)
+				pause.Pending = pause.Pending[1:]
+			},
+			wantErr: `do not follow the assistant tool-call order at "c1"`,
+		},
+
+		// Pending snapshot validation.
+		{
+			name: "missing pending entry",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Pending = pause.Pending[:1]
+			},
+			wantErr: "lists 1 calls but pause.Messages leaves 2 unresolved",
+		},
+		{
+			name: "pending order",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Pending[0], pause.Pending[1] = pause.Pending[1], pause.Pending[0]
+			},
+			wantErr: `pause.Pending[0] identifies tool call "c3"; want "c2"`,
+		},
+		{
+			name: "pending tool name",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Pending[0].ToolCall.ToolName = "ask_user"
+			},
+			wantErr: `names tool "ask_user"; want "deploy"`,
+		},
+		{
+			name: "pending input",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Pending[0].ToolCall.Input.(map[string]any)["env"] = "staging"
+			},
+			wantErr: "input for tool call \"c2\" does not match",
+		},
+		{
+			name: "pending provider metadata",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Pending[0].ToolCall.ProviderMetadata["trace"].(map[string]any)["position"] = float64(99)
+			},
+			wantErr: "provider metadata for tool call \"c2\" does not match",
+		},
+		{
+			name: "zero decision is not pending",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				pause.Pending[0].Approval.Decision = ""
+			},
+			wantErr: `has decision ""; want "deferred"`,
+		},
+		{
+			name: "non JSON-compatible pending input",
+			mutate: func(pause *sdk.ToolApprovalPause, _ *[]sdk.ToolResultPart) {
+				ch := make(chan int)
+				pause.Pending[0].ToolCall.Input = ch
+				replaceAssistantCall(pause, "c2", func(call *sdk.ToolCallPart) { call.Input = ch })
+			},
+			wantErr: "recorded value is not JSON-compatible",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pause := completionPause()
+			results := completionResults()
+			test.mutate(&pause, &results)
+			completed, err := sdk.CompleteToolApprovalPause(&pause, results)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, test.wantErr)
+			}
+			if completed != nil {
+				t.Fatalf("completed = %#v on validation failure, want nil", completed)
+			}
+		})
+	}
+}
+
+func TestCompleteToolApprovalPause_AcceptsJSONEquivalentSnapshot(t *testing.T) {
+	type deploymentInput struct {
+		Env     string   `json:"env"`
+		Regions []string `json:"regions"`
+	}
+	type trace struct {
+		Position int `json:"position"`
+	}
+
+	pause := completionPause()
+	pause.Pending[0].ToolCall.Input = deploymentInput{Env: "prod", Regions: []string{"nrt", "iad"}}
+	pause.Pending[0].ToolCall.ProviderMetadata = nil
+	replaceAssistantCall(&pause, "c2", func(call *sdk.ToolCallPart) {
+		call.ProviderMetadata = nil
+	})
+	pause.Pending[1].ToolCall.ProviderMetadata = map[string]any{"trace": trace{Position: 3}}
+
+	completed, err := sdk.CompleteToolApprovalPause(&pause, completionResults())
+	if err != nil {
+		t.Fatalf("JSON-equivalent struct/map snapshot was rejected: %v", err)
+	}
+	if len(completed) != len(pause.Messages)+1 {
+		t.Fatalf("completed messages = %d, want %d", len(completed), len(pause.Messages)+1)
+	}
+}
+
+func TestCompleteToolApprovalPause_JSONRoundTrip(t *testing.T) {
+	pause := roundTripJSON(t, completionPause())
+	results := roundTripJSON(t, completionResults())
+
+	completed, err := sdk.CompleteToolApprovalPause(&pause, results)
+	if err != nil {
+		t.Fatalf("complete JSON round-trip pause: %v", err)
+	}
+	if ids := resultIDs(toolResultParts(t, completed[len(completed)-1])); !reflect.DeepEqual(ids, []string{"c2", "c3"}) {
+		t.Fatalf("completed result IDs = %v, want [c2 c3]", ids)
+	}
+}
+
+func TestCompleteToolApprovalPause_ReturnsDeepSnapshot(t *testing.T) {
+	pause := completionPause()
+	results := completionResults()
+	completed, err := sdk.CompleteToolApprovalPause(&pause, results)
+	if err != nil {
+		t.Fatalf("CompleteToolApprovalPause: %v", err)
+	}
+	completedSnapshot := snapshotJSON(t, completed)
+
+	// Mutating either input after completion must not rewrite the returned
+	// conversation, including values nested behind interfaces and pointers.
+	replaceAssistantCall(&pause, "c2", func(call *sdk.ToolCallPart) {
+		call.Input.(map[string]any)["regions"].([]any)[0] = "mutated"
+		call.ProviderMetadata["trace"].(map[string]any)["position"] = float64(99)
+	})
+	existing := pause.Messages[len(pause.Messages)-1].Content[0].(sdk.ToolResultPart)
+	existing.Result.(map[string]any)["version"] = "mutated"
+	results[0].Result.(map[string]any)["answer"] = "mutated"
+	results[0].CacheControl.TTL = "mutated"
+	if got := snapshotJSON(t, completed); got != completedSnapshot {
+		t.Fatalf("completed conversation changed through its inputs\ngot:  %s\nwant: %s", got, completedSnapshot)
+	}
+
+	// Mutating the returned snapshot must likewise leave both inputs intact.
+	pauseSnapshot := snapshotJSON(t, pause)
+	resultsSnapshot := snapshotJSON(t, results)
+	added := toolResultParts(t, completed[len(completed)-1])
+	added[0].Result.(map[string]any)["deployment"] = "changed-in-output"
+	if got := snapshotJSON(t, pause); got != pauseSnapshot {
+		t.Fatalf("pause changed through completed conversation\ngot:  %s\nwant: %s", got, pauseSnapshot)
+	}
+	if got := snapshotJSON(t, results); got != resultsSnapshot {
+		t.Fatalf("host results changed through completed conversation\ngot:  %s\nwant: %s", got, resultsSnapshot)
+	}
+}
+
+func resultIDs(results []sdk.ToolResultPart) []string {
+	ids := make([]string, len(results))
+	for i, result := range results {
+		ids[i] = result.ToolCallID
+	}
+	return ids
+}
+
+func roundTripJSON[T any](t *testing.T, value T) T {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+	return result
+}
+
+func snapshotJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON snapshot: %v", err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## 背景

PR #34 引入了可持久化的 `ToolApprovalPause`，能够在同一轮存在多个 deferred tool call 时保存完整暂停状态。但宿主在审批完成、工具执行结束或取得 `ask_user` 答案之后，仍需要自行拼装 tool message，容易产生缺失结果、重复结果、顺序错误或调用参数与暂停会话不一致的问题。

## 设计

本 PR 只新增一个纯辅助函数：

```go
completed, err := sdk.CompleteToolApprovalPause(pause, results)
```

它接收 #34 产生的 pause，以及宿主为每个 pending call 准备好的最终 `ToolResultPart`，严格校验后返回补全 tool protocol 的新 conversation。

该函数不会：

- 审批或拒绝工具调用；
- 执行工具；
- 调用模型；
- 发送 stream event；
- 持久化任何状态。

宿主在可靠保存 completed conversation 后，直接使用普通生成 API 继续：

```go
completed, err := sdk.CompleteToolApprovalPause(pause, results)
if err != nil {
    return err
}

persist(pause.System, completed)

stream, err := sdk.StreamText(ctx,
    sdk.WithModel(model),
    sdk.WithSystem(pause.System),
    sdk.WithMessages(completed),
    sdk.WithTools(tools),
    sdk.WithMaxSteps(5),
    sdk.WithApprovalHandler(handler),
)
```

## 校验规则

暂停会话末尾 assistant message 中的 `ToolCallPart` 是唯一事实源。函数会校验：

- assistant tool call 的 ID 非空且唯一；
- 已存在的 tool results 具有合法 ID、工具名和原始调用顺序；
- `Pause.Pending` 恰好是未完成调用的补集，并与原始 call 的 ID、工具名、输入和 provider metadata 一致；
- 每个 pending call 恰好收到一个宿主结果，拒绝 missing、unknown、duplicate 和 empty ID；
- 宿主结果可以乱序传入，但输出按模型原始 call 顺序排列；
- 省略的 `ToolName` 从原始 call 安全补全，冲突的非空名称直接报错。

返回值是深拷贝，不会修改或共享 `pause.Messages` 与宿主传入结果中的 JSON 形状可变数据。

## 职责边界

部署、支付、`ask_user` 等流程的审批、执行、workspace 绑定、事务、fencing、幂等和恢复仍由宿主负责。本函数的校验保护的是交给模型的 completed conversation，不是副作用执行前的授权检查；宿主不能仅凭不可信或手工拼装的 `Pause.Pending` 执行敏感操作。

本 PR 不承诺工具 exactly-once，也无法关闭“外部副作用成功、completed conversation 持久化前进程崩溃”的窗口。它提供的是更窄且可验证的保证：只有 pause 与最终结果完整一致时，才返回 protocol-complete conversation。

## 测试

测试覆盖多 pending 乱序输入、已有 resolved sibling、交错 sibling、JSON round-trip、ID 与工具名错误、input/provider metadata 漂移、非 deferred pending、错误结果与 cache control 保留，以及双向深拷贝隔离。
