### PR TITLE
fix(openai): preserve Responses reasoning state

### DIFF
--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -328,6 +328,7 @@ func convertResponsesAssistantMessage(msg sdk.Message) []json.RawMessage {
 	var textParts []responsesOutputTextPart
 	var reasoningSummary []responsesReasoningSummaryText
 	var encryptedContent string
+	var reasoningItemID string
 
 	for _, part := range msg.Content {
 		switch p := part.(type) {
@@ -342,8 +343,12 @@ func convertResponsesAssistantMessage(msg sdk.Message) []json.RawMessage {
 				Type: "summary_text",
 				Text: p.Text,
 			})
-			if ec := extractOpenAIEncryptedContent(p.ProviderMetadata); ec != "" {
+			ec, itemID := extractOpenAIReasoningMetadata(p.ProviderMetadata)
+			if ec != "" {
 				encryptedContent = ec
+			}
+			if itemID != "" {
+				reasoningItemID = itemID
 			}
 
 		case sdk.ToolCallPart:
@@ -365,8 +370,9 @@ func convertResponsesAssistantMessage(msg sdk.Message) []json.RawMessage {
 	}
 
 	var prefix []json.RawMessage
-	if len(reasoningSummary) > 0 {
+	if len(reasoningSummary) > 0 || encryptedContent != "" || reasoningItemID != "" {
 		ri := responsesReasoningItem{
+			ID:               reasoningItemID,
 			Type:             "reasoning",
 			Summary:          reasoningSummary,
 			EncryptedContent: encryptedContent,
@@ -741,6 +747,25 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 
 				return utils.ErrStreamDone
 
+			case "response.failed":
+				var chunk responsesFailedChunk
+				if err := json.Unmarshal([]byte(ev.Data), &chunk); err != nil {
+					return nil
+				}
+				if chunk.Response.Usage != nil {
+					usage = convertResponsesUsage(chunk.Response.Usage)
+				}
+				if chunk.Response.Error == nil {
+					send(&sdk.ErrorPart{Error: fmt.Errorf("openai-responses: response failed")})
+				} else {
+					send(&sdk.ErrorPart{Error: fmt.Errorf(
+						"openai-responses: %s: %s",
+						chunk.Response.Error.Code,
+						chunk.Response.Error.Message,
+					)})
+				}
+				return utils.ErrStreamDone
+
 			case "error":
 				var chunk responsesErrorChunk
 				if err := json.Unmarshal([]byte(ev.Data), &chunk); err != nil {
@@ -826,16 +851,17 @@ func convertResponsesUsage(u *responsesUsage) sdk.Usage {
 	}
 }
 
-func extractOpenAIEncryptedContent(meta map[string]any) string {
+func extractOpenAIReasoningMetadata(meta map[string]any) (encryptedContent, itemID string) {
 	if meta == nil {
-		return ""
+		return "", ""
 	}
 	om, ok := meta["openai"].(map[string]any)
 	if !ok {
-		return ""
+		return "", ""
 	}
-	ec, _ := om["reasoningEncryptedContent"].(string)
-	return ec
+	encryptedContent, _ = om["reasoningEncryptedContent"].(string)
+	itemID, _ = om["itemId"].(string)
+	return encryptedContent, itemID
 }
 
 func textFromParts(parts []sdk.MessagePart) string {

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -1065,6 +1065,39 @@ func TestResponsesDoStream_ErrorEvent(t *testing.T) {
 	}
 }
 
+func TestResponsesDoStream_ResponseFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event: response.failed\n")
+		fmt.Fprint(w, `data: {"type":"response.failed","response":{"status":"failed","error":{"type":"server_error","code":"server_error","message":"generation failed"},"usage":{"input_tokens":7,"output_tokens":2}}}`)
+		fmt.Fprint(w, "\n\n")
+		w.(http.Flusher).Flush()
+	}))
+	defer srv.Close()
+
+	p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(srv.URL))
+	sr, err := p.DoStream(context.Background(), sdk.GenerateParams{
+		Model:    p.ChatModel("gpt-5.6"),
+		Messages: []sdk.Message{sdk.UserMessage("test")},
+	})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+
+	var gotError bool
+	for part := range sr.Stream {
+		if errorPart, ok := part.(*sdk.ErrorPart); ok {
+			gotError = true
+			if !strings.Contains(errorPart.Error.Error(), "generation failed") {
+				t.Fatalf("error = %q, want generation failure", errorPart.Error)
+			}
+		}
+	}
+	if !gotError {
+		t.Fatal("expected ErrorPart from response.failed")
+	}
+}
+
 // ---------- input conversion tests ----------
 
 func TestResponsesInputConversion_SystemMessage(t *testing.T) {
@@ -1191,6 +1224,7 @@ func TestResponsesInputConversion_AssistantReasoning(t *testing.T) {
 		}
 
 		var reasoning struct {
+			ID      string `json:"id"`
 			Type    string `json:"type"`
 			Summary []struct {
 				Type string `json:"type"`
@@ -1200,6 +1234,9 @@ func TestResponsesInputConversion_AssistantReasoning(t *testing.T) {
 		json.Unmarshal(body.Input[1], &reasoning)
 		if reasoning.Type != "reasoning" {
 			t.Errorf("input[1] type: got %q, want reasoning", reasoning.Type)
+		}
+		if reasoning.ID != "rs_123" {
+			t.Errorf("input[1] id: got %q, want rs_123", reasoning.ID)
 		}
 		if len(reasoning.Summary) != 1 || reasoning.Summary[0].Text != "I thought carefully" {
 			t.Errorf("reasoning summary: %+v", reasoning.Summary)
@@ -1240,7 +1277,15 @@ func TestResponsesInputConversion_AssistantReasoning(t *testing.T) {
 			{
 				Role: sdk.MessageRoleAssistant,
 				Content: []sdk.MessagePart{
-					sdk.ReasoningPart{Text: "I thought carefully"},
+					sdk.ReasoningPart{
+						Text: "I thought carefully",
+						ProviderMetadata: map[string]any{
+							"openai": map[string]any{
+								"itemId":                    "rs_123",
+								"reasoningEncryptedContent": "encrypted-reasoning",
+							},
+						},
+					},
 					sdk.TextPart{Text: "The answer"},
 				},
 			},
@@ -1248,6 +1293,50 @@ func TestResponsesInputConversion_AssistantReasoning(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("DoGenerate: %v", err)
+	}
+}
+
+func TestResponsesInputConversion_ReplaysOpaqueReasoningWithoutSummary(t *testing.T) {
+	var captured struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer srv.Close()
+
+	p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(srv.URL))
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: p.ChatModel("gpt-5.6"),
+		Messages: []sdk.Message{{
+			Role: sdk.MessageRoleAssistant,
+			Content: []sdk.MessagePart{sdk.ReasoningPart{ProviderMetadata: map[string]any{
+				"openai": map[string]any{
+					"itemId":                    "rs_opaque",
+					"reasoningEncryptedContent": "encrypted-only",
+				},
+			}}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	if len(captured.Input) != 1 {
+		t.Fatalf("input length = %d, want 1", len(captured.Input))
+	}
+	var reasoning struct {
+		ID               string `json:"id"`
+		EncryptedContent string `json:"encrypted_content"`
+	}
+	if err := json.Unmarshal(captured.Input[0], &reasoning); err != nil {
+		t.Fatalf("decode reasoning item: %v", err)
+	}
+	if reasoning.ID != "rs_opaque" || reasoning.EncryptedContent != "encrypted-only" {
+		t.Fatalf("reasoning item = %+v", reasoning)
 	}
 }
 

--- a/provider/openai/responses/types.go
+++ b/provider/openai/responses/types.go
@@ -90,6 +90,7 @@ type responsesReasoningSummaryText struct {
 }
 
 type responsesReasoningItem struct {
+	ID               string                          `json:"id,omitempty"`
 	Type             string                          `json:"type"`
 	Summary          []responsesReasoningSummaryText `json:"summary"`
 	EncryptedContent string                          `json:"encrypted_content,omitempty"`
@@ -241,6 +242,15 @@ type responsesCompletedChunk struct {
 	Response struct {
 		IncompleteDetails *incompleteDetails `json:"incomplete_details,omitempty"`
 		Usage             *responsesUsage    `json:"usage,omitempty"`
+	} `json:"response"`
+}
+
+// responsesFailedChunk is sent for event: response.failed.
+type responsesFailedChunk struct {
+	Type     string `json:"type"`
+	Response struct {
+		Error *responsesError `json:"error,omitempty"`
+		Usage *responsesUsage `json:"usage,omitempty"`
 	} `json:"response"`
 }
 


### PR DESCRIPTION
## Summary

- replay Responses reasoning item IDs together with encrypted reasoning content across tool turns
- keep opaque reasoning items even when no human-readable summary was emitted
- surface `response.failed` terminal events as stream errors instead of silently finishing

## Validation

- `go test ./provider/openai/responses ./sdk/...`
- `git diff --check`

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.