### PR TITLE
fix(openai): request reasoning summaries

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -256,6 +256,7 @@ type GenerateParams struct {
     PresencePenalty  *float64
     Seed             *int
     ReasoningEffort  *string
+    ReasoningSummary *string
     PromptCacheKey   *string
 }
 ```
@@ -347,6 +348,7 @@ All options are of type `GenerateOption` (`func(*generateConfig)`).
 | `WithPresencePenalty(p float64)` | Presence penalty |
 | `WithSeed(s int)` | Random seed for reproducibility |
 | `WithReasoningEffort(effort string)` | Reasoning effort level |
+| `WithReasoningSummary(summary string)` | Explicitly request a provider-supported human-readable reasoning summary |
 | `WithPromptCacheKey(key string)` | Cache routing hint for OpenAI prompt caching (Chat Completions & Responses API) |
 
 #### Orchestration Options

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -299,13 +299,17 @@ result, _ := sdk.GenerateTextResult(ctx,
     sdk.WithMessages([]sdk.Message{
         sdk.UserMessage("What is 15 * 37? Think step by step."),
     }),
-    sdk.WithReasoningEffort(&effort),
+    sdk.WithReasoningEffort(effort),
+    sdk.WithReasoningSummary("auto"),
 )
 fmt.Println(result.Reasoning)  // model's reasoning summary
 fmt.Println(result.Text)       // final answer: "555"
 ```
 
-In streaming mode, reasoning arrives as `ReasoningStartPart` / `ReasoningDeltaPart` / `ReasoningEndPart` before the text content.
+`WithReasoningSummary` is an explicit opt-in. OpenAI Responses supports `"auto"`,
+`"concise"`, and `"detailed"`; compatible endpoints may support a different
+subset. In streaming mode, summaries arrive as `ReasoningStartPart` /
+`ReasoningDeltaPart` / `ReasoningEndPart` before the text content.
 
 ### Supported Features
 

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -240,8 +240,15 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*responsesRequest, 
 		}
 	}
 
-	if params.ReasoningEffort != nil {
-		req.Reasoning = &responsesReasoning{Effort: *params.ReasoningEffort}
+	if (params.ReasoningEffort != nil && *params.ReasoningEffort != "") ||
+		(params.ReasoningSummary != nil && *params.ReasoningSummary != "") {
+		req.Reasoning = &responsesReasoning{}
+		if params.ReasoningEffort != nil {
+			req.Reasoning.Effort = *params.ReasoningEffort
+		}
+		if params.ReasoningSummary != nil {
+			req.Reasoning.Summary = *params.ReasoningSummary
+		}
 	}
 
 	return req, nil

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -200,7 +200,8 @@ func TestResponsesDoGenerate_PromptCacheKeyOmittedWhenUnset(t *testing.T) {
 func TestResponsesDoGenerate_ForwardsMaxReasoningEffortVerbatim(t *testing.T) {
 	var body struct {
 		Reasoning *struct {
-			Effort string `json:"effort"`
+			Effort  string  `json:"effort"`
+			Summary *string `json:"summary"`
 		} `json:"reasoning"`
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -238,6 +239,57 @@ func TestResponsesDoGenerate_ForwardsMaxReasoningEffortVerbatim(t *testing.T) {
 	}
 	if body.Reasoning == nil || body.Reasoning.Effort != "max" {
 		t.Fatalf("reasoning.effort: got %#v, want max (forwarded verbatim)", body.Reasoning)
+	}
+	if body.Reasoning.Summary != nil {
+		t.Fatalf("reasoning.summary should be omitted unless explicitly requested, got %q", *body.Reasoning.Summary)
+	}
+}
+
+func TestResponsesDoGenerate_ReasoningSummaryIsExplicitAndIndependent(t *testing.T) {
+	var body struct {
+		Reasoning *struct {
+			Effort  *string `json:"effort"`
+			Summary *string `json:"summary"`
+		} `json:"reasoning"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "resp_summary",
+			"created_at": 1700000000,
+			"model":      "gpt-5.2",
+			"output": []map[string]any{{
+				"type": "message",
+				"id":   "msg_001",
+				"role": "assistant",
+				"content": []map[string]any{{
+					"type": "output_text",
+					"text": "ok",
+				}},
+			}},
+			"usage": map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	p := responses.New(responses.WithAPIKey("test-key"), responses.WithBaseURL(srv.URL))
+	summary := "auto"
+	_, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:            p.ChatModel("gpt-5.2"),
+		Messages:         []sdk.Message{sdk.UserMessage("hi")},
+		ReasoningSummary: &summary,
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	if body.Reasoning == nil || body.Reasoning.Summary == nil || *body.Reasoning.Summary != "auto" {
+		t.Fatalf("reasoning.summary: got %#v, want auto", body.Reasoning)
+	}
+	if body.Reasoning.Effort != nil {
+		t.Fatalf("reasoning.effort should be omitted when unset, got %q", *body.Reasoning.Effort)
 	}
 }
 
@@ -1483,10 +1535,12 @@ func TestIntegration_ResponsesDoGenerate_Reasoning(t *testing.T) {
 	p := newResponsesIntegrationProvider(t)
 	model := p.ChatModel(openRouterResponsesReasoningModel)
 	effort := "low"
+	summary := "auto"
 	result, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
-		Model:           model,
-		Messages:        []sdk.Message{sdk.UserMessage("What is 15 * 37? Think step by step.")},
-		ReasoningEffort: &effort,
+		Model:            model,
+		Messages:         []sdk.Message{sdk.UserMessage("What is 15 * 37? Think step by step.")},
+		ReasoningEffort:  &effort,
+		ReasoningSummary: &summary,
 	})
 	if err != nil {
 		t.Fatalf("DoGenerate: %v", err)
@@ -1506,10 +1560,12 @@ func TestIntegration_ResponsesDoStream_Reasoning(t *testing.T) {
 	p := newResponsesIntegrationProvider(t)
 	model := p.ChatModel(openRouterResponsesReasoningModel)
 	effort := "low"
+	summary := "auto"
 	sr, err := p.DoStream(context.Background(), sdk.GenerateParams{
-		Model:           model,
-		Messages:        []sdk.Message{sdk.UserMessage("What is 15 * 37? Think step by step.")},
-		ReasoningEffort: &effort,
+		Model:            model,
+		Messages:         []sdk.Message{sdk.UserMessage("What is 15 * 37? Think step by step.")},
+		ReasoningEffort:  &effort,
+		ReasoningSummary: &summary,
 	})
 	if err != nil {
 		t.Fatalf("DoStream: %v", err)

--- a/sdk/generate.go
+++ b/sdk/generate.go
@@ -48,7 +48,11 @@ type GenerateParams struct {
 	PresencePenalty  *float64 `json:"presencePenalty,omitempty"`
 	Seed             *int     `json:"seed,omitempty"`
 	ReasoningEffort  *string  `json:"reasoningEffort,omitempty"`
-	PromptCacheKey   *string  `json:"promptCacheKey,omitempty"`
+	// ReasoningSummary explicitly requests a provider-supported, human-readable
+	// reasoning summary. Values are provider-defined; OpenAI Responses supports
+	// "auto", "concise", and "detailed".
+	ReasoningSummary *string `json:"reasoningSummary,omitempty"`
+	PromptCacheKey   *string `json:"promptCacheKey,omitempty"`
 }
 
 // StepResult represents the outcome of a single step (one LLM call + tool execution round).

--- a/sdk/options.go
+++ b/sdk/options.go
@@ -83,6 +83,13 @@ func WithReasoningEffort(effort string) GenerateOption {
 	return func(c *generateConfig) { c.Params.ReasoningEffort = &effort }
 }
 
+// WithReasoningSummary explicitly requests a provider-supported,
+// human-readable reasoning summary. OpenAI Responses supports "auto",
+// "concise", and "detailed".
+func WithReasoningSummary(summary string) GenerateOption {
+	return func(c *generateConfig) { c.Params.ReasoningSummary = &summary }
+}
+
 func WithPromptCacheKey(key string) GenerateOption {
 	return func(c *generateConfig) { c.Params.PromptCacheKey = &key }
 }


### PR DESCRIPTION
## Problem

Reasoning summaries are an explicit Responses API opt-in, but Twilight had no request-level way to set `reasoning.summary`. Coupling it implicitly to reasoning effort would also affect every OpenAI-compatible `BaseURL`, including endpoints that do not support summaries.

## Change

- Add `sdk.GenerateParams.ReasoningSummary` and `sdk.WithReasoningSummary`.
- Map `reasoning.effort` and `reasoning.summary` independently.
- Omit `reasoning.summary` unless the caller explicitly requests it.
- Document the option and cover independent effort/summary behavior with tests.

```go
sdk.WithReasoningEffort("high"),
sdk.WithReasoningSummary("auto"),
```

This preserves the reasoning-effort passthrough from #43 while allowing callers to opt in only for models and endpoints that support summaries.