### PR TITLE
feat(google): thinkingConfig request-side support (T1 of #41)

### DIFF
--- a/provider/google/generativeai/generativeai.go
+++ b/provider/google/generativeai/generativeai.go
@@ -37,11 +37,32 @@ type ThinkingConfig struct {
 	// Use ThinkingBudgetDynamic (-1) for automatic, ThinkingBudgetDisabled (0) to
 	// disable (only valid on Flash/Lite). Nil means this field is not sent.
 	ThinkingBudget *int
-	// ThinkingLevel sets the effort tier for 3.x-generation models.
-	// Accepted values: "minimal", "low", "medium", "high". Empty means not sent.
+	// ThinkingLevel sets the effort tier for 3.x-generation models. The wire
+	// format is an uppercase proto enum: "MINIMAL", "LOW", "MEDIUM", "HIGH".
+	// Values are upper-cased before being sent, so "high" and "HIGH" are
+	// equivalent here. Empty means not sent.
 	ThinkingLevel string
-	// IncludeThoughts controls whether thought content is returned. Nil means not sent.
+	// IncludeThoughts controls whether thought content is returned. Nil means not
+	// sent. Note that the API only emits thought parts when this is true, so
+	// reasoning stream parts stay empty unless it is explicitly enabled.
 	IncludeThoughts *bool
+}
+
+// isEmpty reports whether the config carries no fields at all. An empty config
+// is treated as "not configured" so it falls through to params.ReasoningEffort
+// rather than sending a bare `thinkingConfig: {}` and swallowing the request's
+// effort.
+func (c *ThinkingConfig) isEmpty() bool {
+	return c.ThinkingBudget == nil && c.ThinkingLevel == "" && c.IncludeThoughts == nil
+}
+
+// normalizeThinkingLevel converts an effort tier to the uppercase form the
+// thinkingLevel proto enum requires, trimming surrounding space. It is a
+// dialect translation and deliberately not a validation: a tier Google does not
+// define (e.g. "xhigh") is upper-cased and sent, surfacing as a 400 from the
+// API rather than being silently downgraded to a supported neighbour.
+func normalizeThinkingLevel(level string) string {
+	return strings.ToUpper(strings.TrimSpace(level))
 }
 
 type Provider struct {
@@ -259,26 +280,34 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*generateRequest, e
 
 	// Thinking configuration: provider-level WithThinking takes precedence over
 	// the generic params.ReasoningEffort. When both are present the provider
-	// option wins — it is more expressive and its intent is unambiguous. When
-	// only ReasoningEffort is set it is treated as a thinkingLevel string, which
-	// is structurally equivalent (both are named effort tiers). When neither is
-	// set thinkingConfig is omitted entirely (omitempty on generationConfig).
+	// option wins — it is more expressive and its intent is unambiguous. An
+	// empty WithThinking carries no intent, so it falls through to
+	// ReasoningEffort instead of suppressing it. When only ReasoningEffort is
+	// set it is treated as a thinkingLevel tier, which is structurally
+	// equivalent (both are named effort tiers). When neither is set
+	// thinkingConfig is omitted entirely (omitempty on generationConfig).
+	//
+	// thinkingLevel is a proto enum and only accepts uppercase members
+	// ("MINIMAL", "LOW", "MEDIUM", "HIGH"), while effort tiers elsewhere in this
+	// SDK are lowercase. Upper-casing here is dialect translation, not
+	// validation: tiers outside Google's enum (e.g. "xhigh") are still passed
+	// through and surface as a 400 rather than being silently remapped.
 	//
 	// No mutual-exclusion check and no budget-range validation are performed;
 	// both would require the SDK to encode knowledge about which model
 	// generation accepts which fields — that is the caller's responsibility.
 	// Illegal combinations surface as 400 errors from the API.
 	switch {
-	case p.thinking != nil:
+	case p.thinking != nil && !p.thinking.isEmpty():
 		tc := &thinkingConfig{
 			ThinkingBudget:  p.thinking.ThinkingBudget,
-			ThinkingLevel:   p.thinking.ThinkingLevel,
+			ThinkingLevel:   normalizeThinkingLevel(p.thinking.ThinkingLevel),
 			IncludeThoughts: p.thinking.IncludeThoughts,
 		}
 		genCfg.ThinkingConfig = tc
 	case params.ReasoningEffort != nil:
-		if effort := strings.TrimSpace(*params.ReasoningEffort); effort != "" {
-			genCfg.ThinkingConfig = &thinkingConfig{ThinkingLevel: effort}
+		if level := normalizeThinkingLevel(*params.ReasoningEffort); level != "" {
+			genCfg.ThinkingConfig = &thinkingConfig{ThinkingLevel: level}
 		}
 	}
 

--- a/provider/google/generativeai/generativeai.go
+++ b/provider/google/generativeai/generativeai.go
@@ -16,10 +16,39 @@ import (
 
 const defaultBaseURL = "https://generativelanguage.googleapis.com/v1beta"
 
+// ThinkingBudgetDynamic instructs the model to choose its own thinking budget
+// (thinkingBudget: -1, AUTOMATIC). Supported on 2.5-generation models.
+const ThinkingBudgetDynamic = -1
+
+// ThinkingBudgetDisabled disables thinking (thinkingBudget: 0, DISABLED).
+// Legal on Flash/Lite models; the API rejects it for 2.5 Pro.
+const ThinkingBudgetDisabled = 0
+
+// ThinkingConfig holds provider-level thinking parameters for Google Generative
+// AI models. The caller is responsible for choosing the right fields for the
+// target model generation:
+//   - ThinkingBudget is used by 2.5-generation models (e.g. gemini-2.5-flash).
+//   - ThinkingLevel is used by 3.x-generation models (e.g. gemini-3.1-pro-preview).
+//
+// Both fields are passed through as-is; the SDK does not validate mutual
+// exclusivity or budget ranges — misuse results in a 400 from the API.
+type ThinkingConfig struct {
+	// ThinkingBudget sets the token budget for 2.5-generation models.
+	// Use ThinkingBudgetDynamic (-1) for automatic, ThinkingBudgetDisabled (0) to
+	// disable (only valid on Flash/Lite). Nil means this field is not sent.
+	ThinkingBudget *int
+	// ThinkingLevel sets the effort tier for 3.x-generation models.
+	// Accepted values: "minimal", "low", "medium", "high". Empty means not sent.
+	ThinkingLevel string
+	// IncludeThoughts controls whether thought content is returned. Nil means not sent.
+	IncludeThoughts *bool
+}
+
 type Provider struct {
 	apiKey     string
 	baseURL    string
 	httpClient *http.Client
+	thinking   *ThinkingConfig
 }
 
 type Option func(*Provider)
@@ -39,6 +68,16 @@ func WithBaseURL(baseURL string) Option {
 func WithHTTPClient(client *http.Client) Option {
 	return func(p *Provider) {
 		p.httpClient = client
+	}
+}
+
+// WithThinking injects provider-level thinking configuration. When set, it
+// takes precedence over the generic params.ReasoningEffort from a Generate
+// call — the more expressive provider option wins. See ThinkingConfig for
+// field semantics and generation-specific guidance.
+func WithThinking(cfg ThinkingConfig) Option {
+	return func(p *Provider) {
+		p.thinking = &cfg
 	}
 }
 
@@ -217,6 +256,32 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*generateRequest, e
 			}
 		}
 	}
+
+	// Thinking configuration: provider-level WithThinking takes precedence over
+	// the generic params.ReasoningEffort. When both are present the provider
+	// option wins — it is more expressive and its intent is unambiguous. When
+	// only ReasoningEffort is set it is treated as a thinkingLevel string, which
+	// is structurally equivalent (both are named effort tiers). When neither is
+	// set thinkingConfig is omitted entirely (omitempty on generationConfig).
+	//
+	// No mutual-exclusion check and no budget-range validation are performed;
+	// both would require the SDK to encode knowledge about which model
+	// generation accepts which fields — that is the caller's responsibility.
+	// Illegal combinations surface as 400 errors from the API.
+	switch {
+	case p.thinking != nil:
+		tc := &thinkingConfig{
+			ThinkingBudget:  p.thinking.ThinkingBudget,
+			ThinkingLevel:   p.thinking.ThinkingLevel,
+			IncludeThoughts: p.thinking.IncludeThoughts,
+		}
+		genCfg.ThinkingConfig = tc
+	case params.ReasoningEffort != nil:
+		if effort := strings.TrimSpace(*params.ReasoningEffort); effort != "" {
+			genCfg.ThinkingConfig = &thinkingConfig{ThinkingLevel: effort}
+		}
+	}
+
 	req.GenerationConfig = genCfg
 
 	if len(params.Tools) > 0 {

--- a/provider/google/generativeai/generativeai_test.go
+++ b/provider/google/generativeai/generativeai_test.go
@@ -1068,6 +1068,8 @@ func TestDoGenerate_ThinkingConfig(t *testing.T) {
 	includeTrue := true
 	effortHigh := "high"
 	effortMedium := "medium"
+	effortXHigh := "xhigh"
+	effortBlank := "   "
 
 	tests := []struct {
 		name            string
@@ -1108,7 +1110,7 @@ func TestDoGenerate_ThinkingConfig(t *testing.T) {
 			providerOpts: []generativeai.Option{
 				generativeai.WithThinking(generativeai.ThinkingConfig{ThinkingLevel: "high"}),
 			},
-			wantLevel: "high",
+			wantLevel: "HIGH",
 		},
 		{
 			name: "WithThinking with IncludeThoughts",
@@ -1118,18 +1120,18 @@ func TestDoGenerate_ThinkingConfig(t *testing.T) {
 					IncludeThoughts: &includeTrue,
 				}),
 			},
-			wantLevel:           "medium",
+			wantLevel:           "MEDIUM",
 			wantIncludeThoughts: &includeTrue,
 		},
 		{
-			name:            "only ReasoningEffort maps to thinkingLevel",
+			name:            "only ReasoningEffort maps to uppercase thinkingLevel",
 			reasoningEffort: &effortHigh,
-			wantLevel:       "high",
+			wantLevel:       "HIGH",
 		},
 		{
-			name:            "ReasoningEffort medium maps to thinkingLevel medium",
+			name:            "ReasoningEffort medium maps to thinkingLevel MEDIUM",
 			reasoningEffort: &effortMedium,
-			wantLevel:       "medium",
+			wantLevel:       "MEDIUM",
 		},
 		{
 			name: "WithThinking overrides ReasoningEffort (provider option wins)",
@@ -1143,6 +1145,43 @@ func TestDoGenerate_ThinkingConfig(t *testing.T) {
 		{
 			name:       "no thinking config when neither set",
 			wantAbsent: true,
+		},
+		{
+			// An empty WithThinking carries no intent, so it must not suppress
+			// the request-level effort or emit a bare thinkingConfig: {}.
+			name: "empty WithThinking falls through to ReasoningEffort",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{}),
+			},
+			reasoningEffort: &effortHigh,
+			wantLevel:       "HIGH",
+		},
+		{
+			name: "empty WithThinking with no effort omits thinkingConfig",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{}),
+			},
+			wantAbsent: true,
+		},
+		{
+			// Already-uppercase input must survive unchanged.
+			name: "WithThinking uppercase level passes through",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{ThinkingLevel: "LOW"}),
+			},
+			wantLevel: "LOW",
+		},
+		{
+			// Tiers outside Google's enum are upper-cased and sent as-is rather
+			// than being remapped to a supported neighbour; the API returns 400.
+			name:            "unsupported tier is passed through uppercased",
+			reasoningEffort: &effortXHigh,
+			wantLevel:       "XHIGH",
+		},
+		{
+			name:            "whitespace-only effort omits thinkingConfig",
+			reasoningEffort: &effortBlank,
+			wantAbsent:      true,
 		},
 	}
 

--- a/provider/google/generativeai/generativeai_test.go
+++ b/provider/google/generativeai/generativeai_test.go
@@ -1030,6 +1030,200 @@ func TestProviderName(t *testing.T) {
 	}
 }
 
+// ---------- thinking config tests ----------
+
+// capturedThinkingConfig decodes the generationConfig.thinkingConfig field from
+// the request body, returning nil when the field is absent.
+func capturedThinkingConfig(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	var body struct {
+		GenerationConfig map[string]any `json:"generationConfig"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if body.GenerationConfig == nil {
+		return nil
+	}
+	tc, _ := body.GenerationConfig["thinkingConfig"].(map[string]any)
+	return tc
+}
+
+func okResponse() map[string]any {
+	return map[string]any{
+		"candidates": []map[string]any{{
+			"content":      map[string]any{"role": "model", "parts": []map[string]any{{"text": "ok"}}},
+			"finishReason": "STOP",
+		}},
+		"usageMetadata": map[string]any{
+			"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2,
+		},
+	}
+}
+
+func TestDoGenerate_ThinkingConfig(t *testing.T) {
+	budget := 1024
+	budgetDynamic := generativeai.ThinkingBudgetDynamic
+	budgetDisabled := generativeai.ThinkingBudgetDisabled
+	includeTrue := true
+	effortHigh := "high"
+	effortMedium := "medium"
+
+	tests := []struct {
+		name            string
+		providerOpts    []generativeai.Option
+		reasoningEffort *string
+		// wantAbsent is true when thinkingConfig must not appear in the request.
+		wantAbsent bool
+		// wantBudget is non-nil when thinkingBudget must be present and equal.
+		wantBudget *int
+		// wantLevel is non-empty when thinkingLevel must be present and equal.
+		wantLevel string
+		// wantIncludeThoughts is non-nil when includeThoughts must be present and equal.
+		wantIncludeThoughts *bool
+	}{
+		{
+			name: "WithThinking budget only",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{ThinkingBudget: &budget}),
+			},
+			wantBudget: &budget,
+		},
+		{
+			name: "WithThinking dynamic budget constant",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{ThinkingBudget: &budgetDynamic}),
+			},
+			wantBudget: &budgetDynamic,
+		},
+		{
+			name: "WithThinking disabled budget constant",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{ThinkingBudget: &budgetDisabled}),
+			},
+			wantBudget: &budgetDisabled,
+		},
+		{
+			name: "WithThinking level only",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{ThinkingLevel: "high"}),
+			},
+			wantLevel: "high",
+		},
+		{
+			name: "WithThinking with IncludeThoughts",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{
+					ThinkingLevel:   "medium",
+					IncludeThoughts: &includeTrue,
+				}),
+			},
+			wantLevel:           "medium",
+			wantIncludeThoughts: &includeTrue,
+		},
+		{
+			name:            "only ReasoningEffort maps to thinkingLevel",
+			reasoningEffort: &effortHigh,
+			wantLevel:       "high",
+		},
+		{
+			name:            "ReasoningEffort medium maps to thinkingLevel medium",
+			reasoningEffort: &effortMedium,
+			wantLevel:       "medium",
+		},
+		{
+			name: "WithThinking overrides ReasoningEffort (provider option wins)",
+			providerOpts: []generativeai.Option{
+				generativeai.WithThinking(generativeai.ThinkingConfig{ThinkingBudget: &budget}),
+			},
+			reasoningEffort: &effortHigh, // should be ignored
+			wantBudget:      &budget,
+			wantLevel:       "",
+		},
+		{
+			name:       "no thinking config when neither set",
+			wantAbsent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedTC map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedTC = capturedThinkingConfig(t, r)
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(okResponse())
+			}))
+			defer srv.Close()
+
+			opts := append([]generativeai.Option{
+				generativeai.WithAPIKey("k"),
+				generativeai.WithBaseURL(srv.URL),
+			}, tt.providerOpts...)
+			p := generativeai.New(opts...)
+
+			params := sdk.GenerateParams{
+				Model:           p.ChatModel("gemini-test"),
+				Messages:        []sdk.Message{sdk.UserMessage("hi")},
+				ReasoningEffort: tt.reasoningEffort,
+			}
+			if _, err := p.DoGenerate(context.Background(), params); err != nil {
+				t.Fatalf("DoGenerate: %v", err)
+			}
+
+			if tt.wantAbsent {
+				if capturedTC != nil {
+					t.Errorf("expected thinkingConfig to be absent, got %v", capturedTC)
+				}
+				return
+			}
+
+			if capturedTC == nil {
+				t.Fatal("expected thinkingConfig to be present, got nil")
+			}
+
+			if tt.wantBudget != nil {
+				// JSON numbers decode to float64 by default.
+				got, ok := capturedTC["thinkingBudget"].(float64)
+				if !ok {
+					t.Fatalf("thinkingBudget: got %T %v, want float64", capturedTC["thinkingBudget"], capturedTC["thinkingBudget"])
+				}
+				if int(got) != *tt.wantBudget {
+					t.Errorf("thinkingBudget: got %d, want %d", int(got), *tt.wantBudget)
+				}
+			} else {
+				if _, present := capturedTC["thinkingBudget"]; present {
+					t.Errorf("thinkingBudget: expected absent, got %v", capturedTC["thinkingBudget"])
+				}
+			}
+
+			if tt.wantLevel != "" {
+				if got, _ := capturedTC["thinkingLevel"].(string); got != tt.wantLevel {
+					t.Errorf("thinkingLevel: got %q, want %q", got, tt.wantLevel)
+				}
+			} else {
+				if v, present := capturedTC["thinkingLevel"]; present && v != "" {
+					t.Errorf("thinkingLevel: expected absent or empty, got %v", v)
+				}
+			}
+
+			if tt.wantIncludeThoughts != nil {
+				got, ok := capturedTC["includeThoughts"].(bool)
+				if !ok {
+					t.Fatalf("includeThoughts: got %T %v, want bool", capturedTC["includeThoughts"], capturedTC["includeThoughts"])
+				}
+				if got != *tt.wantIncludeThoughts {
+					t.Errorf("includeThoughts: got %v, want %v", got, *tt.wantIncludeThoughts)
+				}
+			} else {
+				if _, present := capturedTC["includeThoughts"]; present {
+					t.Errorf("includeThoughts: expected absent, got %v", capturedTC["includeThoughts"])
+				}
+			}
+		})
+	}
+}
+
 // ---------- integration tests (real API, skipped without env) ----------
 
 func envOrSkip(t *testing.T, key string) string {

--- a/provider/google/generativeai/types.go
+++ b/provider/google/generativeai/types.go
@@ -52,16 +52,33 @@ type functionResponseVal struct {
 }
 
 type generationConfig struct {
-	MaxOutputTokens  *int     `json:"maxOutputTokens,omitempty"`
-	Temperature      *float64 `json:"temperature,omitempty"`
-	TopP             *float64 `json:"topP,omitempty"`
-	TopK             *float64 `json:"topK,omitempty"`
-	FrequencyPenalty *float64 `json:"frequencyPenalty,omitempty"`
-	PresencePenalty  *float64 `json:"presencePenalty,omitempty"`
-	StopSequences    []string `json:"stopSequences,omitempty"`
-	Seed             *int     `json:"seed,omitempty"`
-	ResponseMimeType string   `json:"responseMimeType,omitempty"`
-	ResponseSchema   any      `json:"responseSchema,omitempty"`
+	MaxOutputTokens  *int            `json:"maxOutputTokens,omitempty"`
+	Temperature      *float64        `json:"temperature,omitempty"`
+	TopP             *float64        `json:"topP,omitempty"`
+	TopK             *float64        `json:"topK,omitempty"`
+	FrequencyPenalty *float64        `json:"frequencyPenalty,omitempty"`
+	PresencePenalty  *float64        `json:"presencePenalty,omitempty"`
+	StopSequences    []string        `json:"stopSequences,omitempty"`
+	Seed             *int            `json:"seed,omitempty"`
+	ResponseMimeType string          `json:"responseMimeType,omitempty"`
+	ResponseSchema   any             `json:"responseSchema,omitempty"`
+	ThinkingConfig   *thinkingConfig `json:"thinkingConfig,omitempty"`
+}
+
+// thinkingConfig mirrors the upstream Google GenerativeAI API shape.
+// ThinkingBudget and ThinkingLevel are two parallel optional fields on the same
+// struct, exactly as the official google-genai SDK models them. No mutual-exclusion
+// check is performed here; misuse surfaces as a 400 from the API.
+type thinkingConfig struct {
+	// ThinkingBudget is the token budget for thinking on 2.5-generation models.
+	// Use ThinkingBudgetDynamic (-1) for automatic and ThinkingBudgetDisabled (0)
+	// to disable (legal on Flash/Lite; rejected by 2.5 Pro).
+	ThinkingBudget *int `json:"thinkingBudget,omitempty"`
+	// ThinkingLevel is the effort tier for 3.x-generation models.
+	// Values: "minimal", "low", "medium", "high".
+	ThinkingLevel string `json:"thinkingLevel,omitempty"`
+	// IncludeThoughts controls whether thought content is returned in the response.
+	IncludeThoughts *bool `json:"includeThoughts,omitempty"`
 }
 
 type toolGroup struct {

--- a/provider/google/generativeai/types.go
+++ b/provider/google/generativeai/types.go
@@ -69,13 +69,20 @@ type generationConfig struct {
 // ThinkingBudget and ThinkingLevel are two parallel optional fields on the same
 // struct, exactly as the official google-genai SDK models them. No mutual-exclusion
 // check is performed here; misuse surfaces as a 400 from the API.
+//
+// Two deliberate divergences from google-genai: IncludeThoughts is a *bool
+// rather than a bool so an explicit false is distinguishable from unset, and
+// ThinkingBudget is a *int rather than a *int32 to match Go conventions in this
+// SDK. Neither changes the wire format.
 type thinkingConfig struct {
 	// ThinkingBudget is the token budget for thinking on 2.5-generation models.
 	// Use ThinkingBudgetDynamic (-1) for automatic and ThinkingBudgetDisabled (0)
 	// to disable (legal on Flash/Lite; rejected by 2.5 Pro).
 	ThinkingBudget *int `json:"thinkingBudget,omitempty"`
-	// ThinkingLevel is the effort tier for 3.x-generation models.
-	// Values: "minimal", "low", "medium", "high".
+	// ThinkingLevel is the effort tier for 3.x-generation models. This is a proto
+	// enum on the wire and only accepts uppercase members: "MINIMAL", "LOW",
+	// "MEDIUM", "HIGH". Callers pass tiers in any case; buildRequest upper-cases
+	// them before they reach this struct.
 	ThinkingLevel string `json:"thinkingLevel,omitempty"`
 	// IncludeThoughts controls whether thought content is returned in the response.
 	IncludeThoughts *bool `json:"includeThoughts,omitempty"`


### PR DESCRIPTION
## Summary

Implements the first step (T1) of the reasoning-controls roadmap in #41: wires thinking into the Google Generative AI provider's **request** path. Previously the provider handled reasoning only on the *output* side (translating thought content into `ReasoningStart/Delta/End` stream parts); every `ReasoningEffort` passed by a caller was silently dropped, making all Gemini reasoning controls a placebo.

Refs #41

## What changed

**`provider/google/generativeai/types.go`**
- Added unexported `thinkingConfig` struct — a faithful mirror of the upstream Google API wire shape: `thinkingBudget *int`, `thinkingLevel string`, `includeThoughts *bool` with matching JSON tags and `omitempty`.
- Added `ThinkingConfig *thinkingConfig` field to `generationConfig` (`omitempty`, so omitted when nil).

**`provider/google/generativeai/generativeai.go`**
- Exported `ThinkingConfig` struct for callers.
- Added named constants `ThinkingBudgetDynamic = -1` (AUTOMATIC) and `ThinkingBudgetDisabled = 0` (DISABLED) — an improvement over the upstream SDK, which leaves these as undocumented magic numbers in field descriptions.
- Added `WithThinking(ThinkingConfig) Option` and `thinking *ThinkingConfig` field on `Provider`.
- Updated `buildRequest` to populate `generationConfig.ThinkingConfig`:
  - **Provider option (`WithThinking`) wins** when both it and `params.ReasoningEffort` are set — the more expressive, explicit option takes precedence. This rule is documented in the function comment.
  - When **only `params.ReasoningEffort`** is set, it is forwarded as `thinkingLevel` (structurally equivalent for 3.x-generation models).
  - When **neither** is set, `thinkingConfig` is omitted entirely (`omitempty`).

**`provider/google/generativeai/generativeai_test.go`**
- Added `TestDoGenerate_ThinkingConfig` — a table-driven unit test covering all five specified scenarios: `WithThinking` with budget, with `ThinkingBudgetDynamic`/`ThinkingBudgetDisabled` constants, with level, with `IncludeThoughts`; only `ReasoningEffort` maps to `thinkingLevel`; `WithThinking` overrides `ReasoningEffort`; neither set means `thinkingConfig` is absent from the request.

## Design constraints intentionally respected

| Constraint | How |
|---|---|
| **No model-ID sniffing** | `buildRequest` contains zero string operations on `params.Model.ID`. The caller (Memoh) is responsible for choosing the right field per generation. |
| **No client-side validation** | Budget ranges and `thinkingBudget`/`thinkingLevel` mutual exclusivity are not checked. Google's own Go/Python/JS SDKs perform zero such checks. Misuse surfaces as a 400 from the API. |
| **Faithful upstream mirror** | Both fields are parallel on the same struct because the upstream protobuf shape dictates it — not modelled as a union. |
| **`go.mod` untouched** | No version bump, no new dependency. |

## Verification

```
go build ./...       # exit 0
go test ./provider/google/... -v 2>&1 | tail -20   # all pass
go vet ./...         # exit 0
```

```
ok  github.com/memohai/twilight-ai/provider/google/embedding       0.916s
ok  github.com/memohai/twilight-ai/provider/google/generativeai    0.971s
ok  github.com/memohai/twilight-ai/provider/google/transcription   0.957s
```

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.