### PR TITLE
feat(anthropic): model thinking config as a union, retire NormalizeReasoningEffort

### DIFF
--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -33,9 +33,94 @@ const (
 )
 
 // ThinkingConfig controls extended thinking for Anthropic models.
+//
+// This flat shape can express combinations the API rejects, such as
+// {Type: "adaptive", BudgetTokens: 8000}. Prefer the constructor options
+// WithThinkingEnabled, WithThinkingAdaptive and WithThinkingDisabled, which
+// model the same wire object as a union so the illegal combination cannot be
+// built. This type remains fully supported for existing callers.
 type ThinkingConfig struct {
 	Type         string // "enabled", "adaptive", or "disabled"
 	BudgetTokens int    // required when Type is "enabled"
+}
+
+// thinkingConfigUnion mirrors Anthropic's ThinkingConfigParamUnion: exactly one
+// variant is set, and the adaptive variant deliberately has no budget field so
+// adaptive-plus-budget is unrepresentable rather than merely discouraged.
+//
+// A fourth "passthrough" variant carries type strings the SDK does not know
+// about. The SDK executes what a caller declared; it does not validate it, so an
+// unrecognised type reaches the wire untouched and the server decides.
+type thinkingConfigUnion struct {
+	enabled     *thinkingEnabled
+	adaptive    *thinkingAdaptive
+	disabled    *thinkingDisabled
+	passthrough *thinkingPassthrough
+}
+
+// thinkingEnabled is the budget-based mode used by Claude 4.5 and earlier.
+type thinkingEnabled struct {
+	budgetTokens int
+}
+
+// thinkingAdaptive is the mode used by Claude 4.6 and later. It has no budget
+// field: budget_tokens is deprecated on 4.6 and rejected outright by 4.7+, and
+// effort is carried per request through output_config.effort instead.
+type thinkingAdaptive struct{}
+
+// thinkingDisabled turns extended thinking off.
+type thinkingDisabled struct{}
+
+// thinkingPassthrough carries an unrecognised ThinkingConfig from the legacy
+// flat API verbatim. It is unreachable from the union constructors.
+type thinkingPassthrough struct {
+	typ          string
+	budgetTokens int
+}
+
+// active reports whether the union asks for thinking at all. Disabled and unset
+// are both inactive.
+func (t *thinkingConfigUnion) active() bool {
+	if t == nil {
+		return false
+	}
+	return t.enabled != nil || t.adaptive != nil || t.passthrough != nil
+}
+
+// explicitBudget returns the thinking token budget the caller asked for, and
+// whether one was set. Adaptive and disabled never carry a budget.
+func (t *thinkingConfigUnion) explicitBudget() (int, bool) {
+	if t == nil {
+		return 0, false
+	}
+	switch {
+	case t.enabled != nil && t.enabled.budgetTokens > 0:
+		return t.enabled.budgetTokens, true
+	case t.passthrough != nil && t.passthrough.budgetTokens > 0:
+		return t.passthrough.budgetTokens, true
+	default:
+		return 0, false
+	}
+}
+
+// wire renders the union into the request object, or nil when no thinking block
+// should be sent.
+func (t *thinkingConfigUnion) wire() *anthropicThinking {
+	if t == nil {
+		return nil
+	}
+	switch {
+	case t.enabled != nil:
+		return &anthropicThinking{Type: "enabled", BudgetTokens: t.enabled.budgetTokens}
+	case t.adaptive != nil:
+		// No budget field exists on this variant, so none can be sent.
+		return &anthropicThinking{Type: "adaptive"}
+	case t.passthrough != nil:
+		return &anthropicThinking{Type: t.passthrough.typ, BudgetTokens: t.passthrough.budgetTokens}
+	default:
+		// Disabled is expressed by omitting the block entirely.
+		return nil
+	}
 }
 
 type Provider struct {
@@ -44,7 +129,7 @@ type Provider struct {
 	baseURL                       string
 	httpClient                    *http.Client
 	headers                       map[string]string
-	thinking                      *ThinkingConfig
+	thinking                      *thinkingConfigUnion
 	supportsMidConversationSystem bool
 }
 
@@ -83,10 +168,80 @@ func WithHeaders(headers map[string]string) Option {
 	}
 }
 
-// WithThinking enables extended thinking for all requests made by this provider.
+// WithThinking enables extended thinking for all requests made by this provider
+// using the flat ThinkingConfig shape.
+//
+// It is retained for existing callers and produces exactly the same wire output
+// as before. New code should prefer WithThinkingEnabled, WithThinkingAdaptive or
+// WithThinkingDisabled, which cannot express a mode/budget combination the API
+// rejects. A ThinkingConfig with an empty Type configures no thinking at all.
 func WithThinking(cfg ThinkingConfig) Option {
 	return func(p *Provider) {
-		p.thinking = &cfg
+		p.thinking = thinkingFromLegacyConfig(cfg)
+	}
+}
+
+// thinkingFromLegacyConfig lowers the flat ThinkingConfig onto the union.
+// Unrecognised types become a passthrough variant so this conversion never
+// changes what an existing caller puts on the wire.
+func thinkingFromLegacyConfig(cfg ThinkingConfig) *thinkingConfigUnion {
+	switch cfg.Type {
+	case "":
+		return nil
+	case "enabled":
+		return &thinkingConfigUnion{enabled: &thinkingEnabled{budgetTokens: cfg.BudgetTokens}}
+	case "adaptive":
+		// The legacy struct allows a budget here, but adaptive takes none and
+		// the pre-union code never sent one, so it is dropped exactly as before.
+		return &thinkingConfigUnion{adaptive: &thinkingAdaptive{}}
+	case thinkingTypeDisabled:
+		return &thinkingConfigUnion{disabled: &thinkingDisabled{}}
+	default:
+		return &thinkingConfigUnion{passthrough: &thinkingPassthrough{
+			typ:          cfg.Type,
+			budgetTokens: cfg.BudgetTokens,
+		}}
+	}
+}
+
+// WithThinkingEnabled turns on budget-based extended thinking, sending
+// thinking{type:"enabled", budget_tokens:N}.
+//
+// This is the shape accepted by Claude 4.5 and earlier. On those models
+// output_config.effort alone does not turn thinking on, so this option is how a
+// caller enables it. budget_tokens is deprecated on Claude 4.6 and rejected with
+// a 400 by 4.7+; use WithThinkingAdaptive for those. The SDK never infers the
+// model generation, so choosing the right option is the caller's decision.
+//
+// When no explicit MaxTokens is supplied, the budget is added on top of the
+// default answer allowance so thinking does not consume the answer's room.
+func WithThinkingEnabled(budgetTokens int) Option {
+	return func(p *Provider) {
+		p.thinking = &thinkingConfigUnion{enabled: &thinkingEnabled{budgetTokens: budgetTokens}}
+	}
+}
+
+// WithThinkingAdaptive turns on adaptive extended thinking, sending
+// thinking{type:"adaptive"} with no budget.
+//
+// This is the shape used by Claude 4.6 and later, where the depth of thinking is
+// steered per request through output_config.effort (see
+// sdk.GenerateParams.ReasoningEffort) rather than a token budget. There is
+// deliberately no budget parameter: adaptive thinking takes none.
+func WithThinkingAdaptive() Option {
+	return func(p *Provider) {
+		p.thinking = &thinkingConfigUnion{adaptive: &thinkingAdaptive{}}
+	}
+}
+
+// WithThinkingDisabled turns extended thinking off by omitting the thinking
+// block from requests.
+//
+// Note that a ReasoningEffort on the request still sends output_config.effort;
+// this option only controls the thinking block.
+func WithThinkingDisabled() Option {
+	return func(p *Provider) {
+		p.thinking = &thinkingConfigUnion{disabled: &thinkingDisabled{}}
 	}
 }
 
@@ -265,12 +420,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*messagesRequest, e
 		req.ToolChoice = convertToolChoice(params.ToolChoice)
 	}
 
-	if p.thinking != nil && p.thinking.Type != "" && p.thinking.Type != thinkingTypeDisabled {
-		req.Thinking = &anthropicThinking{
-			Type:         p.thinking.Type,
-			BudgetTokens: p.thinking.BudgetTokens,
-		}
-	}
+	req.Thinking = p.thinking.wire()
 
 	// Reasoning effort is carried via output_config.effort. On modern Claude
 	// models (>= 4.6) this is the supported control; budget_tokens is deprecated
@@ -285,17 +435,24 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*messagesRequest, e
 	return req, nil
 }
 
-func resolveMaxTokens(params *sdk.GenerateParams, thinking *ThinkingConfig) *int {
+// resolveMaxTokens derives the output cap for a request.
+//
+// The three outcomes below are behaviour-critical: an explicit thinking budget
+// must be added to the answer allowance, and budget-less reasoning must lift the
+// cap off the low default. Collapsing either case back to defaultMaxTokens
+// silently truncates thinking output rather than failing, so the full matrix is
+// pinned by TestResolveMaxTokens_Matrix.
+func resolveMaxTokens(params *sdk.GenerateParams, thinking *thinkingConfigUnion) *int {
 	if params.MaxTokens != nil {
 		return params.MaxTokens
 	}
 
 	maxTokens := defaultMaxTokens
-	switch {
-	case thinking != nil && thinking.Type != "" && thinking.Type != thinkingTypeDisabled && thinking.BudgetTokens > 0:
+	switch budget, hasBudget := thinking.explicitBudget(); {
+	case hasBudget:
 		// Explicit budget thinking: reserve room for the thinking budget on top
 		// of the answer budget.
-		maxTokens += thinking.BudgetTokens
+		maxTokens += budget
 	case reasoningActive(params, thinking):
 		// Effort-based or adaptive thinking carries no explicit budget, but the
 		// model still needs generous headroom (reasoning + answer). The low 4096
@@ -308,8 +465,8 @@ func resolveMaxTokens(params *sdk.GenerateParams, thinking *ThinkingConfig) *int
 
 // reasoningActive reports whether the request enables reasoning without an
 // explicit token budget (adaptive thinking and/or output_config.effort).
-func reasoningActive(params *sdk.GenerateParams, thinking *ThinkingConfig) bool {
-	if thinking != nil && thinking.Type != "" && thinking.Type != thinkingTypeDisabled {
+func reasoningActive(params *sdk.GenerateParams, thinking *thinkingConfigUnion) bool {
+	if thinking.active() {
 		return true
 	}
 	if params.ReasoningEffort != nil && strings.TrimSpace(*params.ReasoningEffort) != "" {

--- a/provider/anthropic/messages/thinking_test.go
+++ b/provider/anthropic/messages/thinking_test.go
@@ -1,0 +1,392 @@
+package messages_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/anthropic/messages"
+	"github.com/memohai/twilight-ai/sdk"
+)
+
+// capturedThinking mirrors the wire shape of the request fields this file cares
+// about, so assertions run against the JSON that actually leaves the process
+// rather than against internal state.
+type capturedThinking struct {
+	MaxTokens int `json:"max_tokens"`
+	Thinking  *struct {
+		Type         string `json:"type"`
+		BudgetTokens *int   `json:"budget_tokens"`
+	} `json:"thinking"`
+	OutputConfig *struct {
+		Effort string `json:"effort"`
+	} `json:"output_config"`
+}
+
+// captureRequest runs one DoGenerate against a stub server and returns the
+// decoded request body.
+func captureRequest(t *testing.T, opts []messages.Option, params sdk.GenerateParams) capturedThinking {
+	t.Helper()
+
+	var captured capturedThinking
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_capture", "type": "message", "model": "claude-test", "role": "assistant",
+			"content":     []map[string]any{{"type": "text", "text": "OK"}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	defer srv.Close()
+
+	all := append([]messages.Option{
+		messages.WithAPIKey("test-key"),
+		messages.WithBaseURL(srv.URL),
+	}, opts...)
+
+	params.Model = &sdk.Model{ID: "claude-test"}
+	if params.Messages == nil {
+		params.Messages = []sdk.Message{sdk.UserMessage("Hi")}
+	}
+
+	if _, err := messages.New(all...).DoGenerate(context.Background(), params); err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+	return captured
+}
+
+func effortPtr(s string) *string { return &s }
+
+func intPtr(i int) *int { return &i }
+
+// TestResolveMaxTokens_Matrix pins the max_tokens arithmetic across every
+// combination of thinking mode and reasoning effort.
+//
+// This is the regression surface flagged in the design doc: max_tokens is
+// derived from whether thinking is active and whether it carries an explicit
+// budget. Getting it wrong silently truncates thinking output on legacy Claude
+// models, which no other assertion in this package would catch. The expected
+// values here were captured from the pre-union implementation and must not
+// change.
+func TestResolveMaxTokens_Matrix(t *testing.T) {
+	const (
+		defaultMax   = 4096  // no reasoning at all
+		reasoningMax = 32000 // reasoning active without an explicit budget
+	)
+
+	tests := []struct {
+		name          string
+		opts          []messages.Option
+		effort        *string
+		explicitMax   *int
+		wantMaxTokens int
+	}{
+		// --- enabled: budget is added on top of the answer budget ---
+		{
+			name:          "enabled/budget 1024",
+			opts:          []messages.Option{messages.WithThinkingEnabled(1024)},
+			wantMaxTokens: defaultMax + 1024,
+		},
+		{
+			name:          "enabled/budget 5000",
+			opts:          []messages.Option{messages.WithThinkingEnabled(5000)},
+			wantMaxTokens: defaultMax + 5000,
+		},
+		{
+			name:          "enabled/budget 50000",
+			opts:          []messages.Option{messages.WithThinkingEnabled(50000)},
+			wantMaxTokens: defaultMax + 50000,
+		},
+		{
+			// A zero budget is not an explicit budget, so this falls through to
+			// the reasoning-aware default rather than staying at 4096.
+			name:          "enabled/budget 0",
+			opts:          []messages.Option{messages.WithThinkingEnabled(0)},
+			wantMaxTokens: reasoningMax,
+		},
+		{
+			name:          "enabled/budget 8000 + effort",
+			opts:          []messages.Option{messages.WithThinkingEnabled(8000)},
+			effort:        effortPtr("high"),
+			wantMaxTokens: defaultMax + 8000,
+		},
+
+		// --- adaptive: never carries a budget ---
+		{
+			name:          "adaptive",
+			opts:          []messages.Option{messages.WithThinkingAdaptive()},
+			wantMaxTokens: reasoningMax,
+		},
+		{
+			name:          "adaptive + effort",
+			opts:          []messages.Option{messages.WithThinkingAdaptive()},
+			effort:        effortPtr("xhigh"),
+			wantMaxTokens: reasoningMax,
+		},
+
+		// --- disabled: reasoning is off, so the plain default applies ---
+		{
+			name:          "disabled",
+			opts:          []messages.Option{messages.WithThinkingDisabled()},
+			wantMaxTokens: defaultMax,
+		},
+		{
+			// output_config.effort still counts as reasoning even when the
+			// thinking block is explicitly disabled.
+			name:          "disabled + effort",
+			opts:          []messages.Option{messages.WithThinkingDisabled()},
+			effort:        effortPtr("medium"),
+			wantMaxTokens: reasoningMax,
+		},
+
+		// --- effort only, no thinking option ---
+		{
+			name:          "effort only",
+			effort:        effortPtr("high"),
+			wantMaxTokens: reasoningMax,
+		},
+		{
+			name:          "effort blank is not reasoning",
+			effort:        effortPtr("   "),
+			wantMaxTokens: defaultMax,
+		},
+
+		// --- neither ---
+		{
+			name:          "no thinking, no effort",
+			wantMaxTokens: defaultMax,
+		},
+
+		// --- explicit MaxTokens always wins ---
+		{
+			name:          "explicit max_tokens beats enabled budget",
+			opts:          []messages.Option{messages.WithThinkingEnabled(5000)},
+			explicitMax:   intPtr(777),
+			wantMaxTokens: 777,
+		},
+		{
+			name:          "explicit max_tokens beats adaptive",
+			opts:          []messages.Option{messages.WithThinkingAdaptive()},
+			explicitMax:   intPtr(888),
+			wantMaxTokens: 888,
+		},
+		{
+			name:          "explicit max_tokens beats effort",
+			effort:        effortPtr("high"),
+			explicitMax:   intPtr(999),
+			wantMaxTokens: 999,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := captureRequest(t, tc.opts, sdk.GenerateParams{
+				ReasoningEffort: tc.effort,
+				MaxTokens:       tc.explicitMax,
+			})
+			if got.MaxTokens != tc.wantMaxTokens {
+				t.Errorf("max_tokens: got %d, want %d", got.MaxTokens, tc.wantMaxTokens)
+			}
+		})
+	}
+}
+
+// TestThinkingWireShape checks what each option actually serializes to,
+// independent of the max_tokens arithmetic.
+func TestThinkingWireShape(t *testing.T) {
+	tests := []struct {
+		name           string
+		opts           []messages.Option
+		wantAbsent     bool
+		wantType       string
+		wantBudget     *int
+		wantBudgetSent bool
+	}{
+		{
+			name:           "enabled sends type and budget",
+			opts:           []messages.Option{messages.WithThinkingEnabled(5000)},
+			wantType:       "enabled",
+			wantBudget:     intPtr(5000),
+			wantBudgetSent: true,
+		},
+		{
+			name:     "adaptive sends type only",
+			opts:     []messages.Option{messages.WithThinkingAdaptive()},
+			wantType: "adaptive",
+		},
+		{
+			// Disabled thinking is expressed by omitting the block entirely,
+			// matching the pre-union behaviour.
+			name:       "disabled omits the thinking block",
+			opts:       []messages.Option{messages.WithThinkingDisabled()},
+			wantAbsent: true,
+		},
+		{
+			name:       "no option omits the thinking block",
+			wantAbsent: true,
+		},
+		{
+			name:     "last thinking option wins",
+			opts:     []messages.Option{messages.WithThinkingEnabled(5000), messages.WithThinkingAdaptive()},
+			wantType: "adaptive",
+		},
+		{
+			name:       "adaptive then disabled omits the block",
+			opts:       []messages.Option{messages.WithThinkingAdaptive(), messages.WithThinkingDisabled()},
+			wantAbsent: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := captureRequest(t, tc.opts, sdk.GenerateParams{})
+
+			if tc.wantAbsent {
+				if got.Thinking != nil {
+					t.Fatalf("thinking should be absent, got %+v", *got.Thinking)
+				}
+				return
+			}
+
+			if got.Thinking == nil {
+				t.Fatalf("thinking should be present, got nil")
+			}
+			if got.Thinking.Type != tc.wantType {
+				t.Errorf("thinking.type: got %q, want %q", got.Thinking.Type, tc.wantType)
+			}
+
+			switch {
+			case tc.wantBudgetSent:
+				if got.Thinking.BudgetTokens == nil {
+					t.Errorf("budget_tokens: got absent, want %d", *tc.wantBudget)
+				} else if *got.Thinking.BudgetTokens != *tc.wantBudget {
+					t.Errorf("budget_tokens: got %d, want %d", *got.Thinking.BudgetTokens, *tc.wantBudget)
+				}
+			default:
+				if got.Thinking.BudgetTokens != nil {
+					t.Errorf("budget_tokens must be omitted for %s, got %d", tc.wantType, *got.Thinking.BudgetTokens)
+				}
+			}
+		})
+	}
+}
+
+// TestWithThinking_BackwardCompatibility proves the legacy flat-struct API
+// still produces byte-identical wire output after the union refactor.
+//
+// ThinkingConfig and WithThinking are exported and in use downstream (Memoh
+// constructs them by generation), so the union is additive: the old path must
+// keep working, not merely compile.
+func TestWithThinking_BackwardCompatibility(t *testing.T) {
+	tests := []struct {
+		name   string
+		legacy messages.ThinkingConfig
+		modern []messages.Option
+	}{
+		{
+			name:   "enabled with budget",
+			legacy: messages.ThinkingConfig{Type: "enabled", BudgetTokens: 5000},
+			modern: []messages.Option{messages.WithThinkingEnabled(5000)},
+		},
+		{
+			name:   "adaptive",
+			legacy: messages.ThinkingConfig{Type: "adaptive"},
+			modern: []messages.Option{messages.WithThinkingAdaptive()},
+		},
+		{
+			name:   "disabled",
+			legacy: messages.ThinkingConfig{Type: "disabled"},
+			modern: []messages.Option{messages.WithThinkingDisabled()},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := captureRequest(t, []messages.Option{messages.WithThinking(tc.legacy)}, sdk.GenerateParams{})
+			modern := captureRequest(t, tc.modern, sdk.GenerateParams{})
+
+			legacyJSON, err := json.Marshal(legacy)
+			if err != nil {
+				t.Fatalf("marshal legacy: %v", err)
+			}
+			modernJSON, err := json.Marshal(modern)
+			if err != nil {
+				t.Fatalf("marshal modern: %v", err)
+			}
+			if string(legacyJSON) != string(modernJSON) {
+				t.Errorf("wire output diverged:\n legacy = %s\n modern = %s", legacyJSON, modernJSON)
+			}
+		})
+	}
+}
+
+// TestWithThinking_LegacyExactWire pins the exact bytes the legacy call path
+// produced before the union existed, so a refactor cannot quietly change what
+// downstream callers send.
+func TestWithThinking_LegacyExactWire(t *testing.T) {
+	got := captureRequest(t,
+		[]messages.Option{messages.WithThinking(messages.ThinkingConfig{Type: "enabled", BudgetTokens: 5000})},
+		sdk.GenerateParams{},
+	)
+
+	if got.Thinking == nil {
+		t.Fatal("thinking block missing")
+	}
+	if got.Thinking.Type != "enabled" {
+		t.Errorf("thinking.type: got %q, want %q", got.Thinking.Type, "enabled")
+	}
+	if got.Thinking.BudgetTokens == nil || *got.Thinking.BudgetTokens != 5000 {
+		t.Errorf("budget_tokens: got %v, want 5000", got.Thinking.BudgetTokens)
+	}
+	if got.MaxTokens != 4096+5000 {
+		t.Errorf("max_tokens: got %d, want %d", got.MaxTokens, 4096+5000)
+	}
+	if got.OutputConfig != nil {
+		t.Errorf("output_config should be absent, got %+v", *got.OutputConfig)
+	}
+}
+
+// TestWithThinking_LegacyUnknownType keeps the pre-union passthrough behaviour
+// for type strings the SDK does not recognise: they are forwarded verbatim and
+// the server decides. The SDK does not validate what a caller declared.
+func TestWithThinking_LegacyUnknownType(t *testing.T) {
+	got := captureRequest(t,
+		[]messages.Option{messages.WithThinking(messages.ThinkingConfig{Type: "future_mode", BudgetTokens: 1234})},
+		sdk.GenerateParams{},
+	)
+
+	if got.Thinking == nil {
+		t.Fatal("thinking block missing")
+	}
+	if got.Thinking.Type != "future_mode" {
+		t.Errorf("thinking.type: got %q, want %q", got.Thinking.Type, "future_mode")
+	}
+	if got.Thinking.BudgetTokens == nil || *got.Thinking.BudgetTokens != 1234 {
+		t.Errorf("budget_tokens: got %v, want 1234", got.Thinking.BudgetTokens)
+	}
+	if got.MaxTokens != 4096+1234 {
+		t.Errorf("max_tokens: got %d, want %d", got.MaxTokens, 4096+1234)
+	}
+}
+
+// TestWithThinking_LegacyEmptyType covers the zero-value ThinkingConfig, which
+// the pre-union code treated as "no thinking configured".
+func TestWithThinking_LegacyEmptyType(t *testing.T) {
+	got := captureRequest(t,
+		[]messages.Option{messages.WithThinking(messages.ThinkingConfig{})},
+		sdk.GenerateParams{},
+	)
+
+	if got.Thinking != nil {
+		t.Errorf("thinking should be absent for a zero-value config, got %+v", *got.Thinking)
+	}
+	if got.MaxTokens != 4096 {
+		t.Errorf("max_tokens: got %d, want 4096", got.MaxTokens)
+	}
+}

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
-	openaiutil "github.com/memohai/twilight-ai/provider/openai"
 	"github.com/memohai/twilight-ai/sdk"
 )
 
@@ -257,7 +256,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*chatRequest, error
 		FrequencyPenalty:    params.FrequencyPenalty,
 		PresencePenalty:     params.PresencePenalty,
 		Seed:                params.Seed,
-		ReasoningEffort:     normalizeReasoningEffort(params.ReasoningEffort),
+		ReasoningEffort:     params.ReasoningEffort,
 		PromptCacheKey:      params.PromptCacheKey,
 	}
 	if len(params.StopSequences) > 0 {
@@ -277,14 +276,6 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*chatRequest, error
 		return nil, err
 	}
 	return req, nil
-}
-
-func normalizeReasoningEffort(effort *string) *string {
-	if effort == nil {
-		return nil
-	}
-	normalized := openaiutil.NormalizeReasoningEffort(*effort)
-	return &normalized
 }
 
 func (p *Provider) applyChatCompletionsCompat(req *chatRequest) error {

--- a/provider/openai/completions/completions_test.go
+++ b/provider/openai/completions/completions_test.go
@@ -931,7 +931,10 @@ func TestDoGenerate_DeepSeekCompatLeavesOtherReasoningEffortAlone(t *testing.T) 
 	}
 }
 
-func TestDoGenerate_MapsMaxReasoningEffortToXHigh(t *testing.T) {
+// TestDoGenerate_ForwardsMaxReasoningEffortVerbatim pins that the SDK no longer
+// rewrites "max" into "xhigh". Effort is an open enum, so an unsupported tier is
+// the endpoint's 400 to return rather than the SDK's to silently downgrade.
+func TestDoGenerate_ForwardsMaxReasoningEffortVerbatim(t *testing.T) {
 	var body struct {
 		ReasoningEffort *string `json:"reasoning_effort"`
 	}
@@ -962,8 +965,8 @@ func TestDoGenerate_MapsMaxReasoningEffortToXHigh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DoGenerate: %v", err)
 	}
-	if body.ReasoningEffort == nil || *body.ReasoningEffort != "xhigh" {
-		t.Fatalf("reasoning_effort: got %v, want xhigh", body.ReasoningEffort)
+	if body.ReasoningEffort == nil || *body.ReasoningEffort != "max" {
+		t.Fatalf("reasoning_effort: got %v, want max (forwarded verbatim)", body.ReasoningEffort)
 	}
 }
 

--- a/provider/openai/reasoning.go
+++ b/provider/openai/reasoning.go
@@ -1,16 +1,19 @@
 package openai
 
-import "strings"
-
-// NormalizeReasoningEffort maps effort strings that are not accepted by the
-// OpenAI wire format into the closest supported equivalent. Currently this
-// rewrites "max" → "xhigh" because OpenAI-format endpoints reject "max".
+// NormalizeReasoningEffort returns effort unchanged.
 //
-// NOTE: The Memoh server also filters "max" out of the selectable effort list
-// before it reaches the SDK, so this is a defence-in-depth measure.
+// Deprecated: this function no longer has any effect and will be removed in the
+// next release. Callers should pass the effort straight through.
+//
+// It previously rewrote "max" into "xhigh" for OpenAI-format endpoints. That
+// rewrite encoded a guess about what OpenAI would accept rather than something a
+// caller had declared: on the day "max" becomes supported, it would silently
+// downgrade every such request, with no diagnostic and no obvious culprit. Effort
+// is an open enum precisely so new tiers work without an SDK release, and no
+// official provider SDK maintains a tier allow-list. An effort the endpoint does
+// not accept is the provider's 400 to return, not the SDK's to predict.
+//
+// The empty shell remains for one release because the symbol is exported.
 func NormalizeReasoningEffort(effort string) string {
-	if strings.EqualFold(strings.TrimSpace(effort), "max") {
-		return "xhigh"
-	}
 	return effort
 }

--- a/provider/openai/reasoning_test.go
+++ b/provider/openai/reasoning_test.go
@@ -1,0 +1,21 @@
+package openai_test
+
+import (
+	"testing"
+
+	openai "github.com/memohai/twilight-ai/provider/openai"
+)
+
+// TestNormalizeReasoningEffort_IsIdentity pins the shell behaviour: the function
+// is retained only because it is exported, and must not transform anything. In
+// particular "max" is no longer rewritten to "xhigh".
+func TestNormalizeReasoningEffort_IsIdentity(t *testing.T) {
+	for _, effort := range []string{
+		"max", "MAX", "  max  ", "xhigh", "high", "medium", "low", "minimal", "none", "",
+		"some-future-tier",
+	} {
+		if got := openai.NormalizeReasoningEffort(effort); got != effort {
+			t.Errorf("NormalizeReasoningEffort(%q): got %q, want it unchanged", effort, got)
+		}
+	}
+}

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
-	openaiutil "github.com/memohai/twilight-ai/provider/openai"
 	"github.com/memohai/twilight-ai/sdk"
 )
 
@@ -242,7 +241,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*responsesRequest, 
 	}
 
 	if params.ReasoningEffort != nil {
-		req.Reasoning = &responsesReasoning{Effort: openaiutil.NormalizeReasoningEffort(*params.ReasoningEffort)}
+		req.Reasoning = &responsesReasoning{Effort: *params.ReasoningEffort}
 	}
 
 	return req, nil

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -193,7 +193,11 @@ func TestResponsesDoGenerate_PromptCacheKeyOmittedWhenUnset(t *testing.T) {
 	}
 }
 
-func TestResponsesDoGenerate_MapsMaxReasoningEffortToXHigh(t *testing.T) {
+// TestResponsesDoGenerate_ForwardsMaxReasoningEffortVerbatim pins that the SDK
+// no longer rewrites "max" into "xhigh". Effort is an open enum, so an
+// unsupported tier is the endpoint's 400 to return rather than the SDK's to
+// silently downgrade.
+func TestResponsesDoGenerate_ForwardsMaxReasoningEffortVerbatim(t *testing.T) {
 	var body struct {
 		Reasoning *struct {
 			Effort string `json:"effort"`
@@ -232,8 +236,8 @@ func TestResponsesDoGenerate_MapsMaxReasoningEffortToXHigh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DoGenerate: %v", err)
 	}
-	if body.Reasoning == nil || body.Reasoning.Effort != "xhigh" {
-		t.Fatalf("reasoning.effort: got %#v, want xhigh", body.Reasoning)
+	if body.Reasoning == nil || body.Reasoning.Effort != "max" {
+		t.Fatalf("reasoning.effort: got %#v, want max (forwarded verbatim)", body.Reasoning)
 	}
 }
 


### PR DESCRIPTION
Refs #41 — this is **T2** of the roadmap. Independent of T1 (Google, already merged); branched from `main` so it does not overlap `feat/google-thinking`.

## The problem

`ThinkingConfig{Type string, BudgetTokens int}` is a flat struct, so `{Type: "adaptive", BudgetTokens: 8000}` is constructible even though adaptive thinking takes no budget. Claude 4.7+ rejects `budget_tokens` outright, so the illegal combination was only caught after a network round trip.

## Making the illegal state unrepresentable

The wire object is now modelled as a union in the shape the official Go SDK uses (`ThinkingConfigParamUnion` with `OfEnabled`/`OfDisabled`/`OfAdaptive`), where **the adaptive variant has no budget field at all**:

```go
WithThinkingEnabled(budgetTokens int)  // <=4.5 -> thinking{type:"enabled",budget_tokens:N}
WithThinkingAdaptive()                 // 4.6+  -> thinking{type:"adaptive"}
WithThinkingDisabled()                 //       -> thinking block omitted
```

`WithThinkingAdaptive` takes no arguments, so adaptive-plus-budget is a **compile error**, not a runtime check:

```
vet: too many arguments in call to messages.WithThinkingAdaptive
        have (number)
        want ()
```

Nothing needs a conflict rule once the conflict cannot be built. Consistent with the rules in the issue, this adds **no client-side semantic validation** and **no model-id sniffing** — generation stays a caller declaration, and misuse stays the provider's 400 to return.

## resolveMaxTokens: the regression guard

`resolveMaxTokens` / `reasoningActive` derive `max_tokens` from whether thinking is active and whether it carries an explicit budget (`4096` / `4096+budget` / `32000`). This is the most dangerous part of the change: getting it wrong **silently truncates thinking output on legacy Claude** instead of failing loudly, and no other assertion in the package would catch it.

`TestResolveMaxTokens_Matrix` pins all 15 combinations — enabled at several budgets, adaptive, disabled, effort-only, neither, and explicit `MaxTokens` override.

Method note: the matrix was written and run **against the pre-union implementation first** (via a temporary shim expressing the new options in terms of the old struct). It passed there unchanged before the refactor began, so its expected values are a captured characterization of existing behaviour rather than assumptions written to match the new code. Two non-obvious behaviours it locks in:

- `WithThinkingEnabled(0)` is *not* an explicit budget, so it falls through to the reasoning default `32000`, not `4096`.
- `disabled + effort` still counts as reasoning (`output_config.effort` is independent of the thinking block) and yields `32000`.

## Backward compatibility

`ThinkingConfig` and `WithThinking` remain exported and fully supported — Memoh constructs them by generation (`internal/models/sdk.go`). They are lowered internally onto the union.

- `TestWithThinking_BackwardCompatibility` asserts the legacy and union paths produce **byte-identical** request JSON for enabled/adaptive/disabled.
- `TestWithThinking_LegacyExactWire` pins the exact bytes for `{Type:"enabled", BudgetTokens:5000}`.
- Unrecognised `Type` strings still reach the wire verbatim through a passthrough variant, preserving the old "execute what the caller declared, don't validate it" behaviour.

Verified out-of-tree: the full Memoh tree builds against this branch via a `go mod` replace with **zero source changes** (go.mod restored afterwards).

## Why no deprecation markers (except one)

No `// Deprecated:` on `ThinkingConfig`/`WithThinking`. Anthropic's own SDK still has none on `budget_tokens` even though 4.7+ removed it, because it remains valid on older models — a marker would warn every legitimate caller. Generation differences are documented in doc comments instead.

The exception is `NormalizeReasoningEffort`, which **is** genuinely being retired and so does carry the marker.

## NormalizeReasoningEffort

The `max` -> `xhigh` rewrite is gone; an exported no-op shell remains for one release. It encoded a guess about what OpenAI would accept rather than something a caller declared — the day `max` is supported it would silently downgrade the request with no diagnostic and no obvious culprit. Effort is an open enum and no official SDK keeps a tier allow-list.

`completions` and `responses` now forward effort verbatim (`codex` already did, via #26). Two existing tests asserted the rewrite; they are renamed and inverted to pin passthrough, which is the one intentional behaviour change in this PR:

- `TestDoGenerate_MapsMaxReasoningEffortToXHigh` -> `..._ForwardsMaxReasoningEffortVerbatim`
- `TestResponsesDoGenerate_MapsMaxReasoningEffortToXHigh` -> `..._ForwardsMaxReasoningEffortVerbatim`

Callers that relied on the SDK silently rewriting `max` will now see the endpoint's own 400.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` all green across the **whole repo** (exported API changed). `provider/google` untouched.

⚠️ **No human QA** — this PR has not been verified by a human yet. Remove this line once a human confirms the happy path.