### PR TITLE
test: refresh OpenRouter integration models

### DIFF
--- a/provider/openai/completions/completions_test.go
+++ b/provider/openai/completions/completions_test.go
@@ -1314,6 +1314,8 @@ func TestIntegration_DoStream(t *testing.T) {
 
 // ---------- multi-model integration tests (OpenRouter) ----------
 
+const openRouterGoogleIntegrationModel = "google/gemini-3.6-flash"
+
 func TestIntegration_MultiModel(t *testing.T) {
 	p := newIntegrationProvider(t)
 
@@ -1321,7 +1323,7 @@ func TestIntegration_MultiModel(t *testing.T) {
 		id           string
 		hasReasoning bool
 	}{
-		{"google/gemini-2.5-flash", false},
+		{openRouterGoogleIntegrationModel, false},
 		{"deepseek/deepseek-r1", true},
 		{"deepseek/deepseek-chat", false},
 	}
@@ -1357,7 +1359,7 @@ func TestIntegration_MultiModel_Stream(t *testing.T) {
 		id           string
 		hasReasoning bool
 	}{
-		{"google/gemini-2.5-flash", false},
+		{openRouterGoogleIntegrationModel, false},
 		{"deepseek/deepseek-r1", true},
 	}
 

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -1257,6 +1257,8 @@ func TestResponsesInputConversion_AssistantReasoning(t *testing.T) {
 
 // ---------- integration tests ----------
 
+const openRouterResponsesReasoningModel = "openai/gpt-5.4-mini"
+
 func envOrSkip(t *testing.T, key string) string {
 	t.Helper()
 	v := os.Getenv(key)
@@ -1479,7 +1481,7 @@ func TestIntegration_ResponsesDoStream(t *testing.T) {
 
 func TestIntegration_ResponsesDoGenerate_Reasoning(t *testing.T) {
 	p := newResponsesIntegrationProvider(t)
-	model := p.ChatModel("openai/o4-mini")
+	model := p.ChatModel(openRouterResponsesReasoningModel)
 	effort := "low"
 	result, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
 		Model:           model,
@@ -1502,7 +1504,7 @@ func TestIntegration_ResponsesDoGenerate_Reasoning(t *testing.T) {
 
 func TestIntegration_ResponsesDoStream_Reasoning(t *testing.T) {
 	p := newResponsesIntegrationProvider(t)
-	model := p.ChatModel("openai/o4-mini")
+	model := p.ChatModel(openRouterResponsesReasoningModel)
 	effort := "low"
 	sr, err := p.DoStream(context.Background(), sdk.GenerateParams{
 		Model:           model,


### PR DESCRIPTION
## Summary

- update OpenRouter Google coverage from `google/gemini-2.5-flash` to the current stable `google/gemini-3.6-flash`
- update Responses reasoning coverage from deprecated `openai/o4-mini` to `openai/gpt-5.4-mini`
- centralize repeated model slugs as test constants

## Why

The live integration matrix is pinned to older model generations. Refreshing these IDs keeps the tests aligned with current stable models while preserving the existing streaming and reasoning assertions.

This does not change production routing, repository secrets, or the treatment of provider errors.

## Validation

Local checks passed:

- `mise run lint`
- `mise run test`
- `go test ./... -short -count=1 -race`
- `go vet ./...`
- both model slugs are present in the live OpenRouter model catalog

The default pull-request [CI run](https://github.com/memohai/twilight-ai/actions/runs/31600830682) passed Lint, Build, Vet, and Unit Tests; Integration Tests were skipped by the PR event condition.

A manual [workflow_dispatch run](https://github.com/memohai/twilight-ai/actions/runs/31600996934) exercised the real-provider tests. Lint and Test passed, but Integration Tests still received the same provider-policy `403 Terms Of Service` for both new slugs. DeepSeek, ordinary Responses, and tool-call probes continued to pass. This confirms that refreshing model IDs alone does not resolve the configured account/provider policy blocker, so the PR remains Draft.