### PR TITLE
fix(reasoning): send every thinking block back with its own signature

### DIFF
--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -28,6 +28,16 @@ const (
 	blockTypeText     = "text"
 	blockTypeThinking = "thinking"
 	blockTypeToolUse  = "tool_use"
+	// blockTypeRedactedThinking carries encrypted reasoning with no readable
+	// text. It must be replayed verbatim alongside ordinary thinking blocks.
+	blockTypeRedactedThinking = "redacted_thinking"
+
+	// Keys under the provider's metadata namespace. A thinking block is
+	// identified by its signature and a redacted one by its encrypted data; the
+	// two are different kinds of token and never interchangeable.
+	metadataNamespace       = "anthropic"
+	metadataKeySignature    = "signature"
+	metadataKeyRedactedData = "redactedData"
 
 	thinkingTypeDisabled = "disabled"
 )
@@ -716,12 +726,22 @@ func convertAssistantMessage(msg sdk.Message) anthropicMessage {
 			}
 			blocks = append(blocks, block)
 		case sdk.ReasoningPart:
-			sig := extractAnthropicSignature(p.ProviderMetadata)
-			if sig == "" {
-				if p.Text != "" {
-					blocks = append(blocks, contentBlock{Type: blockTypeText, Text: p.Text})
-				}
-			} else {
+			// Only this dialect's blocks can be replayed: the API verifies the
+			// sequence and rejects anything it did not produce. Foreign or
+			// unmarked reasoning is dropped rather than re-sent as text,
+			// because feeding a model its own inner monologue back as ordinary
+			// content teaches it to imitate the form in user-visible answers.
+			if p.Format != sdk.ReasoningFormatAnthropic {
+				continue
+			}
+			if data := redactedDataOf(p.ProviderMetadata); data != "" {
+				blocks = append(blocks, contentBlock{
+					Type: blockTypeRedactedThinking,
+					Data: data,
+				})
+				continue
+			}
+			if sig := signatureOf(p.ProviderMetadata); sig != "" {
 				blocks = append(blocks, contentBlock{
 					Type:      blockTypeThinking,
 					Thinking:  p.Text,
@@ -795,14 +815,18 @@ func (p *Provider) parseResponse(resp *messagesResponse) (*sdk.GenerateResult, e
 		case blockTypeText:
 			result.Text += block.Text
 		case blockTypeThinking:
-			result.Reasoning += block.Thinking
-			if block.Signature != "" {
-				result.ReasoningProviderMetadata = map[string]any{
-					"anthropic": map[string]any{"signature": block.Signature},
-				}
-			}
-		case "redacted_thinking":
-			// Redacted thinking blocks don't contain readable text
+			result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
+				Text:             block.Thinking,
+				Format:           sdk.ReasoningFormatAnthropic,
+				ProviderMetadata: signatureMetadata(block.Signature),
+			})
+		case blockTypeRedactedThinking:
+			// No readable text, but the encrypted payload has to be replayed
+			// or the next request is rejected.
+			result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
+				Format:           sdk.ReasoningFormatAnthropic,
+				ProviderMetadata: redactedMetadata(block.Data),
+			})
 		case blockTypeToolUse:
 			result.ToolCalls = append(result.ToolCalls, sdk.ToolCall{
 				ToolCallID: block.ID,
@@ -811,6 +835,8 @@ func (p *Provider) parseResponse(resp *messagesResponse) (*sdk.GenerateResult, e
 			})
 		}
 	}
+
+	result.Reasoning = sdk.ReasoningText(result.ReasoningParts)
 
 	return result, nil
 }
@@ -942,8 +968,18 @@ func (h *streamHandler) onBlockStart(event *streamEvent) {
 		h.activeBlocks[idx] = &streamingBlock{blockType: blockTypeText}
 		h.send(&sdk.TextStartPart{ID: h.messageID})
 	case blockTypeThinking:
-		h.activeBlocks[idx] = &streamingBlock{blockType: blockTypeThinking}
-		h.send(&sdk.ReasoningStartPart{ID: h.messageID})
+		id := h.reasoningBlockID(idx)
+		h.activeBlocks[idx] = &streamingBlock{blockType: blockTypeThinking, reasoningID: id}
+		h.send(&sdk.ReasoningStartPart{ID: id, Format: sdk.ReasoningFormatAnthropic})
+	case blockTypeRedactedThinking:
+		// Delivered whole: no deltas follow, and the payload is already here.
+		id := h.reasoningBlockID(idx)
+		h.activeBlocks[idx] = &streamingBlock{
+			blockType:    blockTypeRedactedThinking,
+			reasoningID:  id,
+			redactedData: cb.Data,
+		}
+		h.send(&sdk.ReasoningStartPart{ID: id, Format: sdk.ReasoningFormatAnthropic})
 	case blockTypeToolUse:
 		h.activeBlocks[idx] = &streamingBlock{
 			blockType: blockTypeToolUse,
@@ -969,7 +1005,11 @@ func (h *streamHandler) onBlockDelta(event *streamEvent) {
 	case "text_delta":
 		h.send(&sdk.TextDeltaPart{ID: h.messageID, Text: delta.Text})
 	case "thinking_delta":
-		h.send(&sdk.ReasoningDeltaPart{ID: h.messageID, Text: delta.Thinking})
+		id := h.messageID
+		if sb != nil {
+			id = sb.reasoningID
+		}
+		h.send(&sdk.ReasoningDeltaPart{ID: id, Text: delta.Thinking, Format: sdk.ReasoningFormatAnthropic})
 	case "input_json_delta":
 		if sb != nil {
 			sb.args.WriteString(delta.PartialJSON)
@@ -1000,13 +1040,17 @@ func (h *streamHandler) onBlockStop(event *streamEvent) {
 	case blockTypeText:
 		h.send(&sdk.TextEndPart{ID: h.messageID})
 	case blockTypeThinking:
-		var meta map[string]any
-		if sb.signature.Len() > 0 {
-			meta = map[string]any{
-				"anthropic": map[string]any{"signature": sb.signature.String()},
-			}
-		}
-		h.send(&sdk.ReasoningEndPart{ID: h.messageID, ProviderMetadata: meta})
+		h.send(&sdk.ReasoningEndPart{
+			ID:               sb.reasoningID,
+			Format:           sdk.ReasoningFormatAnthropic,
+			ProviderMetadata: signatureMetadata(sb.signature.String()),
+		})
+	case blockTypeRedactedThinking:
+		h.send(&sdk.ReasoningEndPart{
+			ID:               sb.reasoningID,
+			Format:           sdk.ReasoningFormatAnthropic,
+			ProviderMetadata: redactedMetadata(sb.redactedData),
+		})
 	case blockTypeToolUse:
 		h.send(&sdk.ToolInputEndPart{ID: sb.toolID})
 		var input any
@@ -1062,6 +1106,16 @@ type streamingBlock struct {
 	toolName  string
 	args      strings.Builder
 	signature strings.Builder
+	// reasoningID identifies this reasoning block in the part stream. Blocks
+	// need distinct IDs so each signature stays paired with its own text.
+	reasoningID  string
+	redactedData string
+}
+
+// reasoningBlockID derives a stable per-block stream ID from the message ID and
+// the block's index in the response.
+func (h *streamHandler) reasoningBlockID(idx int) string {
+	return fmt.Sprintf("%s:%d", h.messageID, idx)
 }
 
 // ---------- helpers ----------
@@ -1106,16 +1160,21 @@ func mapFinishReason(reason string) sdk.FinishReason {
 	}
 }
 
-func extractAnthropicSignature(meta map[string]any) string {
-	if meta == nil {
-		return ""
-	}
-	am, ok := meta["anthropic"].(map[string]any)
-	if !ok {
-		return ""
-	}
-	sig, _ := am["signature"].(string)
-	return sig
+func signatureMetadata(signature string) map[string]any {
+	return sdk.ReasoningMetadata(metadataNamespace, map[string]string{metadataKeySignature: signature})
+}
+
+func redactedMetadata(data string) map[string]any {
+	return sdk.ReasoningMetadata(metadataNamespace, map[string]string{metadataKeyRedactedData: data})
+}
+
+func signatureOf(meta map[string]any) string {
+	return sdk.ReasoningMetadataString(meta, metadataNamespace, metadataKeySignature)
+}
+
+// redactedDataOf returns the encrypted payload of a redacted thinking block.
+func redactedDataOf(meta map[string]any) string {
+	return sdk.ReasoningMetadataString(meta, metadataNamespace, metadataKeyRedactedData)
 }
 
 func classifyError(err error) *sdk.ProviderTestResult {

--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -411,7 +411,7 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*messagesRequest, e
 	if err != nil {
 		return nil, err
 	}
-	system, messages := convertMessages(params.System, normalized)
+	system, messages := convertMessages(params.System, params.Model.ID, normalized)
 
 	req := &messagesRequest{
 		Model:       params.Model.ID,
@@ -540,7 +540,7 @@ func convertToolChoice(choice any) *anthropicToolChoice {
 // block without cache_control. To attach cache_control to a system prompt,
 // pass it as a MessageRoleSystem message with a TextPart that has CacheControl
 // set instead of using the System field.
-func convertMessages(systemPrompt string, messages []sdk.Message) ([]contentBlock, []anthropicMessage) {
+func convertMessages(systemPrompt, targetModel string, messages []sdk.Message) ([]contentBlock, []anthropicMessage) {
 	var system []contentBlock
 	var out []anthropicMessage
 	conversationStarted := false
@@ -566,7 +566,7 @@ func convertMessages(systemPrompt string, messages []sdk.Message) ([]contentBloc
 
 		case sdk.MessageRoleAssistant:
 			conversationStarted = true
-			out = append(out, convertAssistantMessage(msg))
+			out = append(out, convertAssistantMessage(msg, targetModel))
 
 		case sdk.MessageRoleTool:
 			conversationStarted = true
@@ -714,7 +714,7 @@ func isAnthropicSupportedMediaType(mt string) bool {
 	}
 }
 
-func convertAssistantMessage(msg sdk.Message) anthropicMessage {
+func convertAssistantMessage(msg sdk.Message, targetModel string) anthropicMessage {
 	var blocks []contentBlock
 
 	for _, part := range msg.Content {
@@ -732,6 +732,13 @@ func convertAssistantMessage(msg sdk.Message) anthropicMessage {
 			// because feeding a model its own inner monologue back as ordinary
 			// content teaches it to imitate the form in user-visible answers.
 			if p.Format != sdk.ReasoningFormatAnthropic {
+				continue
+			}
+			// A signature is verified by the model that issued it. After a
+			// mid-conversation model switch the old blocks cannot pass the new
+			// model's check — replaying them is a hard 400 — so they are
+			// dropped, exactly as foreign-dialect reasoning is.
+			if !sdk.SameReasoningModel(p.Model, targetModel) {
 				continue
 			}
 			if data := redactedDataOf(p.ProviderMetadata); data != "" {
@@ -818,6 +825,7 @@ func (p *Provider) parseResponse(resp *messagesResponse) (*sdk.GenerateResult, e
 			result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
 				Text:             block.Thinking,
 				Format:           sdk.ReasoningFormatAnthropic,
+				Model:            resp.Model,
 				ProviderMetadata: signatureMetadata(block.Signature),
 			})
 		case blockTypeRedactedThinking:
@@ -825,6 +833,7 @@ func (p *Provider) parseResponse(resp *messagesResponse) (*sdk.GenerateResult, e
 			// or the next request is rejected.
 			result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
 				Format:           sdk.ReasoningFormatAnthropic,
+				Model:            resp.Model,
 				ProviderMetadata: redactedMetadata(block.Data),
 			})
 		case blockTypeToolUse:
@@ -970,7 +979,7 @@ func (h *streamHandler) onBlockStart(event *streamEvent) {
 	case blockTypeThinking:
 		id := h.reasoningBlockID(idx)
 		h.activeBlocks[idx] = &streamingBlock{blockType: blockTypeThinking, reasoningID: id}
-		h.send(&sdk.ReasoningStartPart{ID: id, Format: sdk.ReasoningFormatAnthropic})
+		h.send(&sdk.ReasoningStartPart{ID: id, Format: sdk.ReasoningFormatAnthropic, Model: h.messageModel})
 	case blockTypeRedactedThinking:
 		// Delivered whole: no deltas follow, and the payload is already here.
 		id := h.reasoningBlockID(idx)
@@ -979,7 +988,7 @@ func (h *streamHandler) onBlockStart(event *streamEvent) {
 			reasoningID:  id,
 			redactedData: cb.Data,
 		}
-		h.send(&sdk.ReasoningStartPart{ID: id, Format: sdk.ReasoningFormatAnthropic})
+		h.send(&sdk.ReasoningStartPart{ID: id, Format: sdk.ReasoningFormatAnthropic, Model: h.messageModel})
 	case blockTypeToolUse:
 		h.activeBlocks[idx] = &streamingBlock{
 			blockType: blockTypeToolUse,
@@ -1009,7 +1018,7 @@ func (h *streamHandler) onBlockDelta(event *streamEvent) {
 		if sb != nil {
 			id = sb.reasoningID
 		}
-		h.send(&sdk.ReasoningDeltaPart{ID: id, Text: delta.Thinking, Format: sdk.ReasoningFormatAnthropic})
+		h.send(&sdk.ReasoningDeltaPart{ID: id, Text: delta.Thinking, Format: sdk.ReasoningFormatAnthropic, Model: h.messageModel})
 	case "input_json_delta":
 		if sb != nil {
 			sb.args.WriteString(delta.PartialJSON)
@@ -1043,12 +1052,14 @@ func (h *streamHandler) onBlockStop(event *streamEvent) {
 		h.send(&sdk.ReasoningEndPart{
 			ID:               sb.reasoningID,
 			Format:           sdk.ReasoningFormatAnthropic,
+			Model:            h.messageModel,
 			ProviderMetadata: signatureMetadata(sb.signature.String()),
 		})
 	case blockTypeRedactedThinking:
 		h.send(&sdk.ReasoningEndPart{
 			ID:               sb.reasoningID,
 			Format:           sdk.ReasoningFormatAnthropic,
+			Model:            h.messageModel,
 			ProviderMetadata: redactedMetadata(sb.redactedData),
 		})
 	case blockTypeToolUse:
@@ -1056,7 +1067,11 @@ func (h *streamHandler) onBlockStop(event *streamEvent) {
 		var input any
 		if sb.args.Len() > 0 {
 			if err := json.Unmarshal([]byte(sb.args.String()), &input); err != nil {
+				// A call whose arguments cannot be parsed must not become a
+				// call: emitting it with nil input would hand the tool empty
+				// arguments and run it anyway.
 				h.send(&sdk.ErrorPart{Error: fmt.Errorf("anthropic: unmarshal tool args for %q: %w", sb.toolName, err)})
+				return
 			}
 		}
 		h.send(&sdk.StreamToolCallPart{

--- a/provider/anthropic/messages/messages.go
+++ b/provider/anthropic/messages/messages.go
@@ -749,9 +749,10 @@ func convertAssistantMessage(msg sdk.Message, targetModel string) anthropicMessa
 				continue
 			}
 			if sig := signatureOf(p.ProviderMetadata); sig != "" {
+				thinking := p.Text
 				blocks = append(blocks, contentBlock{
 					Type:      blockTypeThinking,
-					Thinking:  p.Text,
+					Thinking:  &thinking,
 					Signature: sig,
 				})
 			}

--- a/provider/anthropic/messages/messages_test.go
+++ b/provider/anthropic/messages/messages_test.go
@@ -887,14 +887,15 @@ func TestDoGenerate_ReasoningFromOtherProvider(t *testing.T) {
 				t.Error("reasoning from other provider should not become a thinking block")
 			}
 		}
-		if len(assistantMsg.Content) != 2 {
-			t.Fatalf("expected 2 text blocks (reasoning fallback + text), got %+v", assistantMsg.Content)
+		// Foreign reasoning is dropped rather than re-sent as text. Replaying a
+		// model's inner monologue as ordinary content teaches it to imitate the
+		// form in user-visible answers, and Anthropic cannot verify a signature
+		// it did not issue.
+		if len(assistantMsg.Content) != 1 {
+			t.Fatalf("expected only the text block to survive, got %+v", assistantMsg.Content)
 		}
-		if assistantMsg.Content[0]["type"] != "text" || assistantMsg.Content[0]["text"] != "thinking from gemini" {
-			t.Errorf("expected reasoning fallback as text, got %+v", assistantMsg.Content[0])
-		}
-		if assistantMsg.Content[1]["type"] != "text" || assistantMsg.Content[1]["text"] != "The answer" {
-			t.Errorf("expected original text block, got %+v", assistantMsg.Content[1])
+		if assistantMsg.Content[0]["type"] != "text" || assistantMsg.Content[0]["text"] != "The answer" {
+			t.Errorf("expected original text block, got %+v", assistantMsg.Content[0])
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/provider/anthropic/messages/reasoning_roundtrip_test.go
+++ b/provider/anthropic/messages/reasoning_roundtrip_test.go
@@ -103,7 +103,7 @@ func TestConvertAssistantMessageReplaysThinkingAndRedactedBlocks(t *testing.T) {
 		},
 	}
 
-	converted := convertAssistantMessage(msg)
+	converted := convertAssistantMessage(msg, "claude-opus-5")
 	if len(converted.Content) != 3 {
 		t.Fatalf("blocks: got %d, want 3: %+v", len(converted.Content), converted.Content)
 	}
@@ -158,7 +158,7 @@ func TestConvertAssistantMessageDropsForeignReasoning(t *testing.T) {
 		},
 	}
 
-	converted := convertAssistantMessage(msg)
+	converted := convertAssistantMessage(msg, "claude-opus-5")
 	if len(converted.Content) != 1 {
 		t.Fatalf("blocks: got %d, want 1: %+v", len(converted.Content), converted.Content)
 	}
@@ -250,7 +250,7 @@ func TestConvertAssistantMessageDropsUnmarkedReasoning(t *testing.T) {
 		},
 	}
 
-	converted := convertAssistantMessage(msg)
+	converted := convertAssistantMessage(msg, "claude-opus-5")
 	if len(converted.Content) != 1 || converted.Content[0].Type != blockTypeText {
 		t.Fatalf("blocks: got %+v, want only the text block", converted.Content)
 	}
@@ -344,5 +344,74 @@ func TestInterleavedThinkingSurvivesReplay(t *testing.T) {
 		if replayed[i][w.key] != w.value {
 			t.Errorf("block %d %s: got %v, want %s", i, w.key, replayed[i][w.key], w.value)
 		}
+	}
+}
+
+// The live failure this guards: a conversation starts on one Claude and
+// switches to another. The old model's thinking blocks cannot pass the new
+// model's signature check — Anthropic rejects them with
+// "messages.N.content: Invalid input" — so they are dropped on replay.
+func TestConvertAssistantMessageDropsBlocksFromAnotherModel(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "signed by sonnet 5",
+				Format:           sdk.ReasoningFormatAnthropic,
+				Model:            "anthropic/claude-sonnet-5",
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"signature": "SIG_S5"}},
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	converted := convertAssistantMessage(msg, "anthropic/claude-sonnet-4.6")
+	if len(converted.Content) != 1 || converted.Content[0].Type != blockTypeText {
+		t.Fatalf("blocks: got %+v, want only the text block", converted.Content)
+	}
+}
+
+// The same model under different spellings is still the same model: its
+// signatures are portable across the direct API, Bedrock and gateways, and
+// dropping them on a spelling change would lose valid reasoning.
+func TestConvertAssistantMessageKeepsBlocksAcrossSpellings(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "signed by sonnet 5",
+				Format:           sdk.ReasoningFormatAnthropic,
+				Model:            "anthropic/claude-sonnet-5",
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"signature": "SIG_S5"}},
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	converted := convertAssistantMessage(msg, "us.anthropic.claude-sonnet-5-v1:0")
+	if len(converted.Content) != 2 || converted.Content[0].Type != blockTypeThinking {
+		t.Fatalf("blocks: got %+v, want thinking then text", converted.Content)
+	}
+}
+
+// Blocks persisted before Model existed carry no producer. They cannot
+// establish a mismatch, so they replay as before — the field tightens the
+// guard going forward without invalidating existing history.
+func TestConvertAssistantMessageKeepsLegacyBlocksWithoutModel(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "pre-field block",
+				Format:           sdk.ReasoningFormatAnthropic,
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"signature": "SIG"}},
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	converted := convertAssistantMessage(msg, "anthropic/claude-sonnet-5")
+	if len(converted.Content) != 2 || converted.Content[0].Type != blockTypeThinking {
+		t.Fatalf("blocks: got %+v, want thinking then text", converted.Content)
 	}
 }

--- a/provider/anthropic/messages/reasoning_roundtrip_test.go
+++ b/provider/anthropic/messages/reasoning_roundtrip_test.go
@@ -415,3 +415,42 @@ func TestConvertAssistantMessageKeepsLegacyBlocksWithoutModel(t *testing.T) {
 		t.Fatalf("blocks: got %+v, want thinking then text", converted.Content)
 	}
 }
+
+// A summarized thinking block signs empty text, and Anthropic rejects a
+// thinking block whose thinking key is missing outright — "messages.N.content:
+// Invalid input", reproduced live against Sonnet 5. The empty string has to
+// reach the wire, which omitempty on a plain string silently prevents.
+func TestConvertAssistantMessageKeepsEmptyThinkingKeyOnWire(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "",
+				Format:           sdk.ReasoningFormatAnthropic,
+				Model:            "claude-sonnet-5",
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"signature": "SIG"}},
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	converted := convertAssistantMessage(msg, "claude-sonnet-5")
+	raw, err := json.Marshal(converted.Content[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	thinking, present := wire["thinking"]
+	if !present {
+		t.Fatalf("thinking key missing from the wire: %s", raw)
+	}
+	if thinking != "" {
+		t.Errorf("thinking: got %v, want the empty string", thinking)
+	}
+	if wire["signature"] != "SIG" {
+		t.Errorf("signature: got %v, want SIG", wire["signature"])
+	}
+}

--- a/provider/anthropic/messages/reasoning_roundtrip_test.go
+++ b/provider/anthropic/messages/reasoning_roundtrip_test.go
@@ -1,0 +1,348 @@
+package messages
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// Anthropic rejects a modified sequence of thinking blocks in the latest
+// assistant message with a 400: the blocks cannot be rearranged, edited, or
+// partially dropped, and that includes redacted_thinking. Each block must
+// therefore survive parsing with its own signature attached.
+
+func anthropicMeta(t *testing.T, meta map[string]any, key string) string {
+	t.Helper()
+	am, ok := meta["anthropic"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	value, _ := am[key].(string)
+	return value
+}
+
+func TestParseResponseKeepsEveryThinkingBlockSignature(t *testing.T) {
+	resp := &messagesResponse{
+		ID: "msg_1", Model: "claude-opus-5",
+		Content: []responseBlock{
+			{Type: "thinking", Thinking: "AAA", Signature: "SIG_A"},
+			{Type: "thinking", Thinking: "BBB", Signature: "SIG_B"},
+			{Type: "text", Text: "answer"},
+		},
+	}
+
+	result, err := (&Provider{}).parseResponse(resp)
+	if err != nil {
+		t.Fatalf("parseResponse: %v", err)
+	}
+	if len(result.ReasoningParts) != 2 {
+		t.Fatalf("ReasoningParts: got %d, want 2", len(result.ReasoningParts))
+	}
+	for i, want := range []struct{ text, sig string }{{"AAA", "SIG_A"}, {"BBB", "SIG_B"}} {
+		block := result.ReasoningParts[i]
+		if block.Format != sdk.ReasoningFormatAnthropic {
+			t.Errorf("block %d format: got %q, want %q", i, block.Format, sdk.ReasoningFormatAnthropic)
+		}
+		if block.Text != want.text {
+			t.Errorf("block %d text: got %q, want %q", i, block.Text, want.text)
+		}
+		if got := anthropicMeta(t, block.ProviderMetadata, "signature"); got != want.sig {
+			t.Errorf("block %d signature: got %q, want %q", i, got, want.sig)
+		}
+	}
+}
+
+// A redacted_thinking block has no readable text — its whole payload is the
+// encrypted data field. Dropping it is the documented top cause of the 400.
+func TestParseResponseKeepsRedactedThinkingData(t *testing.T) {
+	resp := &messagesResponse{
+		ID: "msg_1", Model: "claude-opus-5",
+		Content: []responseBlock{
+			{Type: "thinking", Thinking: "AAA", Signature: "SIG_A"},
+			{Type: "redacted_thinking", Data: "ENCRYPTED_BLOB"},
+			{Type: "text", Text: "answer"},
+		},
+	}
+
+	result, err := (&Provider{}).parseResponse(resp)
+	if err != nil {
+		t.Fatalf("parseResponse: %v", err)
+	}
+	if len(result.ReasoningParts) != 2 {
+		t.Fatalf("ReasoningParts: got %d, want 2 — redacted block was dropped", len(result.ReasoningParts))
+	}
+	redacted := result.ReasoningParts[1]
+	if redacted.Text != "" {
+		t.Errorf("redacted block text: got %q, want empty", redacted.Text)
+	}
+	if got := anthropicMeta(t, redacted.ProviderMetadata, "redactedData"); got != "ENCRYPTED_BLOB" {
+		t.Errorf("redactedData: got %q, want ENCRYPTED_BLOB", got)
+	}
+}
+
+// Replaying the assistant turn must reproduce both block types on the wire,
+// in their original order, each with its own opaque token.
+func TestConvertAssistantMessageReplaysThinkingAndRedactedBlocks(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "AAA",
+				Format:           sdk.ReasoningFormatAnthropic,
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"signature": "SIG_A"}},
+			},
+			sdk.ReasoningPart{
+				Format:           sdk.ReasoningFormatAnthropic,
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"redactedData": "ENCRYPTED_BLOB"}},
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	converted := convertAssistantMessage(msg)
+	if len(converted.Content) != 3 {
+		t.Fatalf("blocks: got %d, want 3: %+v", len(converted.Content), converted.Content)
+	}
+
+	if converted.Content[0].Type != blockTypeThinking {
+		t.Errorf("block 0 type: got %q, want %q", converted.Content[0].Type, blockTypeThinking)
+	}
+	if converted.Content[0].Signature != "SIG_A" {
+		t.Errorf("block 0 signature: got %q, want SIG_A", converted.Content[0].Signature)
+	}
+	if converted.Content[1].Type != blockTypeRedactedThinking {
+		t.Errorf("block 1 type: got %q, want %q", converted.Content[1].Type, blockTypeRedactedThinking)
+	}
+	if converted.Content[1].Data != "ENCRYPTED_BLOB" {
+		t.Errorf("block 1 data: got %q, want ENCRYPTED_BLOB", converted.Content[1].Data)
+	}
+	if converted.Content[2].Type != blockTypeText {
+		t.Errorf("block 2 type: got %q, want %q", converted.Content[2].Type, blockTypeText)
+	}
+
+	// A redacted block must not leak an empty "thinking" key onto the wire.
+	raw, err := json.Marshal(converted.Content[1])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := wire["thinking"]; present {
+		t.Errorf("redacted block carries a thinking field: %s", raw)
+	}
+	if _, present := wire["signature"]; present {
+		t.Errorf("redacted block carries a signature field: %s", raw)
+	}
+}
+
+// Reasoning that carries no Anthropic opaque token cannot be replayed as a
+// thinking block. Re-rendering it as ordinary text teaches the model to
+// imitate its own inner monologue in user-visible output, so the part is
+// dropped instead.
+func TestConvertAssistantMessageDropsForeignReasoning(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "reasoning from another provider",
+				Format:           sdk.ReasoningFormatOpenAIResponses,
+				ProviderMetadata: map[string]any{"openai": map[string]any{"itemId": "rs_1"}},
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	converted := convertAssistantMessage(msg)
+	if len(converted.Content) != 1 {
+		t.Fatalf("blocks: got %d, want 1: %+v", len(converted.Content), converted.Content)
+	}
+	if converted.Content[0].Type != blockTypeText || converted.Content[0].Text != "answer" {
+		t.Errorf("surviving block = %+v, want the answer text", converted.Content[0])
+	}
+}
+
+// Streaming delivers the signature at block end, and the block boundaries are
+// what pair each signature with its own text.
+func TestStreamHandlerKeepsPerBlockSignatures(t *testing.T) {
+	ch := make(chan sdk.StreamPart, 32)
+	h := &streamHandler{
+		ch:           ch,
+		ctx:          context.Background(),
+		activeBlocks: make(map[int]*streamingBlock),
+	}
+
+	idx0, idx1 := 0, 1
+	h.onBlockStart(&streamEvent{Index: &idx0, ContentBlock: &responseBlock{Type: "thinking"}})
+	h.onBlockDelta(&streamEvent{Index: &idx0, Delta: &streamDelta{Type: "thinking_delta", Thinking: "AAA"}})
+	h.onBlockDelta(&streamEvent{Index: &idx0, Delta: &streamDelta{Type: "signature_delta", Signature: "SIG_A"}})
+	h.onBlockStop(&streamEvent{Index: &idx0})
+	h.onBlockStart(&streamEvent{Index: &idx1, ContentBlock: &responseBlock{Type: "thinking"}})
+	h.onBlockDelta(&streamEvent{Index: &idx1, Delta: &streamDelta{Type: "thinking_delta", Thinking: "BBB"}})
+	h.onBlockDelta(&streamEvent{Index: &idx1, Delta: &streamDelta{Type: "signature_delta", Signature: "SIG_B"}})
+	h.onBlockStop(&streamEvent{Index: &idx1})
+
+	close(ch)
+	var ends []*sdk.ReasoningEndPart
+	for p := range ch {
+		if end, ok := p.(*sdk.ReasoningEndPart); ok {
+			ends = append(ends, end)
+		}
+	}
+	if len(ends) != 2 {
+		t.Fatalf("ReasoningEndPart count: got %d, want 2", len(ends))
+	}
+	for i, want := range []string{"SIG_A", "SIG_B"} {
+		if got := anthropicMeta(t, ends[i].ProviderMetadata, "signature"); got != want {
+			t.Errorf("end %d signature: got %q, want %q", i, got, want)
+		}
+	}
+	if ends[0].ID == ends[1].ID {
+		t.Errorf("both blocks share stream ID %q; signatures cannot be paired with their text", ends[0].ID)
+	}
+}
+
+// A redacted_thinking block arrives whole, with no deltas.
+func TestStreamHandlerEmitsRedactedThinkingBlock(t *testing.T) {
+	ch := make(chan sdk.StreamPart, 32)
+	h := &streamHandler{
+		ch:           ch,
+		ctx:          context.Background(),
+		activeBlocks: make(map[int]*streamingBlock),
+	}
+
+	idx := 0
+	h.onBlockStart(&streamEvent{Index: &idx, ContentBlock: &responseBlock{
+		Type: "redacted_thinking", Data: "ENCRYPTED_BLOB",
+	}})
+	h.onBlockStop(&streamEvent{Index: &idx})
+
+	close(ch)
+	for p := range ch {
+		if end, ok := p.(*sdk.ReasoningEndPart); ok {
+			if got := anthropicMeta(t, end.ProviderMetadata, "redactedData"); got != "ENCRYPTED_BLOB" {
+				t.Fatalf("redactedData: got %q, want ENCRYPTED_BLOB", got)
+			}
+			return
+		}
+	}
+	t.Fatal("no ReasoningEndPart emitted for redacted_thinking block")
+}
+
+// Reasoning persisted before dialects were recorded carries no Format. Its
+// block structure is unknown — the text may be several blocks concatenated
+// under one signature — so it cannot be replayed as a verifiable thinking
+// block.
+func TestConvertAssistantMessageDropsUnmarkedReasoning(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "legacy reasoning",
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"signature": "SIG_OLD"}},
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	converted := convertAssistantMessage(msg)
+	if len(converted.Content) != 1 || converted.Content[0].Type != blockTypeText {
+		t.Fatalf("blocks: got %+v, want only the text block", converted.Content)
+	}
+}
+
+// The whole point of the design: a turn containing several thinking blocks and
+// a redacted one must come back on the wire exactly as it arrived. Anthropic
+// rejects a modified sequence with a 400.
+func TestInterleavedThinkingSurvivesReplay(t *testing.T) {
+	var replayed []map[string]any
+	turn := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		turn++
+		if turn == 2 {
+			var body struct {
+				Messages []struct {
+					Role    string           `json:"role"`
+					Content []map[string]any `json:"content"`
+				} `json:"messages"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			for _, m := range body.Messages {
+				if m.Role == "assistant" {
+					replayed = m.Content
+				}
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_1", "type": "message", "model": "claude-opus-5", "role": "assistant",
+			"content": []map[string]any{
+				{"type": "thinking", "thinking": "first", "signature": "SIG_1"},
+				{"type": "redacted_thinking", "data": "BLOB"},
+				{"type": "thinking", "thinking": "second", "signature": "SIG_2"},
+				{"type": "text", "text": "done"},
+			},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 5, "output_tokens": 5},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	p := New(WithAPIKey("k"), WithBaseURL(srv.URL))
+	model := &sdk.Model{ID: "claude-opus-5"}
+
+	first, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    model,
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("first turn: %v", err)
+	}
+	if len(first.ReasoningParts) != 3 {
+		t.Fatalf("ReasoningParts: got %d, want 3", len(first.ReasoningParts))
+	}
+
+	content := make([]sdk.MessagePart, 0, len(first.ReasoningParts)+1)
+	for _, part := range first.ReasoningParts {
+		content = append(content, part)
+	}
+	content = append(content, sdk.TextPart{Text: first.Text})
+
+	if _, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model: model,
+		Messages: []sdk.Message{
+			sdk.UserMessage("hi"),
+			{Role: sdk.MessageRoleAssistant, Content: content},
+			sdk.UserMessage("more"),
+		},
+	}); err != nil {
+		t.Fatalf("second turn: %v", err)
+	}
+
+	want := []struct{ typ, key, value string }{
+		{"thinking", "signature", "SIG_1"},
+		{"redacted_thinking", "data", "BLOB"},
+		{"thinking", "signature", "SIG_2"},
+		{"text", "text", "done"},
+	}
+	if len(replayed) != len(want) {
+		t.Fatalf("replayed %d blocks, want %d: %+v", len(replayed), len(want), replayed)
+	}
+	for i, w := range want {
+		if replayed[i]["type"] != w.typ {
+			t.Errorf("block %d type: got %v, want %s", i, replayed[i]["type"], w.typ)
+		}
+		if replayed[i][w.key] != w.value {
+			t.Errorf("block %d %s: got %v, want %s", i, w.key, replayed[i][w.key], w.value)
+		}
+	}
+}

--- a/provider/anthropic/messages/types.go
+++ b/provider/anthropic/messages/types.go
@@ -53,9 +53,12 @@ type contentBlock struct {
 	Source *imageSource `json:"source,omitempty"`
 	Title  string       `json:"title,omitempty"`
 
-	// thinking block
-	Thinking  string `json:"thinking,omitempty"`
-	Signature string `json:"signature,omitempty"`
+	// thinking block. Thinking is a pointer because the empty string is a
+	// legal value that must reach the wire: a summarized thinking block
+	// carries a signature over empty text, and the API rejects the block as
+	// invalid when the thinking key is missing entirely.
+	Thinking  *string `json:"thinking,omitempty"`
+	Signature string  `json:"signature,omitempty"`
 
 	// redacted_thinking block: an encrypted payload replayed verbatim.
 	Data string `json:"data,omitempty"`

--- a/provider/anthropic/messages/types.go
+++ b/provider/anthropic/messages/types.go
@@ -57,6 +57,9 @@ type contentBlock struct {
 	Thinking  string `json:"thinking,omitempty"`
 	Signature string `json:"signature,omitempty"`
 
+	// redacted_thinking block: an encrypted payload replayed verbatim.
+	Data string `json:"data,omitempty"`
+
 	// tool_use block
 	ID    string `json:"id,omitempty"`
 	Name  string `json:"name,omitempty"`

--- a/provider/github/copilot/copilot.go
+++ b/provider/github/copilot/copilot.go
@@ -241,7 +241,7 @@ func convertAssistantMessage(msg sdk.Message) chatMessage {
 
 	var contentParts []sdk.MessagePart
 	var toolCalls []chatToolCall
-	var reasoning string
+	var reasoning, reasoningOpaque string
 
 	for _, part := range msg.Content {
 		switch p := part.(type) {
@@ -263,7 +263,13 @@ func convertAssistantMessage(msg sdk.Message) chatMessage {
 				},
 			})
 		case sdk.ReasoningPart:
-			reasoning += p.Text
+			if p.Format != sdk.ReasoningFormatCopilot {
+				continue
+			}
+			if opaque := reasoningOpaqueOf(p.ProviderMetadata); opaque != "" {
+				reasoningOpaque = opaque
+				reasoning += p.Text
+			}
 		default:
 			contentParts = append(contentParts, part)
 		}
@@ -272,8 +278,10 @@ func convertAssistantMessage(msg sdk.Message) chatMessage {
 	if len(contentParts) > 0 {
 		cm.Content = convertContent(contentParts)
 	}
-	if reasoning != "" {
-		cm.ReasoningContent = reasoning
+	// The API accepts reasoning_text only together with its opaque token.
+	if reasoningOpaque != "" {
+		cm.ReasoningOpaque = reasoningOpaque
+		cm.ReasoningText = reasoning
 	}
 	if len(toolCalls) > 0 {
 		cm.ToolCalls = toolCalls
@@ -339,6 +347,13 @@ func (p *Provider) parseResponse(resp *chatResponse) (*sdk.GenerateResult, error
 		choice := resp.Choices[0]
 		result.Text = choice.Message.Content
 		result.Reasoning = reasoningFromMessage(&choice.Message)
+		if result.Reasoning != "" || choice.Message.ReasoningOpaque != "" {
+			result.ReasoningParts = []sdk.ReasoningPart{{
+				Text:             result.Reasoning,
+				Format:           sdk.ReasoningFormatCopilot,
+				ProviderMetadata: reasoningOpaqueMetadata(choice.Message.ReasoningOpaque),
+			}}
+		}
 		result.FinishReason = mapFinishReason(choice.FinishReason)
 		result.RawFinishReason = choice.FinishReason
 
@@ -456,17 +471,40 @@ type streamingToolCall struct {
 }
 
 func reasoningFromMessage(m *chatRespMessage) string {
-	if m.ReasoningContent != "" {
+	switch {
+	case m.ReasoningText != "":
+		return m.ReasoningText
+	case m.ReasoningContent != "":
 		return m.ReasoningContent
+	default:
+		return m.Reasoning
 	}
-	return m.Reasoning
 }
 
 func reasoningFromDelta(d *chatChunkDelta) string {
-	if d.ReasoningContent != "" {
+	switch {
+	case d.ReasoningText != "":
+		return d.ReasoningText
+	case d.ReasoningContent != "":
 		return d.ReasoningContent
+	default:
+		return d.Reasoning
 	}
-	return d.Reasoning
+}
+
+const (
+	metadataNamespace = "copilot"
+	// metadataKeyOpaque holds Copilot's reasoning_opaque: the upstream model's
+	// signature, wrapped uniformly regardless of which model produced it.
+	metadataKeyOpaque = "reasoningOpaque"
+)
+
+func reasoningOpaqueMetadata(opaque string) map[string]any {
+	return sdk.ReasoningMetadata(metadataNamespace, map[string]string{metadataKeyOpaque: opaque})
+}
+
+func reasoningOpaqueOf(meta map[string]any) string {
+	return sdk.ReasoningMetadataString(meta, metadataNamespace, metadataKeyOpaque)
 }
 
 func convertUsage(u *chatUsage) sdk.Usage {

--- a/provider/github/copilot/copilot.go
+++ b/provider/github/copilot/copilot.go
@@ -351,6 +351,7 @@ func (p *Provider) parseResponse(resp *chatResponse) (*sdk.GenerateResult, error
 			result.ReasoningParts = []sdk.ReasoningPart{{
 				Text:             result.Reasoning,
 				Format:           sdk.ReasoningFormatCopilot,
+				Model:            resp.Model,
 				ProviderMetadata: reasoningOpaqueMetadata(choice.Message.ReasoningOpaque),
 			}}
 		}

--- a/provider/github/copilot/reasoning_roundtrip_test.go
+++ b/provider/github/copilot/reasoning_roundtrip_test.go
@@ -1,0 +1,130 @@
+package copilot
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// Copilot carries the upstream model's signature in reasoning_opaque and
+// accepts reasoning_text only alongside it. Replaying text without the token
+// would feed the model its own inner monologue as ordinary content, which
+// teaches it to imitate the form in user-visible answers.
+
+func TestParseResponseCapturesReasoningOpaque(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": "c1", "model": "claude-sonnet-4.5", "created": 1,
+			"choices": []map[string]any{{
+				"index": 0,
+				"message": map[string]any{
+					"role":             "assistant",
+					"content":          "answer",
+					"reasoning_text":   "thought",
+					"reasoning_opaque": "OPAQUE_TOKEN",
+				},
+				"finish_reason": "stop",
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	p := New(WithAPIKey("k"), WithBaseURL(srv.URL))
+	result, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    &sdk.Model{ID: "claude-sonnet-4.5"},
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+
+	if len(result.ReasoningParts) != 1 {
+		t.Fatalf("ReasoningParts: got %d, want 1", len(result.ReasoningParts))
+	}
+	part := result.ReasoningParts[0]
+	if part.Format != sdk.ReasoningFormatCopilot {
+		t.Errorf("format: got %q, want %q", part.Format, sdk.ReasoningFormatCopilot)
+	}
+	if part.Text != "thought" {
+		t.Errorf("text: got %q, want %q", part.Text, "thought")
+	}
+	if got := reasoningOpaqueOf(part.ProviderMetadata); got != "OPAQUE_TOKEN" {
+		t.Errorf("opaque: got %q, want OPAQUE_TOKEN", got)
+	}
+}
+
+func TestConvertAssistantMessageReplaysReasoningOpaque(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "thought",
+				Format:           sdk.ReasoningFormatCopilot,
+				ProviderMetadata: reasoningOpaqueMetadata("OPAQUE_TOKEN"),
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	cm := convertAssistantMessage(msg)
+	if cm.ReasoningOpaque != "OPAQUE_TOKEN" {
+		t.Errorf("reasoning_opaque: got %q, want OPAQUE_TOKEN", cm.ReasoningOpaque)
+	}
+	if cm.ReasoningText != "thought" {
+		t.Errorf("reasoning_text: got %q, want %q", cm.ReasoningText, "thought")
+	}
+
+	raw, err := json.Marshal(cm)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// reasoning_content belongs to other vendors; sending it here is a no-op at
+	// best and misleading at worst.
+	if _, present := wire["reasoning_content"]; present {
+		t.Errorf("wire carries reasoning_content: %s", raw)
+	}
+}
+
+// Without the token the text cannot be verified, so neither field is sent.
+func TestConvertAssistantMessageOmitsReasoningTextWithoutOpaque(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{Text: "thought", Format: sdk.ReasoningFormatCopilot},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	cm := convertAssistantMessage(msg)
+	if cm.ReasoningText != "" || cm.ReasoningOpaque != "" {
+		t.Errorf("reasoning replayed without a token: text=%q opaque=%q", cm.ReasoningText, cm.ReasoningOpaque)
+	}
+}
+
+func TestConvertAssistantMessageDropsForeignReasoning(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				Text:             "anthropic thinking",
+				Format:           sdk.ReasoningFormatAnthropic,
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"signature": "SIG"}},
+			},
+			sdk.TextPart{Text: "answer"},
+		},
+	}
+
+	cm := convertAssistantMessage(msg)
+	if cm.ReasoningText != "" || cm.ReasoningOpaque != "" {
+		t.Errorf("foreign reasoning replayed: text=%q opaque=%q", cm.ReasoningText, cm.ReasoningOpaque)
+	}
+}

--- a/provider/github/copilot/stream.go
+++ b/provider/github/copilot/stream.go
@@ -41,6 +41,7 @@ func (sp *streamProcessor) endReasoning(id string) {
 		sp.send(&sdk.ReasoningEndPart{
 			ID:               id,
 			Format:           sdk.ReasoningFormatCopilot,
+			Model:            sp.chunkModel,
 			ProviderMetadata: reasoningOpaqueMetadata(sp.reasoningOpaque),
 		})
 		sp.reasoningStartSent = false
@@ -72,8 +73,16 @@ func (sp *streamProcessor) finishToolCall(stc *streamingToolCall) {
 	}
 	sp.send(&sdk.ToolInputEndPart{ID: stc.id})
 	var input any
-	if err := json.Unmarshal([]byte(stc.args.String()), &input); err != nil {
-		sp.send(&sdk.ErrorPart{Error: fmt.Errorf("github-copilot: unmarshal tool call arguments for %q: %w", stc.name, err)})
+	// Providers stream arguments incrementally and no-arg tools may close with
+	// an empty buffer, which is not malformed JSON — only a non-empty buffer
+	// that fails to parse is. Such a call must not be emitted: nil input would
+	// hand the tool empty arguments and run it anyway.
+	if args := stc.args.String(); args != "" {
+		if err := json.Unmarshal([]byte(args), &input); err != nil {
+			sp.send(&sdk.ErrorPart{Error: fmt.Errorf("github-copilot: unmarshal tool call arguments for %q: %w", stc.name, err)})
+			stc.finished = true
+			return
+		}
 	}
 	sp.send(&sdk.StreamToolCallPart{
 		ToolCallID: stc.id,
@@ -119,11 +128,11 @@ func (sp *streamProcessor) processReasoning(delta *chatChunkDelta, chunkID strin
 		return
 	}
 	if !sp.reasoningStartSent {
-		sp.send(&sdk.ReasoningStartPart{ID: chunkID, Format: sdk.ReasoningFormatCopilot})
+		sp.send(&sdk.ReasoningStartPart{ID: chunkID, Format: sdk.ReasoningFormatCopilot, Model: sp.chunkModel})
 		sp.reasoningStartSent = true
 	}
 	if reasoningContent != "" {
-		sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent, Format: sdk.ReasoningFormatCopilot})
+		sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent, Format: sdk.ReasoningFormatCopilot, Model: sp.chunkModel})
 	}
 }
 

--- a/provider/github/copilot/stream.go
+++ b/provider/github/copilot/stream.go
@@ -14,14 +14,17 @@ type streamProcessor struct {
 	ch                 chan sdk.StreamPart
 	textStartSent      bool
 	reasoningStartSent bool
-	rawFinishReason    string
-	finishReason       sdk.FinishReason
-	usage              sdk.Usage
-	chunkID            string
-	chunkModel         string
-	chunkCreated       int64
-	flushed            bool
-	pendingToolCalls   map[int]*streamingToolCall
+	// reasoningOpaque is the block's token, delivered on a delta and applied
+	// when the block closes.
+	reasoningOpaque  string
+	rawFinishReason  string
+	finishReason     sdk.FinishReason
+	usage            sdk.Usage
+	chunkID          string
+	chunkModel       string
+	chunkCreated     int64
+	flushed          bool
+	pendingToolCalls map[int]*streamingToolCall
 }
 
 func (sp *streamProcessor) send(part sdk.StreamPart) bool {
@@ -35,7 +38,11 @@ func (sp *streamProcessor) send(part sdk.StreamPart) bool {
 
 func (sp *streamProcessor) endReasoning(id string) {
 	if sp.reasoningStartSent {
-		sp.send(&sdk.ReasoningEndPart{ID: id})
+		sp.send(&sdk.ReasoningEndPart{
+			ID:               id,
+			Format:           sdk.ReasoningFormatCopilot,
+			ProviderMetadata: reasoningOpaqueMetadata(sp.reasoningOpaque),
+		})
 		sp.reasoningStartSent = false
 	}
 }
@@ -102,15 +109,22 @@ func (sp *streamProcessor) processChunk(chunk *chatChunkResponse) error {
 }
 
 func (sp *streamProcessor) processReasoning(delta *chatChunkDelta, chunkID string) {
+	if delta.ReasoningOpaque != "" {
+		sp.reasoningOpaque = delta.ReasoningOpaque
+	}
 	reasoningContent := reasoningFromDelta(delta)
-	if reasoningContent == "" {
+	// The opaque token may arrive on a delta carrying no text; that delta still
+	// opens the block, because without the token the text cannot be replayed.
+	if reasoningContent == "" && delta.ReasoningOpaque == "" {
 		return
 	}
 	if !sp.reasoningStartSent {
-		sp.send(&sdk.ReasoningStartPart{ID: chunkID})
+		sp.send(&sdk.ReasoningStartPart{ID: chunkID, Format: sdk.ReasoningFormatCopilot})
 		sp.reasoningStartSent = true
 	}
-	sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent})
+	if reasoningContent != "" {
+		sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent, Format: sdk.ReasoningFormatCopilot})
+	}
 }
 
 func (sp *streamProcessor) processContent(delta *chatChunkDelta, chunkID string) {

--- a/provider/github/copilot/types.go
+++ b/provider/github/copilot/types.go
@@ -41,11 +41,15 @@ type chatFunction struct {
 }
 
 type chatMessage struct {
-	Role             string         `json:"role"`
-	Content          any            `json:"content"`
-	ReasoningContent string         `json:"reasoning_content,omitempty"`
-	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
-	ToolCallID       string         `json:"tool_call_id,omitempty"`
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+	// ReasoningText and ReasoningOpaque are Copilot's own reasoning fields. The
+	// opaque token wraps the upstream model's signature; the text is only
+	// accepted alongside it.
+	ReasoningText   string         `json:"reasoning_text,omitempty"`
+	ReasoningOpaque string         `json:"reasoning_opaque,omitempty"`
+	ToolCalls       []chatToolCall `json:"tool_calls,omitempty"`
+	ToolCallID      string         `json:"tool_call_id,omitempty"`
 }
 
 type chatContentPartText struct {
@@ -81,8 +85,12 @@ type chatChoice struct {
 }
 
 type chatRespMessage struct {
-	Role             string          `json:"role"`
-	Content          string          `json:"content"`
+	Role            string `json:"role"`
+	Content         string `json:"content"`
+	ReasoningText   string `json:"reasoning_text,omitempty"`
+	ReasoningOpaque string `json:"reasoning_opaque,omitempty"`
+	// ReasoningContent and Reasoning are other vendors' field names, accepted
+	// because Copilot proxies models that emit them.
 	ReasoningContent string          `json:"reasoning_content,omitempty"`
 	Reasoning        string          `json:"reasoning,omitempty"`
 	Refusal          string          `json:"refusal,omitempty"`
@@ -136,8 +144,12 @@ type chatChunkChoice struct {
 }
 
 type chatChunkDelta struct {
-	Role             string              `json:"role,omitempty"`
-	Content          string              `json:"content,omitempty"`
+	Role            string `json:"role,omitempty"`
+	Content         string `json:"content,omitempty"`
+	ReasoningText   string `json:"reasoning_text,omitempty"`
+	ReasoningOpaque string `json:"reasoning_opaque,omitempty"`
+	// ReasoningContent and Reasoning are other vendors' field names, accepted
+	// because Copilot proxies models that emit them.
 	ReasoningContent string              `json:"reasoning_content,omitempty"`
 	Reasoning        string              `json:"reasoning,omitempty"`
 	Refusal          string              `json:"refusal,omitempty"`

--- a/provider/google/generativeai/generativeai.go
+++ b/provider/google/generativeai/generativeai.go
@@ -410,17 +410,25 @@ func convertAssistantMessage(msg sdk.Message) content {
 				parts = append(parts, cp)
 			}
 		case sdk.ReasoningPart:
-			if p.Text != "" {
-				thought := true
-				cp := contentPart{
-					Text:    p.Text,
-					Thought: &thought,
-				}
-				if sig := extractGoogleThoughtSignature(p.ProviderMetadata); sig != "" {
-					cp.ThoughtSignature = sig
-				}
-				parts = append(parts, cp)
+			// Only this dialect's parts can be replayed: a signature is bound to
+			// the exact part it arrived on, and foreign reasoning re-sent as
+			// text teaches the model to imitate it in user-visible answers.
+			if p.Format != sdk.ReasoningFormatGoogle {
+				continue
 			}
+			sig := extractGoogleThoughtSignature(p.ProviderMetadata)
+			// A signature may arrive on a part with no text; dropping it would
+			// break the positional context the signature is bound to.
+			if p.Text == "" && sig == "" {
+				continue
+			}
+			thought := true
+			cp := contentPart{
+				Text:             p.Text,
+				Thought:          &thought,
+				ThoughtSignature: sig,
+			}
+			parts = append(parts, cp)
 		case sdk.ToolCallPart:
 			cp := contentPart{
 				FunctionCall: &functionCall{
@@ -529,12 +537,15 @@ func (p *Provider) parseResponse(resp *generateResponse) (*sdk.GenerateResult, e
 			case part.Text != "":
 				isThought := part.Thought != nil && *part.Thought
 				if isThought {
-					result.Reasoning += part.Text
-					if part.ThoughtSignature != "" {
-						result.ReasoningProviderMetadata = map[string]any{
-							"google": map[string]any{"thoughtSignature": part.ThoughtSignature},
-						}
-					}
+					// Each thought part is its own block: a signature is bound
+					// to the exact part it arrived on and cannot be merged with
+					// another part's. Parts without a signature are normal —
+					// Google signs only the first of several parallel calls.
+					result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
+						Text:             part.Text,
+						Format:           sdk.ReasoningFormatGoogle,
+						ProviderMetadata: googleThoughtSignatureMetadata(part.ThoughtSignature),
+					})
 				} else {
 					result.Text += part.Text
 				}
@@ -549,6 +560,7 @@ func (p *Provider) parseResponse(resp *generateResponse) (*sdk.GenerateResult, e
 
 	result.FinishReason = mapFinishReason(candidate.FinishReason, hasToolCalls)
 	result.RawFinishReason = candidate.FinishReason
+	result.Reasoning = sdk.ReasoningText(result.ReasoningParts)
 
 	return result, nil
 }
@@ -609,7 +621,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 			}
 			flushed = true
 			if reasoningStartSent {
-				send(&sdk.ReasoningEndPart{ID: currentReasoningID, ProviderMetadata: reasoningEndMeta()})
+				send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, ProviderMetadata: reasoningEndMeta()})
 				reasoningStartSent = false
 			}
 			if textStartSent {
@@ -653,7 +665,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					switch {
 					case part.FunctionCall != nil:
 						if reasoningStartSent {
-							send(&sdk.ReasoningEndPart{ID: currentReasoningID, ProviderMetadata: reasoningEndMeta()})
+							send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, ProviderMetadata: reasoningEndMeta()})
 							reasoningStartSent = false
 						}
 						if textStartSent {
@@ -700,13 +712,13 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 							if !reasoningStartSent {
 								currentReasoningID = fmt.Sprintf("%d", blockCounter)
 								blockCounter++
-								send(&sdk.ReasoningStartPart{ID: currentReasoningID})
+								send(&sdk.ReasoningStartPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle})
 								reasoningStartSent = true
 							}
-							send(&sdk.ReasoningDeltaPart{ID: currentReasoningID, Text: part.Text})
+							send(&sdk.ReasoningDeltaPart{ID: currentReasoningID, Text: part.Text, Format: sdk.ReasoningFormatGoogle})
 						} else {
 							if reasoningStartSent {
-								send(&sdk.ReasoningEndPart{ID: currentReasoningID, ProviderMetadata: reasoningEndMeta()})
+								send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, ProviderMetadata: reasoningEndMeta()})
 								reasoningStartSent = false
 							}
 							if !textStartSent {
@@ -723,7 +735,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 							textStartSent = false
 						}
 						if reasoningStartSent {
-							send(&sdk.ReasoningEndPart{ID: currentReasoningID, ProviderMetadata: reasoningEndMeta()})
+							send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, ProviderMetadata: reasoningEndMeta()})
 							reasoningStartSent = false
 						}
 						send(&sdk.StreamFilePart{

--- a/provider/google/generativeai/generativeai.go
+++ b/provider/google/generativeai/generativeai.go
@@ -544,10 +544,18 @@ func (p *Provider) parseResponse(resp *generateResponse) (*sdk.GenerateResult, e
 					result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
 						Text:             part.Text,
 						Format:           sdk.ReasoningFormatGoogle,
+						Model:            resp.ModelVersion,
 						ProviderMetadata: googleThoughtSignatureMetadata(part.ThoughtSignature),
 					})
 				} else {
 					result.Text += part.Text
+					// Gemini binds a thought signature to the exact part that
+					// carries it, and a response without a function call signs
+					// an ordinary text part — usually the last one. That token
+					// has to survive even though the text itself is flattened.
+					if part.ThoughtSignature != "" {
+						result.TextProviderMetadata = googleThoughtSignatureMetadata(part.ThoughtSignature)
+					}
 				}
 			case part.InlineData != nil:
 				result.Files = append(result.Files, sdk.GeneratedFile{
@@ -595,6 +603,8 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 			currentTextID      string
 			currentReasoningID string
 			lastThoughtSig     string
+			lastTextSig        string
+			streamModel        string
 		)
 
 		send := func(part sdk.StreamPart) bool {
@@ -615,17 +625,26 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 			}
 		}
 
+		textEndMeta := func() map[string]any {
+			if lastTextSig == "" {
+				return nil
+			}
+			meta := googleThoughtSignatureMetadata(lastTextSig)
+			lastTextSig = ""
+			return meta
+		}
+
 		flush := func() {
 			if flushed {
 				return
 			}
 			flushed = true
 			if reasoningStartSent {
-				send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, ProviderMetadata: reasoningEndMeta()})
+				send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, Model: streamModel, ProviderMetadata: reasoningEndMeta()})
 				reasoningStartSent = false
 			}
 			if textStartSent {
-				send(&sdk.TextEndPart{ID: currentTextID})
+				send(&sdk.TextEndPart{ID: currentTextID, ProviderMetadata: textEndMeta()})
 				textStartSent = false
 			}
 		}
@@ -651,6 +670,9 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 				return err
 			}
 
+			if chunk.ModelVersion != "" {
+				streamModel = chunk.ModelVersion
+			}
 			if chunk.UsageMetadata != nil {
 				usage = convertUsage(chunk.UsageMetadata)
 			}
@@ -665,7 +687,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					switch {
 					case part.FunctionCall != nil:
 						if reasoningStartSent {
-							send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, ProviderMetadata: reasoningEndMeta()})
+							send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, Model: streamModel, ProviderMetadata: reasoningEndMeta()})
 							reasoningStartSent = false
 						}
 						if textStartSent {
@@ -712,13 +734,13 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 							if !reasoningStartSent {
 								currentReasoningID = fmt.Sprintf("%d", blockCounter)
 								blockCounter++
-								send(&sdk.ReasoningStartPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle})
+								send(&sdk.ReasoningStartPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, Model: streamModel})
 								reasoningStartSent = true
 							}
-							send(&sdk.ReasoningDeltaPart{ID: currentReasoningID, Text: part.Text, Format: sdk.ReasoningFormatGoogle})
+							send(&sdk.ReasoningDeltaPart{ID: currentReasoningID, Text: part.Text, Format: sdk.ReasoningFormatGoogle, Model: streamModel})
 						} else {
 							if reasoningStartSent {
-								send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, ProviderMetadata: reasoningEndMeta()})
+								send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, Model: streamModel, ProviderMetadata: reasoningEndMeta()})
 								reasoningStartSent = false
 							}
 							if !textStartSent {
@@ -727,15 +749,21 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 								send(&sdk.TextStartPart{ID: currentTextID})
 								textStartSent = true
 							}
+							// A signature can ride on an ordinary text part —
+							// possibly one with empty text — and belongs to the
+							// block, delivered when it closes.
+							if part.ThoughtSignature != "" {
+								lastTextSig = part.ThoughtSignature
+							}
 							send(&sdk.TextDeltaPart{ID: currentTextID, Text: part.Text})
 						}
 					case part.InlineData != nil:
 						if textStartSent {
-							send(&sdk.TextEndPart{ID: currentTextID})
+							send(&sdk.TextEndPart{ID: currentTextID, ProviderMetadata: textEndMeta()})
 							textStartSent = false
 						}
 						if reasoningStartSent {
-							send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, ProviderMetadata: reasoningEndMeta()})
+							send(&sdk.ReasoningEndPart{ID: currentReasoningID, Format: sdk.ReasoningFormatGoogle, Model: streamModel, ProviderMetadata: reasoningEndMeta()})
 							reasoningStartSent = false
 						}
 						send(&sdk.StreamFilePart{

--- a/provider/google/generativeai/text_signature_test.go
+++ b/provider/google/generativeai/text_signature_test.go
@@ -1,0 +1,66 @@
+package generativeai
+
+import (
+	"testing"
+
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// Gemini binds a thought signature to the exact part that carries it — not
+// only to thought parts. A response without a function call signs an ordinary
+// text part (usually the last one), and Gemini 3 rejects a later request that
+// fails to return it. See ai.google.dev/gemini-api/docs/generate-content/thought-signatures.
+
+func TestParseResponseKeepsSignatureOnPlainTextPart(t *testing.T) {
+	thought := true
+	resp := &generateResponse{
+		Candidates: []candidate{{
+			Content: &content{Parts: []contentPart{
+				{Text: "thinking...", Thought: &thought, ThoughtSignature: "SIG_THOUGHT"},
+				{Text: "the answer", ThoughtSignature: "SIG_TEXT"},
+			}},
+			FinishReason: "STOP",
+		}},
+	}
+
+	result, err := (&Provider{}).parseResponse(resp)
+	if err != nil {
+		t.Fatalf("parseResponse: %v", err)
+	}
+
+	if got := extractGoogleThoughtSignature(result.TextProviderMetadata); got != "SIG_TEXT" {
+		t.Errorf("text signature: got %q, want SIG_TEXT — a signature on a plain part was dropped", got)
+	}
+	if len(result.ReasoningParts) != 1 {
+		t.Fatalf("reasoning parts: got %d, want 1", len(result.ReasoningParts))
+	}
+	if got := extractGoogleThoughtSignature(result.ReasoningParts[0].ProviderMetadata); got != "SIG_THOUGHT" {
+		t.Errorf("thought signature: got %q, want SIG_THOUGHT", got)
+	}
+}
+
+// The signed text part must come back out on the wire with its signature in
+// place. TextPart already carries ProviderMetadata on replay; this closes the
+// loop from parse to request.
+func TestAssistantTextSignatureRoundTrips(t *testing.T) {
+	msg := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.TextPart{
+				Text:             "the answer",
+				ProviderMetadata: googleThoughtSignatureMetadata("SIG_TEXT"),
+			},
+		},
+	}
+
+	converted := convertAssistantMessage(msg)
+	if len(converted.Parts) != 1 {
+		t.Fatalf("parts: got %d, want 1", len(converted.Parts))
+	}
+	if converted.Parts[0].ThoughtSignature != "SIG_TEXT" {
+		t.Errorf("replayed signature: got %q, want SIG_TEXT", converted.Parts[0].ThoughtSignature)
+	}
+	if converted.Parts[0].Thought != nil && *converted.Parts[0].Thought {
+		t.Error("a signed text part must stay an ordinary part, not become a thought")
+	}
+}

--- a/provider/google/generativeai/types.go
+++ b/provider/google/generativeai/types.go
@@ -118,6 +118,10 @@ type generateResponse struct {
 	Candidates     []candidate     `json:"candidates"`
 	UsageMetadata  *usageMetadata  `json:"usageMetadata,omitempty"`
 	PromptFeedback *promptFeedback `json:"promptFeedback,omitempty"`
+	// ModelVersion is the concrete model that served the call, as the API
+	// reports it. It stamps reasoning parts so replay can tell whose thought
+	// signature a block carries.
+	ModelVersion string `json:"modelVersion,omitempty"`
 }
 
 type candidate struct {

--- a/provider/openai/codex/codex.go
+++ b/provider/openai/codex/codex.go
@@ -234,6 +234,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 						send(&sdk.ReasoningStartPart{
 							ID:               chunk.Item.ID,
 							Format:           sdk.ReasoningFormatOpenAIResponses,
+							Model:            responseModel,
 							ProviderMetadata: openaiutil.ReasoningItemMetadata(chunk.Item.ID, chunk.Item.EncryptedContent),
 						})
 						activeReasoningID = chunk.Item.ID
@@ -267,10 +268,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 				}
 				if activeReasoningID != chunk.ItemID {
 					endReasoning(nil)
-					send(&sdk.ReasoningStartPart{ID: chunk.ItemID, Format: sdk.ReasoningFormatOpenAIResponses})
+					send(&sdk.ReasoningStartPart{ID: chunk.ItemID, Format: sdk.ReasoningFormatOpenAIResponses, Model: responseModel})
 					activeReasoningID = chunk.ItemID
 				}
-				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta, Format: sdk.ReasoningFormatOpenAIResponses})
+				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta, Format: sdk.ReasoningFormatOpenAIResponses, Model: responseModel})
 
 			case "response.function_call_arguments.delta":
 				var chunk codexFuncArgsDeltaChunk
@@ -323,8 +324,15 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 							args = stc.args.String()
 						}
 						var input any
-						if err := json.Unmarshal([]byte(args), &input); err != nil {
-							send(&sdk.ErrorPart{Error: fmt.Errorf("openai-codex: unmarshal tool call arguments for %q: %w", stc.name, err)})
+						// A call whose arguments cannot be parsed must not
+						// become a call: nil input would hand the tool empty
+						// arguments and run it anyway.
+						if args != "" {
+							if err := json.Unmarshal([]byte(args), &input); err != nil {
+								send(&sdk.ErrorPart{Error: fmt.Errorf("openai-codex: unmarshal tool call arguments for %q: %w", stc.name, err)})
+								stc.finished = true
+								break
+							}
 						}
 						send(&sdk.StreamToolCallPart{ToolCallID: stc.id, ToolName: stc.name, Input: input})
 						stc.finished = true

--- a/provider/openai/codex/codex.go
+++ b/provider/openai/codex/codex.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
+	openaiutil "github.com/memohai/twilight-ai/provider/openai"
 	"github.com/memohai/twilight-ai/sdk"
 )
 
@@ -174,7 +175,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 
 		flush := func() {
 			if reasoningStartSent {
-				send(&sdk.ReasoningEndPart{ID: responseID})
+				send(&sdk.ReasoningEndPart{ID: responseID, Format: sdk.ReasoningFormatOpenAIResponses})
 				reasoningStartSent = false
 			}
 			if textStartSent {
@@ -216,16 +217,11 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					}
 				case outputTypeReasoning:
 					if !reasoningStartSent {
-						var meta map[string]any
-						if chunk.Item.EncryptedContent != "" {
-							meta = map[string]any{
-								"openai": map[string]any{
-									"reasoningEncryptedContent": chunk.Item.EncryptedContent,
-									"itemId":                    chunk.Item.ID,
-								},
-							}
-						}
-						send(&sdk.ReasoningStartPart{ID: chunk.Item.ID, ProviderMetadata: meta})
+						send(&sdk.ReasoningStartPart{
+							ID:               chunk.Item.ID,
+							Format:           sdk.ReasoningFormatOpenAIResponses,
+							ProviderMetadata: openaiutil.ReasoningItemMetadata(chunk.Item.ID, chunk.Item.EncryptedContent),
+						})
 						reasoningStartSent = true
 					}
 				case outputTypeFunctionCall:
@@ -244,7 +240,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					return nil
 				}
 				if reasoningStartSent {
-					send(&sdk.ReasoningEndPart{ID: responseID})
+					send(&sdk.ReasoningEndPart{ID: responseID, Format: sdk.ReasoningFormatOpenAIResponses})
 					reasoningStartSent = false
 				}
 				if !textStartSent {
@@ -259,10 +255,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					return nil
 				}
 				if !reasoningStartSent {
-					send(&sdk.ReasoningStartPart{ID: chunk.ItemID})
+					send(&sdk.ReasoningStartPart{ID: chunk.ItemID, Format: sdk.ReasoningFormatOpenAIResponses})
 					reasoningStartSent = true
 				}
-				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta})
+				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta, Format: sdk.ReasoningFormatOpenAIResponses})
 
 			case "response.function_call_arguments.delta":
 				var chunk codexFuncArgsDeltaChunk
@@ -289,7 +285,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					}
 				case outputTypeReasoning:
 					if reasoningStartSent {
-						send(&sdk.ReasoningEndPart{ID: chunk.Item.ID})
+						send(&sdk.ReasoningEndPart{ID: chunk.Item.ID, Format: sdk.ReasoningFormatOpenAIResponses})
 						reasoningStartSent = false
 					}
 				case outputTypeFunctionCall:
@@ -475,17 +471,38 @@ func convertCodexUserMessage(msg sdk.Message) []json.RawMessage {
 func convertCodexAssistantMessage(msg sdk.Message) []json.RawMessage {
 	var items []json.RawMessage
 	var textParts []codexOutputTextPart
-	var reasoningSummary []codexReasoningSummaryText
-	var encryptedContent string
+	var reasoningItems []codexReasoningItem
+	reasoningIndexByID := map[string]int{}
 
 	for _, part := range msg.Content {
 		switch p := part.(type) {
 		case sdk.TextPart:
 			textParts = append(textParts, codexOutputTextPart{Type: "output_text", Text: p.Text})
 		case sdk.ReasoningPart:
-			reasoningSummary = append(reasoningSummary, codexReasoningSummaryText{Type: "summary_text", Text: p.Text})
-			if ec := extractOpenAIEncryptedContent(p.ProviderMetadata); ec != "" {
-				encryptedContent = ec
+			// Same dialect as the public Responses API; anything else cannot be
+			// verified here and is dropped rather than re-sent as text.
+			if p.Format != sdk.ReasoningFormatOpenAIResponses {
+				continue
+			}
+			id := openaiutil.ReasoningItemID(p.ProviderMetadata)
+			if id == "" {
+				id = p.ID
+			}
+			idx, ok := reasoningIndexByID[id]
+			if !ok || id == "" {
+				reasoningItems = append(reasoningItems, codexReasoningItem{
+					Type:             "reasoning",
+					ID:               id,
+					EncryptedContent: openaiutil.ReasoningEncryptedContent(p.ProviderMetadata),
+				})
+				idx = len(reasoningItems) - 1
+				if id != "" {
+					reasoningIndexByID[id] = idx
+				}
+			}
+			if p.Text != "" {
+				reasoningItems[idx].Summary = append(reasoningItems[idx].Summary,
+					codexReasoningSummaryText{Type: "summary_text", Text: p.Text})
 			}
 		case sdk.ToolCallPart:
 			args, err := json.Marshal(p.Input)
@@ -506,12 +523,13 @@ func convertCodexAssistantMessage(msg sdk.Message) []json.RawMessage {
 	}
 
 	var prefix []json.RawMessage
-	if len(reasoningSummary) > 0 {
-		prefix = append(prefix, marshalRaw(codexReasoningItem{
-			Type:             "reasoning",
-			Summary:          reasoningSummary,
-			EncryptedContent: encryptedContent,
-		}))
+	for i := range reasoningItems {
+		// Summary is schema-required, so an item that carried only encrypted
+		// content still needs the key present.
+		if reasoningItems[i].Summary == nil {
+			reasoningItems[i].Summary = []codexReasoningSummaryText{}
+		}
+		prefix = append(prefix, marshalRaw(reasoningItems[i]))
 	}
 	if len(textParts) > 0 {
 		prefix = append(prefix, marshalRaw(codexAssistantMessage{Role: "assistant", Content: textParts}))
@@ -629,13 +647,4 @@ func joinWithDoubleNewline(values []string) string {
 		result += "\n\n" + value
 	}
 	return result
-}
-
-func extractOpenAIEncryptedContent(meta map[string]any) string {
-	if meta == nil {
-		return ""
-	}
-	openai, _ := meta["openai"].(map[string]any)
-	encrypted, _ := openai["reasoningEncryptedContent"].(string)
-	return encrypted
 }

--- a/provider/openai/codex/codex.go
+++ b/provider/openai/codex/codex.go
@@ -159,9 +159,9 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 			incompleteReason string
 			hasFunctionCall  bool
 
-			textStartSent      bool
-			reasoningStartSent bool
-			pendingToolCalls   = map[int]*streamingToolCall{}
+			textStartSent     bool
+			activeReasoningID string
+			pendingToolCalls  = map[int]*streamingToolCall{}
 		)
 
 		send := func(part sdk.StreamPart) bool {
@@ -173,11 +173,24 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 			}
 		}
 
-		flush := func() {
-			if reasoningStartSent {
-				send(&sdk.ReasoningEndPart{ID: responseID, Format: sdk.ReasoningFormatOpenAIResponses})
-				reasoningStartSent = false
+		// endReasoning closes the active reasoning block. meta carries the
+		// block's final metadata: encrypted_content is populated only on
+		// response.output_item.done, so the closing part is the only chance to
+		// deliver it. Every other close path passes nil.
+		endReasoning := func(meta map[string]any) {
+			if activeReasoningID == "" {
+				return
 			}
+			send(&sdk.ReasoningEndPart{
+				ID:               activeReasoningID,
+				Format:           sdk.ReasoningFormatOpenAIResponses,
+				ProviderMetadata: meta,
+			})
+			activeReasoningID = ""
+		}
+
+		flush := func() {
+			endReasoning(nil)
 			if textStartSent {
 				send(&sdk.TextEndPart{ID: responseID})
 				textStartSent = false
@@ -216,13 +229,14 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 						textStartSent = true
 					}
 				case outputTypeReasoning:
-					if !reasoningStartSent {
+					if activeReasoningID != chunk.Item.ID {
+						endReasoning(nil)
 						send(&sdk.ReasoningStartPart{
 							ID:               chunk.Item.ID,
 							Format:           sdk.ReasoningFormatOpenAIResponses,
 							ProviderMetadata: openaiutil.ReasoningItemMetadata(chunk.Item.ID, chunk.Item.EncryptedContent),
 						})
-						reasoningStartSent = true
+						activeReasoningID = chunk.Item.ID
 					}
 				case outputTypeFunctionCall:
 					flush()
@@ -239,10 +253,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 				if json.Unmarshal([]byte(ev.Data), &chunk) != nil {
 					return nil
 				}
-				if reasoningStartSent {
-					send(&sdk.ReasoningEndPart{ID: responseID, Format: sdk.ReasoningFormatOpenAIResponses})
-					reasoningStartSent = false
-				}
+				endReasoning(nil)
 				if !textStartSent {
 					send(&sdk.TextStartPart{ID: chunk.ItemID})
 					textStartSent = true
@@ -254,9 +265,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 				if json.Unmarshal([]byte(ev.Data), &chunk) != nil {
 					return nil
 				}
-				if !reasoningStartSent {
+				if activeReasoningID != chunk.ItemID {
+					endReasoning(nil)
 					send(&sdk.ReasoningStartPart{ID: chunk.ItemID, Format: sdk.ReasoningFormatOpenAIResponses})
-					reasoningStartSent = true
+					activeReasoningID = chunk.ItemID
 				}
 				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta, Format: sdk.ReasoningFormatOpenAIResponses})
 
@@ -284,9 +296,22 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 						textStartSent = false
 					}
 				case outputTypeReasoning:
-					if reasoningStartSent {
-						send(&sdk.ReasoningEndPart{ID: chunk.Item.ID, Format: sdk.ReasoningFormatOpenAIResponses})
-						reasoningStartSent = false
+					// The done event is where encrypted_content arrives; the
+					// added event fires before it is populated.
+					meta := openaiutil.ReasoningItemMetadata(chunk.Item.ID, chunk.Item.EncryptedContent)
+					switch {
+					case activeReasoningID == chunk.Item.ID:
+						endReasoning(meta)
+					case chunk.Item.EncryptedContent != "":
+						// The block was already closed by an interleaved event.
+						// Send another end part for it: the accumulator merges
+						// metadata by block ID, so the payload still lands on
+						// the right block instead of being lost.
+						send(&sdk.ReasoningEndPart{
+							ID:               chunk.Item.ID,
+							Format:           sdk.ReasoningFormatOpenAIResponses,
+							ProviderMetadata: meta,
+						})
 					}
 				case outputTypeFunctionCall:
 					hasFunctionCall = true

--- a/provider/openai/codex/codex_test.go
+++ b/provider/openai/codex/codex_test.go
@@ -150,3 +150,56 @@ func TestCodexListModels(t *testing.T) {
 		t.Fatalf("unexpected first model: %s", models[0].ID)
 	}
 }
+
+// encrypted_content is populated only on response.output_item.done, not on
+// output_item.added — reading it at added silently loses the payload, and the
+// next turn then replays a bare rs_… id the server can neither decrypt nor
+// look up (Codex always sends store:false).
+func TestCodexDoStream_CapturesEncryptedContentFromItemDone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.created\n"))
+		_, _ = w.Write([]byte("data: {\"response\":{\"id\":\"resp_ec\",\"created_at\":1700000000,\"model\":\"gpt-5.2\"}}\n\n"))
+		// added: no encrypted_content yet — this mirrors the real API.
+		_, _ = w.Write([]byte("event: response.output_item.added\n"))
+		_, _ = w.Write([]byte("data: {\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_ec\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.reasoning_summary_text.delta\n"))
+		_, _ = w.Write([]byte("data: {\"item_id\":\"rs_ec\",\"delta\":\"thinking\"}\n\n"))
+		// done: the payload arrives here and only here.
+		_, _ = w.Write([]byte("event: response.output_item.done\n"))
+		_, _ = w.Write([]byte("data: {\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"id\":\"rs_ec\",\"encrypted_content\":\"ENC_PAYLOAD\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_item.added\n"))
+		_, _ = w.Write([]byte("data: {\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_text.delta\n"))
+		_, _ = w.Write([]byte("data: {\"item_id\":\"msg_1\",\"delta\":\"answer\"}\n\n"))
+		_, _ = w.Write([]byte("event: response.output_item.done\n"))
+		_, _ = w.Write([]byte("data: {\"output_index\":1,\"item\":{\"type\":\"message\",\"id\":\"msg_1\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.completed\n"))
+		_, _ = w.Write([]byte("data: {\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"))
+	}))
+	defer srv.Close()
+
+	p := codex.New(codex.WithAccessToken("token-123"), codex.WithBaseURL(srv.URL))
+	result, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    p.ChatModel("gpt-5.2"),
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+
+	if len(result.ReasoningParts) != 1 {
+		t.Fatalf("ReasoningParts: got %d, want 1 (%+v)", len(result.ReasoningParts), result.ReasoningParts)
+	}
+	part := result.ReasoningParts[0]
+	if part.Text != "thinking" {
+		t.Errorf("text: got %q, want %q", part.Text, "thinking")
+	}
+	meta, _ := part.ProviderMetadata["openai"].(map[string]any)
+	if meta["reasoningEncryptedContent"] != "ENC_PAYLOAD" {
+		t.Errorf("encrypted content lost in streaming: metadata = %+v", part.ProviderMetadata)
+	}
+	if meta["itemId"] != "rs_ec" {
+		t.Errorf("item id: got %v, want rs_ec", meta["itemId"])
+	}
+}

--- a/provider/openai/codex/types.go
+++ b/provider/openai/codex/types.go
@@ -76,7 +76,10 @@ type codexReasoningSummaryText struct {
 }
 
 type codexReasoningItem struct {
-	Type             string                      `json:"type"`
+	Type string `json:"type"`
+	// ID is schema-required by the API and must be the id the item was issued
+	// under.
+	ID               string                      `json:"id,omitempty"`
 	Summary          []codexReasoningSummaryText `json:"summary"`
 	EncryptedContent string                      `json:"encrypted_content,omitempty"`
 }

--- a/provider/openai/codex/types.go
+++ b/provider/openai/codex/types.go
@@ -111,6 +111,9 @@ type codexOutputItemDoneChunk struct {
 		CallID    string `json:"call_id,omitempty"`
 		Name      string `json:"name,omitempty"`
 		Arguments string `json:"arguments,omitempty"`
+		// reasoning fields. encrypted_content is populated only on this event,
+		// not on output_item.added, where the item has just been created.
+		EncryptedContent string `json:"encrypted_content,omitempty"`
 	} `json:"item"`
 }
 

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -398,6 +398,9 @@ func convertAssistantMessage(msg sdk.Message) chatMessage {
 				},
 			})
 		case sdk.ReasoningPart:
+			if p.Format != sdk.ReasoningFormatOpenAIChat {
+				continue
+			}
 			reasoning += p.Text
 			if details := extractMiniMaxReasoningDetails(p.ProviderMetadata); len(details) > 0 {
 				reasoningDetails = details
@@ -484,8 +487,12 @@ func (p *Provider) parseResponse(resp *chatResponse) (*sdk.GenerateResult, error
 		choice := resp.Choices[0]
 		result.Text = choice.Message.Content
 		result.Reasoning = reasoningFromMessage(&choice.Message)
-		if len(choice.Message.ReasoningDetails) > 0 {
-			result.ReasoningProviderMetadata = minimaxReasoningMetadata(choice.Message.ReasoningDetails)
+		if result.Reasoning != "" || len(choice.Message.ReasoningDetails) > 0 {
+			result.ReasoningParts = []sdk.ReasoningPart{{
+				Text:             result.Reasoning,
+				Format:           sdk.ReasoningFormatOpenAIChat,
+				ProviderMetadata: minimaxReasoningMetadata(choice.Message.ReasoningDetails),
+			}}
 		}
 		result.FinishReason = mapFinishReason(choice.FinishReason)
 		result.RawFinishReason = choice.FinishReason

--- a/provider/openai/completions/completions.go
+++ b/provider/openai/completions/completions.go
@@ -491,6 +491,7 @@ func (p *Provider) parseResponse(resp *chatResponse) (*sdk.GenerateResult, error
 			result.ReasoningParts = []sdk.ReasoningPart{{
 				Text:             result.Reasoning,
 				Format:           sdk.ReasoningFormatOpenAIChat,
+				Model:            resp.Model,
 				ProviderMetadata: minimaxReasoningMetadata(choice.Message.ReasoningDetails),
 			}}
 		}

--- a/provider/openai/completions/completions_test.go
+++ b/provider/openai/completions/completions_test.go
@@ -1170,7 +1170,7 @@ func TestDoGenerate_AssistantReasoningInRequest(t *testing.T) {
 				Role: sdk.MessageRoleAssistant,
 				Content: []sdk.MessagePart{
 					sdk.TextPart{Text: "The answer"},
-					sdk.ReasoningPart{Text: "I thought about it"},
+					sdk.ReasoningPart{Text: "I thought about it", Format: sdk.ReasoningFormatOpenAIChat},
 				},
 			},
 		},

--- a/provider/openai/completions/stream.go
+++ b/provider/openai/completions/stream.go
@@ -39,7 +39,7 @@ func (sp *streamProcessor) send(part sdk.StreamPart) bool {
 
 func (sp *streamProcessor) endReasoning(id string) {
 	if sp.reasoningStartSent {
-		sp.send(&sdk.ReasoningEndPart{ID: id, Format: sdk.ReasoningFormatOpenAIChat, ProviderMetadata: minimaxReasoningMetadata(sp.reasoningDetails)})
+		sp.send(&sdk.ReasoningEndPart{ID: id, Format: sdk.ReasoningFormatOpenAIChat, Model: sp.chunkModel, ProviderMetadata: minimaxReasoningMetadata(sp.reasoningDetails)})
 		sp.reasoningStartSent = false
 	}
 }
@@ -69,8 +69,16 @@ func (sp *streamProcessor) finishToolCall(stc *streamingToolCall) {
 	}
 	sp.send(&sdk.ToolInputEndPart{ID: stc.id})
 	var input any
-	if err := json.Unmarshal([]byte(stc.args.String()), &input); err != nil {
-		sp.send(&sdk.ErrorPart{Error: fmt.Errorf("openai: unmarshal tool call arguments for %q: %w", stc.name, err)})
+	// Providers stream arguments incrementally and no-arg tools may close with
+	// an empty buffer, which is not malformed JSON — only a non-empty buffer
+	// that fails to parse is. Such a call must not be emitted: nil input would
+	// hand the tool empty arguments and run it anyway.
+	if args := stc.args.String(); args != "" {
+		if err := json.Unmarshal([]byte(args), &input); err != nil {
+			sp.send(&sdk.ErrorPart{Error: fmt.Errorf("openai: unmarshal tool call arguments for %q: %w", stc.name, err)})
+			stc.finished = true
+			return
+		}
 	}
 	sp.send(&sdk.StreamToolCallPart{
 		ToolCallID: stc.id,
@@ -121,10 +129,10 @@ func (sp *streamProcessor) processReasoning(delta *chatChunkDelta, chunkID strin
 		return
 	}
 	if !sp.reasoningStartSent {
-		sp.send(&sdk.ReasoningStartPart{ID: chunkID, Format: sdk.ReasoningFormatOpenAIChat})
+		sp.send(&sdk.ReasoningStartPart{ID: chunkID, Format: sdk.ReasoningFormatOpenAIChat, Model: sp.chunkModel})
 		sp.reasoningStartSent = true
 	}
-	sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent, Format: sdk.ReasoningFormatOpenAIChat})
+	sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent, Format: sdk.ReasoningFormatOpenAIChat, Model: sp.chunkModel})
 }
 
 func trimReasoningPrefix(text, previous string) string {

--- a/provider/openai/completions/stream.go
+++ b/provider/openai/completions/stream.go
@@ -39,7 +39,7 @@ func (sp *streamProcessor) send(part sdk.StreamPart) bool {
 
 func (sp *streamProcessor) endReasoning(id string) {
 	if sp.reasoningStartSent {
-		sp.send(&sdk.ReasoningEndPart{ID: id, ProviderMetadata: minimaxReasoningMetadata(sp.reasoningDetails)})
+		sp.send(&sdk.ReasoningEndPart{ID: id, Format: sdk.ReasoningFormatOpenAIChat, ProviderMetadata: minimaxReasoningMetadata(sp.reasoningDetails)})
 		sp.reasoningStartSent = false
 	}
 }
@@ -121,10 +121,10 @@ func (sp *streamProcessor) processReasoning(delta *chatChunkDelta, chunkID strin
 		return
 	}
 	if !sp.reasoningStartSent {
-		sp.send(&sdk.ReasoningStartPart{ID: chunkID})
+		sp.send(&sdk.ReasoningStartPart{ID: chunkID, Format: sdk.ReasoningFormatOpenAIChat})
 		sp.reasoningStartSent = true
 	}
-	sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent})
+	sp.send(&sdk.ReasoningDeltaPart{ID: chunkID, Text: reasoningContent, Format: sdk.ReasoningFormatOpenAIChat})
 }
 
 func trimReasoningPrefix(text, previous string) string {

--- a/provider/openai/reasoning_metadata.go
+++ b/provider/openai/reasoning_metadata.go
@@ -1,0 +1,41 @@
+package openai
+
+import sdk "github.com/memohai/twilight-ai/sdk"
+
+// The Responses reasoning dialect, shared by the public Responses API and the
+// Codex backend: the same API behind a different base URL, producing
+// byte-identical reasoning items.
+const (
+	metadataNamespace           = "openai"
+	metadataKeyItemID           = "itemId"
+	metadataKeyEncryptedContent = "reasoningEncryptedContent"
+
+	// IncludeReasoningEncryptedContent asks the API to return the encrypted
+	// reasoning payload. It is required to replay reasoning when the
+	// conversation is not stored server-side.
+	IncludeReasoningEncryptedContent = "reasoning.encrypted_content"
+)
+
+// ReasoningItemMetadata records what a reasoning item needs on replay: the item
+// id, which the API requires, and the encrypted content that carries the
+// reasoning state when the conversation is not stored server-side.
+//
+// The encrypted payload is scoped to the account and endpoint that issued it.
+// Replaying it elsewhere fails verification even though the wire shape matches,
+// so this metadata travels with the part rather than being reconstructed.
+func ReasoningItemMetadata(itemID, encryptedContent string) map[string]any {
+	return sdk.ReasoningMetadata(metadataNamespace, map[string]string{
+		metadataKeyItemID:           itemID,
+		metadataKeyEncryptedContent: encryptedContent,
+	})
+}
+
+// ReasoningItemID returns the reasoning item id a part must be replayed under.
+func ReasoningItemID(meta map[string]any) string {
+	return sdk.ReasoningMetadataString(meta, metadataNamespace, metadataKeyItemID)
+}
+
+// ReasoningEncryptedContent returns the encrypted reasoning payload.
+func ReasoningEncryptedContent(meta map[string]any) string {
+	return sdk.ReasoningMetadataString(meta, metadataNamespace, metadataKeyEncryptedContent)
+}

--- a/provider/openai/responses/reasoning_roundtrip_test.go
+++ b/provider/openai/responses/reasoning_roundtrip_test.go
@@ -180,3 +180,117 @@ func TestRequestAsksForEncryptedReasoning(t *testing.T) {
 		t.Errorf("store: got %v, want false", captured["store"])
 	}
 }
+
+// In streaming, encrypted_content is populated only on
+// response.output_item.done — output_item.added fires before it exists. A
+// converter that reads it at added (as LangChain.js did, langchainjs#10844)
+// silently loses the payload, and with store:false the next turn then replays
+// a bare rs_… id the server can neither decrypt nor look up.
+func TestDoStreamCapturesEncryptedContentFromItemDone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, e := range []struct{ event, data string }{
+			{"response.created",
+				`{"type":"response.created","response":{"id":"resp_ec","created_at":1700000000,"model":"gpt-5.6"}}`},
+			// added: no encrypted_content yet — this mirrors the real API.
+			{"response.output_item.added",
+				`{"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_ec"}}`},
+			{"response.reasoning_summary_text.delta",
+				`{"type":"response.reasoning_summary_text.delta","item_id":"rs_ec","summary_index":0,"delta":"thinking"}`},
+			// done: the payload arrives here and only here.
+			{"response.output_item.done",
+				`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs_ec","encrypted_content":"ENC_PAYLOAD"}}`},
+			{"response.output_item.added",
+				`{"type":"response.output_item.added","output_index":1,"item":{"type":"message","id":"msg_ec"}}`},
+			{"response.output_text.delta",
+				`{"type":"response.output_text.delta","item_id":"msg_ec","delta":"answer"}`},
+			{"response.output_item.done",
+				`{"type":"response.output_item.done","output_index":1,"item":{"type":"message","id":"msg_ec"}}`},
+			{"response.completed",
+				`{"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}`},
+		} {
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", e.event, e.data)
+		}
+	}))
+	defer srv.Close()
+
+	p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(srv.URL))
+	sr, err := p.DoStream(context.Background(), sdk.GenerateParams{
+		Model:    p.ChatModel("gpt-5.6"),
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+
+	result, err := sr.ToResult()
+	if err != nil {
+		t.Fatalf("ToResult: %v", err)
+	}
+	if len(result.ReasoningParts) != 1 {
+		t.Fatalf("ReasoningParts: got %d, want 1 (%+v)", len(result.ReasoningParts), result.ReasoningParts)
+	}
+	part := result.ReasoningParts[0]
+	if part.Text != "thinking" {
+		t.Errorf("text: got %q, want %q", part.Text, "thinking")
+	}
+	meta, _ := part.ProviderMetadata["openai"].(map[string]any)
+	if meta["reasoningEncryptedContent"] != "ENC_PAYLOAD" {
+		t.Errorf("encrypted content lost in streaming: metadata = %+v", part.ProviderMetadata)
+	}
+	if meta["itemId"] != "rs_ec" {
+		t.Errorf("item id: got %v, want rs_ec", meta["itemId"])
+	}
+}
+
+// A tool call arriving between the reasoning deltas and the item's done event
+// closes the block early; the payload on the late done event must still reach
+// the block rather than being dropped because it is no longer active.
+func TestDoStreamKeepsEncryptedContentWhenToolCallClosesBlockFirst(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, e := range []struct{ event, data string }{
+			{"response.created",
+				`{"type":"response.created","response":{"id":"resp_tc","created_at":1700000000,"model":"gpt-5.6"}}`},
+			{"response.output_item.added",
+				`{"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_tc"}}`},
+			{"response.reasoning_summary_text.delta",
+				`{"type":"response.reasoning_summary_text.delta","item_id":"rs_tc","summary_index":0,"delta":"planning"}`},
+			// function_call added ends the reasoning block before rs_tc's done.
+			{"response.output_item.added",
+				`{"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc_tc","call_id":"call_tc","name":"lookup"}}`},
+			{"response.output_item.done",
+				`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs_tc","encrypted_content":"ENC_LATE"}}`},
+			{"response.function_call_arguments.delta",
+				`{"type":"response.function_call_arguments.delta","item_id":"fc_tc","output_index":1,"delta":"{}"}`},
+			{"response.output_item.done",
+				`{"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","id":"fc_tc","call_id":"call_tc","name":"lookup","arguments":"{}"}}`},
+			{"response.completed",
+				`{"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}`},
+		} {
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", e.event, e.data)
+		}
+	}))
+	defer srv.Close()
+
+	p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(srv.URL))
+	sr, err := p.DoStream(context.Background(), sdk.GenerateParams{
+		Model:    p.ChatModel("gpt-5.6"),
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+	})
+	if err != nil {
+		t.Fatalf("DoStream: %v", err)
+	}
+
+	result, err := sr.ToResult()
+	if err != nil {
+		t.Fatalf("ToResult: %v", err)
+	}
+	if len(result.ReasoningParts) != 1 {
+		t.Fatalf("ReasoningParts: got %d, want 1 (%+v)", len(result.ReasoningParts), result.ReasoningParts)
+	}
+	meta, _ := result.ReasoningParts[0].ProviderMetadata["openai"].(map[string]any)
+	if meta["reasoningEncryptedContent"] != "ENC_LATE" {
+		t.Errorf("late encrypted content lost: metadata = %+v", result.ReasoningParts[0].ProviderMetadata)
+	}
+}

--- a/provider/openai/responses/reasoning_roundtrip_test.go
+++ b/provider/openai/responses/reasoning_roundtrip_test.go
@@ -1,0 +1,182 @@
+package responses_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/memohai/twilight-ai/provider/openai/responses"
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// A reasoning item may carry several summary entries. Each becomes its own
+// part so nothing is flattened, but all of them share the item's id — so
+// replaying must regroup them into one item, not several.
+
+func captureInput(t *testing.T, messages []sdk.Message) []map[string]any {
+	t.Helper()
+	var captured struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer srv.Close()
+
+	p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(srv.URL))
+	if _, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    p.ChatModel("gpt-5.6"),
+		Messages: messages,
+	}); err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+
+	items := make([]map[string]any, 0, len(captured.Input))
+	for _, raw := range captured.Input {
+		var item map[string]any
+		if err := json.Unmarshal(raw, &item); err != nil {
+			t.Fatalf("unmarshal item: %v", err)
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func TestReplayRegroupsPartsSharingAnItemID(t *testing.T) {
+	meta := map[string]any{"openai": map[string]any{
+		"itemId":                    "rs_1",
+		"reasoningEncryptedContent": "EC",
+	}}
+	items := captureInput(t, []sdk.Message{{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{ID: "rs_1", Text: "first", Format: sdk.ReasoningFormatOpenAIResponses, ProviderMetadata: meta},
+			sdk.ReasoningPart{ID: "rs_1", Text: "second", Format: sdk.ReasoningFormatOpenAIResponses, ProviderMetadata: meta},
+			sdk.TextPart{Text: "answer"},
+		},
+	}})
+
+	var reasoning []map[string]any
+	for _, item := range items {
+		if item["type"] == "reasoning" {
+			reasoning = append(reasoning, item)
+		}
+	}
+	if len(reasoning) != 1 {
+		t.Fatalf("reasoning items: got %d, want 1 — parts sharing an id must merge: %+v", len(reasoning), items)
+	}
+	if reasoning[0]["id"] != "rs_1" {
+		t.Errorf("item id: got %v, want rs_1 (the API requires it)", reasoning[0]["id"])
+	}
+	summary, _ := reasoning[0]["summary"].([]any)
+	if len(summary) != 2 {
+		t.Fatalf("summary entries: got %d, want 2: %+v", len(summary), reasoning[0])
+	}
+	if reasoning[0]["encrypted_content"] != "EC" {
+		t.Errorf("encrypted_content: got %v, want EC", reasoning[0]["encrypted_content"])
+	}
+}
+
+// Distinct items stay distinct, in their original order.
+func TestReplayKeepsDistinctItemsSeparate(t *testing.T) {
+	items := captureInput(t, []sdk.Message{{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{Text: "a", Format: sdk.ReasoningFormatOpenAIResponses,
+				ProviderMetadata: map[string]any{"openai": map[string]any{"itemId": "rs_1"}}},
+			sdk.ReasoningPart{Text: "b", Format: sdk.ReasoningFormatOpenAIResponses,
+				ProviderMetadata: map[string]any{"openai": map[string]any{"itemId": "rs_2"}}},
+			sdk.TextPart{Text: "answer"},
+		},
+	}})
+
+	var ids []any
+	for _, item := range items {
+		if item["type"] == "reasoning" {
+			ids = append(ids, item["id"])
+		}
+	}
+	if len(ids) != 2 || ids[0] != "rs_1" || ids[1] != "rs_2" {
+		t.Fatalf("reasoning item ids: got %v, want [rs_1 rs_2]", ids)
+	}
+}
+
+// An item whose payload is only encrypted content still has to be replayed:
+// dropping it loses the reasoning chain. summary is schema-required, so the key
+// must be present even when empty.
+func TestReplayKeepsEncryptedOnlyItem(t *testing.T) {
+	items := captureInput(t, []sdk.Message{{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{Format: sdk.ReasoningFormatOpenAIResponses,
+				ProviderMetadata: map[string]any{"openai": map[string]any{
+					"itemId":                    "rs_opaque",
+					"reasoningEncryptedContent": "ENCRYPTED_ONLY",
+				}}},
+		},
+	}})
+
+	if len(items) != 1 || items[0]["type"] != "reasoning" {
+		t.Fatalf("items: got %+v, want a single reasoning item", items)
+	}
+	if items[0]["encrypted_content"] != "ENCRYPTED_ONLY" {
+		t.Errorf("encrypted_content: got %v", items[0]["encrypted_content"])
+	}
+	if _, present := items[0]["summary"]; !present {
+		t.Errorf("summary key absent, but the schema requires it: %+v", items[0])
+	}
+}
+
+func TestReplayDropsForeignReasoning(t *testing.T) {
+	items := captureInput(t, []sdk.Message{{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{Text: "anthropic thinking", Format: sdk.ReasoningFormatAnthropic,
+				ProviderMetadata: map[string]any{"anthropic": map[string]any{"signature": "SIG"}}},
+			sdk.TextPart{Text: "answer"},
+		},
+	}})
+
+	for _, item := range items {
+		if item["type"] == "reasoning" {
+			t.Fatalf("foreign reasoning replayed: %+v", item)
+		}
+	}
+}
+
+// Encrypted reasoning is returned only when asked for, and only a stateless
+// request keeps the SDK's own message list authoritative.
+func TestRequestAsksForEncryptedReasoning(t *testing.T) {
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+	defer srv.Close()
+
+	p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(srv.URL))
+	if _, err := p.DoGenerate(context.Background(), sdk.GenerateParams{
+		Model:    p.ChatModel("gpt-5.6"),
+		Messages: []sdk.Message{sdk.UserMessage("hi")},
+	}); err != nil {
+		t.Fatalf("DoGenerate: %v", err)
+	}
+
+	include, _ := captured["include"].([]any)
+	if len(include) != 1 || include[0] != "reasoning.encrypted_content" {
+		t.Errorf("include: got %v, want [reasoning.encrypted_content]", captured["include"])
+	}
+	if store, ok := captured["store"].(bool); !ok || store {
+		t.Errorf("store: got %v, want false", captured["store"])
+	}
+}

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -483,6 +483,7 @@ func (p *Provider) parseResponse(resp *responsesResponse) (*sdk.GenerateResult, 
 				result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
 					ID:               item.ID,
 					Format:           sdk.ReasoningFormatOpenAIResponses,
+					Model:            resp.Model,
 					ProviderMetadata: meta,
 				})
 			}
@@ -494,6 +495,7 @@ func (p *Provider) parseResponse(resp *responsesResponse) (*sdk.GenerateResult, 
 					ID:               item.ID,
 					Text:             s.Text,
 					Format:           sdk.ReasoningFormatOpenAIResponses,
+					Model:            resp.Model,
 					ProviderMetadata: meta,
 				})
 			}
@@ -691,7 +693,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					return nil
 				}
 				startReasoning(chunk.ItemID, nil)
-				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta, Format: sdk.ReasoningFormatOpenAIResponses})
+				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta, Format: sdk.ReasoningFormatOpenAIResponses, Model: responseModel})
 
 			case "response.function_call_arguments.delta":
 				var chunk responsesFuncArgsDeltaChunk
@@ -747,8 +749,15 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 							args = stc.args.String()
 						}
 						var input any
-						if err := json.Unmarshal([]byte(args), &input); err != nil {
-							send(&sdk.ErrorPart{Error: fmt.Errorf("openai-responses: unmarshal tool call arguments for %q: %w", stc.name, err)})
+						// A call whose arguments cannot be parsed must not
+						// become a call: nil input would hand the tool empty
+						// arguments and run it anyway.
+						if args != "" {
+							if err := json.Unmarshal([]byte(args), &input); err != nil {
+								send(&sdk.ErrorPart{Error: fmt.Errorf("openai-responses: unmarshal tool call arguments for %q: %w", stc.name, err)})
+								stc.finished = true
+								break
+							}
 						}
 						send(&sdk.StreamToolCallPart{
 							ToolCallID: stc.id,

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -567,11 +567,19 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 			}
 		}
 
-		endReasoning := func() {
+		// endReasoning closes the active reasoning block. meta carries the
+		// block's final metadata: encrypted_content is populated only on
+		// response.output_item.done, so the closing part is the only chance to
+		// deliver it. Every other close path passes nil.
+		endReasoning := func(meta map[string]any) {
 			if activeReasoningID == "" {
 				return
 			}
-			send(&sdk.ReasoningEndPart{ID: activeReasoningID, Format: sdk.ReasoningFormatOpenAIResponses})
+			send(&sdk.ReasoningEndPart{
+				ID:               activeReasoningID,
+				Format:           sdk.ReasoningFormatOpenAIResponses,
+				ProviderMetadata: meta,
+			})
 			activeReasoningID = ""
 		}
 
@@ -579,7 +587,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 			if activeReasoningID == id {
 				return
 			}
-			endReasoning()
+			endReasoning(nil)
 			send(&sdk.ReasoningStartPart{
 				ID:               id,
 				Format:           sdk.ReasoningFormatOpenAIResponses,
@@ -589,7 +597,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 		}
 
 		flush := func() {
-			endReasoning()
+			endReasoning(nil)
 			if textStartSent {
 				send(&sdk.TextEndPart{ID: responseID})
 				textStartSent = false
@@ -646,7 +654,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 				case outputTypeReasoning:
 					startReasoning(chunk.Item.ID, openaiutil.ReasoningItemMetadata(chunk.Item.ID, chunk.Item.EncryptedContent))
 				case outputTypeFunctionCall:
-					endReasoning()
+					endReasoning(nil)
 					if textStartSent {
 						send(&sdk.TextEndPart{ID: responseID})
 						textStartSent = false
@@ -670,7 +678,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 				if err := json.Unmarshal([]byte(ev.Data), &chunk); err != nil {
 					return nil
 				}
-				endReasoning()
+				endReasoning(nil)
 				if !textStartSent {
 					send(&sdk.TextStartPart{ID: chunk.ItemID})
 					textStartSent = true
@@ -712,8 +720,22 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 						textStartSent = false
 					}
 				case outputTypeReasoning:
-					if activeReasoningID == chunk.Item.ID {
-						endReasoning()
+					// The done event is where encrypted_content arrives; the
+					// added event fires before it is populated.
+					meta := openaiutil.ReasoningItemMetadata(chunk.Item.ID, chunk.Item.EncryptedContent)
+					switch {
+					case activeReasoningID == chunk.Item.ID:
+						endReasoning(meta)
+					case chunk.Item.EncryptedContent != "":
+						// The block was already closed by an interleaved event.
+						// Send another end part for it: the accumulator merges
+						// metadata by block ID, so the payload still lands on
+						// the right block instead of being lost.
+						send(&sdk.ReasoningEndPart{
+							ID:               chunk.Item.ID,
+							Format:           sdk.ReasoningFormatOpenAIResponses,
+							ProviderMetadata: meta,
+						})
 					}
 				case outputTypeFunctionCall:
 					hasFunctionCall = true

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/memohai/twilight-ai/internal/messagecompat"
 	"github.com/memohai/twilight-ai/internal/utils"
+	openaiutil "github.com/memohai/twilight-ai/provider/openai"
 	"github.com/memohai/twilight-ai/sdk"
 )
 
@@ -208,6 +209,10 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*responsesRequest, 
 	if err != nil {
 		return nil, err
 	}
+	// The SDK carries conversation state in its own message list, so the server
+	// must not store it. That makes encrypted_content the only channel for
+	// reasoning state across turns, and it is returned only when requested.
+	store := false
 	req := &responsesRequest{
 		Model:           params.Model.ID,
 		Instructions:    params.System,
@@ -216,6 +221,8 @@ func (p *Provider) buildRequest(params *sdk.GenerateParams) (*responsesRequest, 
 		TopP:            params.TopP,
 		MaxOutputTokens: params.MaxTokens,
 		PromptCacheKey:  params.PromptCacheKey,
+		Include:         []string{openaiutil.IncludeReasoningEncryptedContent},
+		Store:           &store,
 	}
 
 	if len(params.Tools) > 0 {
@@ -325,8 +332,8 @@ func convertResponsesUserMessage(msg sdk.Message) []json.RawMessage {
 func convertResponsesAssistantMessage(msg sdk.Message) []json.RawMessage {
 	var items []json.RawMessage
 	var textParts []responsesOutputTextPart
-	var reasoningSummary []responsesReasoningSummaryText
-	var encryptedContent string
+	var reasoningItems []responsesReasoningItem
+	reasoningIndexByID := map[string]int{}
 
 	for _, part := range msg.Content {
 		switch p := part.(type) {
@@ -337,12 +344,31 @@ func convertResponsesAssistantMessage(msg sdk.Message) []json.RawMessage {
 			})
 
 		case sdk.ReasoningPart:
-			reasoningSummary = append(reasoningSummary, responsesReasoningSummaryText{
-				Type: "summary_text",
-				Text: p.Text,
-			})
-			if ec := extractOpenAIEncryptedContent(p.ProviderMetadata); ec != "" {
-				encryptedContent = ec
+			// Only this dialect's blocks can be replayed; anything else the API
+			// cannot verify, and re-sending reasoning as ordinary text teaches
+			// the model to imitate it in user-visible answers.
+			if p.Format != sdk.ReasoningFormatOpenAIResponses {
+				continue
+			}
+			id := openaiutil.ReasoningItemID(p.ProviderMetadata)
+			if id == "" {
+				id = p.ID
+			}
+			idx, ok := reasoningIndexByID[id]
+			if !ok || id == "" {
+				reasoningItems = append(reasoningItems, responsesReasoningItem{
+					Type:             "reasoning",
+					ID:               id,
+					EncryptedContent: openaiutil.ReasoningEncryptedContent(p.ProviderMetadata),
+				})
+				idx = len(reasoningItems) - 1
+				if id != "" {
+					reasoningIndexByID[id] = idx
+				}
+			}
+			if p.Text != "" {
+				reasoningItems[idx].Summary = append(reasoningItems[idx].Summary,
+					responsesReasoningSummaryText{Type: "summary_text", Text: p.Text})
 			}
 
 		case sdk.ToolCallPart:
@@ -364,13 +390,13 @@ func convertResponsesAssistantMessage(msg sdk.Message) []json.RawMessage {
 	}
 
 	var prefix []json.RawMessage
-	if len(reasoningSummary) > 0 {
-		ri := responsesReasoningItem{
-			Type:             "reasoning",
-			Summary:          reasoningSummary,
-			EncryptedContent: encryptedContent,
+	for i := range reasoningItems {
+		// Summary is schema-required, so an item that carried only encrypted
+		// content still needs the key present.
+		if reasoningItems[i].Summary == nil {
+			reasoningItems[i].Summary = []responsesReasoningSummaryText{}
 		}
-		prefix = append(prefix, marshalRaw(ri))
+		prefix = append(prefix, marshalRaw(reasoningItems[i]))
 	}
 	if len(textParts) > 0 {
 		prefix = append(prefix, marshalRaw(responsesAssistantMessage{
@@ -440,18 +466,29 @@ func (p *Provider) parseResponse(resp *responsesResponse) (*sdk.GenerateResult, 
 			}
 
 		case outputTypeReasoning:
-			for _, s := range item.Summary {
-				if s.Type == "summary_text" {
-					result.Reasoning += s.Text
-				}
+			// One reasoning item may carry several summary entries; each becomes
+			// its own block, all sharing the item's identity so the item can be
+			// reassembled on replay. An item with no summary still has to be
+			// replayed when it carries encrypted content, so it yields a block
+			// with empty text rather than none.
+			meta := openaiutil.ReasoningItemMetadata(item.ID, item.EncryptedContent)
+			if len(item.Summary) == 0 {
+				result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
+					ID:               item.ID,
+					Format:           sdk.ReasoningFormatOpenAIResponses,
+					ProviderMetadata: meta,
+				})
 			}
-			if item.EncryptedContent != "" {
-				result.ReasoningProviderMetadata = map[string]any{
-					"openai": map[string]any{
-						"reasoningEncryptedContent": item.EncryptedContent,
-						"itemId":                    item.ID,
-					},
+			for _, s := range item.Summary {
+				if s.Type != "summary_text" {
+					continue
 				}
+				result.ReasoningParts = append(result.ReasoningParts, sdk.ReasoningPart{
+					ID:               item.ID,
+					Text:             s.Text,
+					Format:           sdk.ReasoningFormatOpenAIResponses,
+					ProviderMetadata: meta,
+				})
 			}
 
 		case outputTypeFunctionCall:
@@ -476,6 +513,7 @@ func (p *Provider) parseResponse(resp *responsesResponse) (*sdk.GenerateResult, 
 	if incompleteReason != "" {
 		result.RawFinishReason = incompleteReason
 	}
+	result.Reasoning = sdk.ReasoningText(result.ReasoningParts)
 
 	return result, nil
 }
@@ -524,7 +562,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 
 		flush := func() {
 			if reasoningStartSent {
-				send(&sdk.ReasoningEndPart{ID: responseID})
+				send(&sdk.ReasoningEndPart{ID: responseID, Format: sdk.ReasoningFormatOpenAIResponses})
 				reasoningStartSent = false
 			}
 			if textStartSent {
@@ -582,21 +620,16 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					}
 				case outputTypeReasoning:
 					if !reasoningStartSent {
-						var meta map[string]any
-						if chunk.Item.EncryptedContent != "" {
-							meta = map[string]any{
-								"openai": map[string]any{
-									"reasoningEncryptedContent": chunk.Item.EncryptedContent,
-									"itemId":                    chunk.Item.ID,
-								},
-							}
-						}
-						send(&sdk.ReasoningStartPart{ID: chunk.Item.ID, ProviderMetadata: meta})
+						send(&sdk.ReasoningStartPart{
+							ID:               chunk.Item.ID,
+							Format:           sdk.ReasoningFormatOpenAIResponses,
+							ProviderMetadata: openaiutil.ReasoningItemMetadata(chunk.Item.ID, chunk.Item.EncryptedContent),
+						})
 						reasoningStartSent = true
 					}
 				case outputTypeFunctionCall:
 					if reasoningStartSent {
-						send(&sdk.ReasoningEndPart{ID: responseID})
+						send(&sdk.ReasoningEndPart{ID: responseID, Format: sdk.ReasoningFormatOpenAIResponses})
 						reasoningStartSent = false
 					}
 					if textStartSent {
@@ -623,7 +656,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					return nil
 				}
 				if reasoningStartSent {
-					send(&sdk.ReasoningEndPart{ID: responseID})
+					send(&sdk.ReasoningEndPart{ID: responseID, Format: sdk.ReasoningFormatOpenAIResponses})
 					reasoningStartSent = false
 				}
 				if !textStartSent {
@@ -638,10 +671,10 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					return nil
 				}
 				if !reasoningStartSent {
-					send(&sdk.ReasoningStartPart{ID: chunk.ItemID})
+					send(&sdk.ReasoningStartPart{ID: chunk.ItemID, Format: sdk.ReasoningFormatOpenAIResponses})
 					reasoningStartSent = true
 				}
-				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta})
+				send(&sdk.ReasoningDeltaPart{ID: chunk.ItemID, Text: chunk.Delta, Format: sdk.ReasoningFormatOpenAIResponses})
 
 			case "response.function_call_arguments.delta":
 				var chunk responsesFuncArgsDeltaChunk
@@ -671,7 +704,7 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 					}
 				case outputTypeReasoning:
 					if reasoningStartSent {
-						send(&sdk.ReasoningEndPart{ID: chunk.Item.ID})
+						send(&sdk.ReasoningEndPart{ID: chunk.Item.ID, Format: sdk.ReasoningFormatOpenAIResponses})
 						reasoningStartSent = false
 					}
 				case outputTypeFunctionCall:
@@ -823,18 +856,6 @@ func convertResponsesUsage(u *responsesUsage) sdk.Usage {
 			TextTokens:      outputTokens - reasoningTokens,
 		},
 	}
-}
-
-func extractOpenAIEncryptedContent(meta map[string]any) string {
-	if meta == nil {
-		return ""
-	}
-	om, ok := meta["openai"].(map[string]any)
-	if !ok {
-		return ""
-	}
-	ec, _ := om["reasoningEncryptedContent"].(string)
-	return ec
 }
 
 func textFromParts(parts []sdk.MessagePart) string {

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -803,6 +803,25 @@ func (p *Provider) DoStream(ctx context.Context, params sdk.GenerateParams) (*sd
 
 				return utils.ErrStreamDone
 
+			case "response.failed":
+				var chunk responsesFailedChunk
+				if err := json.Unmarshal([]byte(ev.Data), &chunk); err != nil {
+					return nil
+				}
+				if chunk.Response.Usage != nil {
+					usage = convertResponsesUsage(chunk.Response.Usage)
+				}
+				if chunk.Response.Error == nil {
+					send(&sdk.ErrorPart{Error: fmt.Errorf("openai-responses: response failed")})
+				} else {
+					send(&sdk.ErrorPart{Error: fmt.Errorf(
+						"openai-responses: %s: %s",
+						chunk.Response.Error.Code,
+						chunk.Response.Error.Message,
+					)})
+				}
+				return utils.ErrStreamDone
+
 			case "error":
 				var chunk responsesErrorChunk
 				if err := json.Unmarshal([]byte(ev.Data), &chunk); err != nil {

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -1244,7 +1244,7 @@ func TestResponsesInputConversion_AssistantReasoning(t *testing.T) {
 			{
 				Role: sdk.MessageRoleAssistant,
 				Content: []sdk.MessagePart{
-					sdk.ReasoningPart{Text: "I thought carefully"},
+					sdk.ReasoningPart{Text: "I thought carefully", Format: sdk.ReasoningFormatOpenAIResponses},
 					sdk.TextPart{Text: "The answer"},
 				},
 			},

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -1166,6 +1166,86 @@ func TestResponsesDoStream_ErrorEvent(t *testing.T) {
 	}
 }
 
+func TestResponsesDoStream_ResponseFailed(t *testing.T) {
+	tests := []struct {
+		name      string
+		response  string
+		wantError string
+		wantUsage sdk.Usage
+	}{
+		{
+			name: "structured error and usage",
+			response: `{"type":"response.failed","response":{"status":"failed","error":{` +
+				`"type":"server_error","code":"server_error","message":"generation failed"},` +
+				`"usage":{"input_tokens":7,"output_tokens":2,"input_tokens_details":{"cached_tokens":3},` +
+				`"output_tokens_details":{"reasoning_tokens":1}}}}`,
+			wantError: "openai-responses: server_error: generation failed",
+			wantUsage: sdk.Usage{
+				InputTokens:       7,
+				OutputTokens:      2,
+				TotalTokens:       9,
+				ReasoningTokens:   1,
+				CachedInputTokens: 3,
+			},
+		},
+		{
+			name:      "missing error payload",
+			response:  `{"type":"response.failed","response":{"status":"failed"}}`,
+			wantError: "openai-responses: response failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				fmt.Fprintf(w, "event: response.failed\ndata: %s\n\n", tt.response)
+				w.(http.Flusher).Flush()
+			}))
+			defer srv.Close()
+
+			p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(srv.URL))
+			sr, err := p.DoStream(context.Background(), sdk.GenerateParams{
+				Model:    p.ChatModel("gpt-5.6"),
+				Messages: []sdk.Message{sdk.UserMessage("test")},
+			})
+			if err != nil {
+				t.Fatalf("DoStream: %v", err)
+			}
+
+			var (
+				errorsSeen []error
+				finish     *sdk.FinishPart
+			)
+			for part := range sr.Stream {
+				switch part := part.(type) {
+				case *sdk.ErrorPart:
+					errorsSeen = append(errorsSeen, part.Error)
+				case *sdk.FinishPart:
+					finish = part
+				}
+			}
+
+			if len(errorsSeen) != 1 {
+				t.Fatalf("ErrorPart count = %d, want 1 (%v)", len(errorsSeen), errorsSeen)
+			}
+			if got := errorsSeen[0].Error(); got != tt.wantError {
+				t.Errorf("error = %q, want %q", got, tt.wantError)
+			}
+			if finish == nil {
+				t.Fatal("expected FinishPart after response.failed")
+			}
+			if finish.TotalUsage.InputTokens != tt.wantUsage.InputTokens ||
+				finish.TotalUsage.OutputTokens != tt.wantUsage.OutputTokens ||
+				finish.TotalUsage.TotalTokens != tt.wantUsage.TotalTokens ||
+				finish.TotalUsage.ReasoningTokens != tt.wantUsage.ReasoningTokens ||
+				finish.TotalUsage.CachedInputTokens != tt.wantUsage.CachedInputTokens {
+				t.Errorf("usage = %+v, want selected fields from %+v", finish.TotalUsage, tt.wantUsage)
+			}
+		})
+	}
+}
+
 // ---------- input conversion tests ----------
 
 func TestResponsesInputConversion_SystemMessage(t *testing.T) {

--- a/provider/openai/responses/types.go
+++ b/provider/openai/responses/types.go
@@ -16,6 +16,8 @@ type responsesRequest struct {
 	ToolChoice      any                 `json:"tool_choice,omitempty"`
 	Text            *responsesTextFmt   `json:"text,omitempty"`
 	Reasoning       *responsesReasoning `json:"reasoning,omitempty"`
+	Include         []string            `json:"include,omitempty"`
+	Store           *bool               `json:"store,omitempty"`
 	Stream          bool                `json:"stream,omitempty"`
 }
 
@@ -90,7 +92,10 @@ type responsesReasoningSummaryText struct {
 }
 
 type responsesReasoningItem struct {
-	Type             string                          `json:"type"`
+	Type string `json:"type"`
+	// ID is schema-required by the API and must be the id the item was issued
+	// under.
+	ID               string                          `json:"id,omitempty"`
 	Summary          []responsesReasoningSummaryText `json:"summary"`
 	EncryptedContent string                          `json:"encrypted_content,omitempty"`
 }

--- a/provider/openai/responses/types.go
+++ b/provider/openai/responses/types.go
@@ -208,6 +208,9 @@ type responsesOutputItemDoneChunk struct {
 		CallID    string `json:"call_id,omitempty"`
 		Name      string `json:"name,omitempty"`
 		Arguments string `json:"arguments,omitempty"`
+		// reasoning fields. encrypted_content is populated only on this event,
+		// not on output_item.added, where the item has just been created.
+		EncryptedContent string `json:"encrypted_content,omitempty"`
 	} `json:"item"`
 }
 

--- a/provider/openai/responses/types.go
+++ b/provider/openai/responses/types.go
@@ -251,6 +251,15 @@ type responsesCompletedChunk struct {
 	} `json:"response"`
 }
 
+// responsesFailedChunk is sent for event: response.failed.
+type responsesFailedChunk struct {
+	Type     string `json:"type"`
+	Response struct {
+		Error *responsesError `json:"error,omitempty"`
+		Usage *responsesUsage `json:"usage,omitempty"`
+	} `json:"response"`
+}
+
 // responsesErrorChunk is sent for event: error
 type responsesErrorChunk struct {
 	Type  string `json:"type"`

--- a/sdk/generate.go
+++ b/sdk/generate.go
@@ -53,8 +53,11 @@ type GenerateParams struct {
 
 // StepResult represents the outcome of a single step (one LLM call + tool execution round).
 type StepResult struct {
-	Text                 string              `json:"text"`
+	Text string `json:"text"`
+	// Reasoning is the parts' text joined for display; ReasoningParts is the
+	// round-trip value. See GenerateResult.
 	Reasoning            string              `json:"reasoning,omitempty"`
+	ReasoningParts       []ReasoningPart     `json:"reasoningParts,omitempty"`
 	FinishReason         FinishReason        `json:"finishReason"`
 	RawFinishReason      string              `json:"rawFinishReason,omitempty"`
 	Usage                Usage               `json:"usage"`
@@ -68,18 +71,22 @@ type StepResult struct {
 }
 
 type GenerateResult struct {
-	Text                      string              `json:"text"`
-	Reasoning                 string              `json:"reasoning,omitempty"`
-	ReasoningProviderMetadata map[string]any      `json:"-"`
-	FinishReason              FinishReason        `json:"finishReason"`
-	RawFinishReason           string              `json:"rawFinishReason,omitempty"`
-	Usage                     Usage               `json:"usage"`
-	Sources                   []Source            `json:"sources,omitempty"`
-	Files                     []GeneratedFile     `json:"files,omitempty"`
-	ToolCalls                 []ToolCall          `json:"toolCalls,omitempty"`
-	ToolResults               []ToolResult        `json:"toolResults,omitempty"`
-	Response                  ResponseMetadata    `json:"response,omitempty"`
-	DeferredToolApproval      *ToolApprovalResult `json:"deferredToolApproval,omitempty"`
+	Text string `json:"text"`
+	// Reasoning is the parts' text joined for display. It is a view: rebuild
+	// requests from ReasoningParts, which keeps the per-block opaque tokens.
+	Reasoning string `json:"reasoning,omitempty"`
+	// ReasoningParts holds the reasoning blocks in provider order, each with
+	// its own dialect and opaque token. This is the round-trip value.
+	ReasoningParts       []ReasoningPart     `json:"reasoningParts,omitempty"`
+	FinishReason         FinishReason        `json:"finishReason"`
+	RawFinishReason      string              `json:"rawFinishReason,omitempty"`
+	Usage                Usage               `json:"usage"`
+	Sources              []Source            `json:"sources,omitempty"`
+	Files                []GeneratedFile     `json:"files,omitempty"`
+	ToolCalls            []ToolCall          `json:"toolCalls,omitempty"`
+	ToolResults          []ToolResult        `json:"toolResults,omitempty"`
+	Response             ResponseMetadata    `json:"response,omitempty"`
+	DeferredToolApproval *ToolApprovalResult `json:"deferredToolApproval,omitempty"`
 	// Steps holds the result of each step in a multi-step execution.
 	Steps []StepResult `json:"steps,omitempty"`
 	// Messages holds all output messages across all steps (assistant + tool),

--- a/sdk/generate.go
+++ b/sdk/generate.go
@@ -81,7 +81,12 @@ type GenerateResult struct {
 	Reasoning string `json:"reasoning,omitempty"`
 	// ReasoningParts holds the reasoning blocks in provider order, each with
 	// its own dialect and opaque token. This is the round-trip value.
-	ReasoningParts       []ReasoningPart     `json:"reasoningParts,omitempty"`
+	ReasoningParts []ReasoningPart `json:"reasoningParts,omitempty"`
+	// TextProviderMetadata carries an opaque token bound to the answer text.
+	// Google attaches a thought signature to an ordinary part when a response
+	// makes no function call — at most one per step, which is why this is a
+	// single slot rather than a list.
+	TextProviderMetadata map[string]any      `json:"-"`
 	FinishReason         FinishReason        `json:"finishReason"`
 	RawFinishReason      string              `json:"rawFinishReason,omitempty"`
 	Usage                Usage               `json:"usage"`

--- a/sdk/generate_text.go
+++ b/sdk/generate_text.go
@@ -27,10 +27,11 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 		if err != nil {
 			return nil, err
 		}
-		stepMsgs := buildStepMessages(result.Text, result.Reasoning, result.ReasoningProviderMetadata, result.ToolCalls, nil, &result.Usage)
+		stepMsgs := buildStepMessages(result.Text, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
 		step := StepResult{
 			Text:            result.Text,
 			Reasoning:       result.Reasoning,
+			ReasoningParts:  result.ReasoningParts,
 			FinishReason:    result.FinishReason,
 			RawFinishReason: result.RawFinishReason,
 			Usage:           result.Usage,
@@ -78,7 +79,7 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 
 		// No tool calls or not a tool-calls finish → final step
 		if result.FinishReason != FinishReasonToolCalls || len(result.ToolCalls) == 0 || !hasExecutableTools(result.ToolCalls, toolMap) {
-			stepMsgs := buildStepMessages(result.Text, result.Reasoning, result.ReasoningProviderMetadata, result.ToolCalls, nil, &result.Usage)
+			stepMsgs := buildStepMessages(result.Text, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
 			sr := StepResult{
 				Text:            result.Text,
 				Reasoning:       result.Reasoning,
@@ -103,10 +104,11 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 		if err != nil {
 			var deferred *ToolApprovalDeferredError
 			if errors.As(err, &deferred) {
-				stepMsgs := buildStepMessages(result.Text, result.Reasoning, result.ReasoningProviderMetadata, result.ToolCalls, nil, &result.Usage)
+				stepMsgs := buildStepMessages(result.Text, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
 				sr := StepResult{
 					Text:                 result.Text,
 					Reasoning:            result.Reasoning,
+					ReasoningParts:       result.ReasoningParts,
 					FinishReason:         result.FinishReason,
 					RawFinishReason:      result.RawFinishReason,
 					Usage:                result.Usage,
@@ -127,10 +129,11 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 			return nil, err
 		}
 
-		stepMsgs := buildStepMessages(result.Text, result.Reasoning, result.ReasoningProviderMetadata, result.ToolCalls, toolResults, &result.Usage)
+		stepMsgs := buildStepMessages(result.Text, result.ReasoningParts, result.ToolCalls, toolResults, &result.Usage)
 		sr := StepResult{
 			Text:            result.Text,
 			Reasoning:       result.Reasoning,
+			ReasoningParts:  result.ReasoningParts,
 			FinishReason:    result.FinishReason,
 			RawFinishReason: result.RawFinishReason,
 			Usage:           result.Usage,

--- a/sdk/generate_text.go
+++ b/sdk/generate_text.go
@@ -27,7 +27,7 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 		if err != nil {
 			return nil, err
 		}
-		stepMsgs := buildStepMessages(result.Text, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
+		stepMsgs := buildStepMessages(result.Text, result.TextProviderMetadata, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
 		step := StepResult{
 			Text:            result.Text,
 			Reasoning:       result.Reasoning,
@@ -79,7 +79,7 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 
 		// No tool calls or not a tool-calls finish → final step
 		if result.FinishReason != FinishReasonToolCalls || len(result.ToolCalls) == 0 || !hasExecutableTools(result.ToolCalls, toolMap) {
-			stepMsgs := buildStepMessages(result.Text, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
+			stepMsgs := buildStepMessages(result.Text, result.TextProviderMetadata, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
 			sr := StepResult{
 				Text:            result.Text,
 				Reasoning:       result.Reasoning,
@@ -105,7 +105,7 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 		if err != nil {
 			var deferred *ToolApprovalDeferredError
 			if errors.As(err, &deferred) {
-				stepMsgs := buildStepMessages(result.Text, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
+				stepMsgs := buildStepMessages(result.Text, result.TextProviderMetadata, result.ReasoningParts, result.ToolCalls, nil, &result.Usage)
 				sr := StepResult{
 					Text:                 result.Text,
 					Reasoning:            result.Reasoning,
@@ -130,7 +130,7 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 			return nil, err
 		}
 
-		stepMsgs := buildStepMessages(result.Text, result.ReasoningParts, result.ToolCalls, toolResults, &result.Usage)
+		stepMsgs := buildStepMessages(result.Text, result.TextProviderMetadata, result.ReasoningParts, result.ToolCalls, toolResults, &result.Usage)
 		sr := StepResult{
 			Text:            result.Text,
 			Reasoning:       result.Reasoning,

--- a/sdk/generate_text.go
+++ b/sdk/generate_text.go
@@ -83,6 +83,7 @@ func (c *Client) GenerateTextResult(ctx context.Context, options ...GenerateOpti
 			sr := StepResult{
 				Text:            result.Text,
 				Reasoning:       result.Reasoning,
+				ReasoningParts:  result.ReasoningParts,
 				FinishReason:    result.FinishReason,
 				RawFinishReason: result.RawFinishReason,
 				Usage:           result.Usage,

--- a/sdk/malformed_tool_args_test.go
+++ b/sdk/malformed_tool_args_test.go
@@ -1,0 +1,93 @@
+package sdk_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	anthropicmessages "github.com/memohai/twilight-ai/provider/anthropic/messages"
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// A tool call whose streamed arguments fail to parse must not run. Emitting it
+// with nil input hands the tool empty arguments and executes it anyway — with
+// whatever side effects that implies — and then commits the step as if nothing
+// were wrong, leaving an error event and a completed call for the same block.
+func TestMalformedToolArgsDoNotExecute(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, chunk := range []string{
+			`event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","model":"claude-opus-5","usage":{"input_tokens":5,"output_tokens":0}}}`,
+			`event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"delete_file"}}`,
+			`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\": \"/etc"}}`,
+			`event: content_block_stop
+data: {"type":"content_block_stop","index":0}`,
+			`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":10}}`,
+			`event: message_stop
+data: {"type":"message_stop"}`,
+		} {
+			fmt.Fprintf(w, "%s\n\n", chunk)
+		}
+		w.(http.Flusher).Flush()
+	}))
+	defer srv.Close()
+
+	executed := false
+	committed := 0
+	provider := anthropicmessages.New(
+		anthropicmessages.WithAPIKey("k"),
+		anthropicmessages.WithBaseURL(srv.URL),
+	)
+	client := sdk.NewClient()
+
+	result, err := client.StreamText(context.Background(),
+		sdk.WithModel(provider.ChatModel("claude-opus-5")),
+		sdk.WithMessages([]sdk.Message{sdk.UserMessage("delete something")}),
+		sdk.WithTools([]sdk.Tool{{
+			Name:        "delete_file",
+			Description: "deletes a file",
+			Parameters:  map[string]any{"type": "object"},
+			Execute: func(ctx *sdk.ToolExecContext, input any) (any, error) {
+				executed = true
+				return "deleted", nil
+			},
+		}}),
+		sdk.WithOnStepCommitted(func(ctx context.Context, stepIndex int, step *sdk.StepResult) error {
+			committed++
+			return nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("StreamText: %v", err)
+	}
+
+	var sawError bool
+	var calls int
+	for part := range result.Stream {
+		switch part.(type) {
+		case *sdk.ErrorPart:
+			sawError = true
+		case *sdk.StreamToolCallPart:
+			calls++
+		}
+	}
+
+	if !sawError {
+		t.Error("no ErrorPart for malformed tool arguments")
+	}
+	if calls != 0 {
+		t.Errorf("StreamToolCallPart emitted %d time(s) for a call that could not be parsed", calls)
+	}
+	if executed {
+		t.Error("the tool ran on nil input")
+	}
+	if committed != 0 {
+		t.Errorf("OnStepCommitted fired %d time(s) for a failed step", committed)
+	}
+}

--- a/sdk/message.go
+++ b/sdk/message.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 type MessageRole string
@@ -76,12 +77,192 @@ func (p TextPart) PartType() MessagePartType { return MessagePartTypeText }
 
 // --- Reasoning ---
 
+// ReasoningFormat identifies the wire dialect of a reasoning part.
+//
+// It describes what a part looks like and how to send it back, not who
+// produced it: the same dialect reaches us from a direct endpoint, Bedrock,
+// Vertex or any compatible gateway, and comparing provider names would treat
+// those as foreign. An empty format means the dialect is unknown — such a part
+// is never replayed, because no provider can verify a token it did not issue.
+type ReasoningFormat string
+
+const (
+	ReasoningFormatUnknown ReasoningFormat = ""
+	// ReasoningFormatAnthropic is the Anthropic Messages thinking dialect:
+	// thinking blocks with a per-block signature, plus redacted_thinking.
+	ReasoningFormatAnthropic ReasoningFormat = "anthropic-v1"
+	// ReasoningFormatOpenAIResponses is the OpenAI Responses reasoning-item
+	// dialect. It covers the Codex backend too: that is the same API behind a
+	// different base URL, and it produces byte-identical reasoning items.
+	ReasoningFormatOpenAIResponses ReasoningFormat = "openai-responses-v1"
+	// ReasoningFormatGoogle is the Gemini generateContent dialect: a thought
+	// signature bound to the exact part it arrived on.
+	ReasoningFormatGoogle ReasoningFormat = "google-v1"
+	// ReasoningFormatCopilot is the GitHub Copilot dialect, which wraps each
+	// upstream model's own token in a single reasoning_opaque per response.
+	ReasoningFormatCopilot ReasoningFormat = "copilot-v1"
+	// ReasoningFormatOpenAIChat is the Chat Completions reasoning dialect used
+	// by DeepSeek and MiniMax. It carries no opaque token: replaying it affects
+	// answer quality, never request validity.
+	ReasoningFormatOpenAIChat ReasoningFormat = "openai-chat-v1"
+)
+
+// ReasoningPart carries one block of reasoning produced by the model.
+//
+// A model may emit several blocks in a single assistant turn (Anthropic
+// interleaves thinking with tool calls; OpenAI splits a reasoning item into
+// several summary parts). Each block is its own ReasoningPart, kept in the
+// order the provider emitted it: providers treat a block as an opaque,
+// indivisible round-trip unit and reject a modified sequence, so blocks must
+// never be merged, reordered, or dropped.
+//
+// Text may be empty while ProviderMetadata is not — Anthropic's
+// redacted_thinking blocks carry only an encrypted blob, and Google may attach
+// a thought signature to a part with no text. Such a part still has to be
+// replayed, so emptiness is never a reason to skip it.
+//
+// The opaque token stays in ProviderMetadata under the provider's own key
+// rather than becoming a field here: a signature means different things to
+// each provider (Anthropic verifies one per block, OpenAI pairs encrypted
+// content with an item id, Google signs a specific part), and promoting it
+// would imply a shared meaning that does not exist.
 type ReasoningPart struct {
-	Text             string         `json:"text"`
+	// ID is the provider's own identity for this block, such as an OpenAI
+	// rs_… item id. Providers without a block identity leave it empty.
+	ID string `json:"id,omitempty"`
+
+	Text string `json:"text"`
+
+	// Format is the wire dialect this block belongs to. Replay it only to a
+	// provider that speaks the same dialect.
+	Format ReasoningFormat `json:"format,omitempty"`
+
 	ProviderMetadata map[string]any `json:"providerMetadata,omitempty"`
 }
 
 func (p ReasoningPart) PartType() MessagePartType { return MessagePartTypeReasoning }
+
+// ReasoningText joins the parts' text for display. The result is a view, not a
+// round-trip value: it drops the block boundaries and opaque tokens providers
+// require, so never rebuild a request from it.
+func ReasoningText(parts []ReasoningPart) string {
+	var sb strings.Builder
+	for i := range parts {
+		sb.WriteString(parts[i].Text)
+	}
+	return sb.String()
+}
+
+// ReasoningMetadata builds a provider-namespaced metadata bag, skipping empty
+// values. It returns nil when nothing is left, so callers can tell "no token"
+// from "empty token".
+func ReasoningMetadata(namespace string, kv map[string]string) map[string]any {
+	inner := make(map[string]any, len(kv))
+	for key, value := range kv {
+		if value != "" {
+			inner[key] = value
+		}
+	}
+	if len(inner) == 0 {
+		return nil
+	}
+	return map[string]any{namespace: inner}
+}
+
+// ReasoningMetadataString reads one string value out of a provider's namespace.
+func ReasoningMetadataString(meta map[string]any, namespace, key string) string {
+	if meta == nil {
+		return ""
+	}
+	inner, ok := meta[namespace].(map[string]any)
+	if !ok {
+		return ""
+	}
+	value, _ := inner[key].(string)
+	return value
+}
+
+// reasoningAccumulator folds a reasoning part stream into ordered parts.
+//
+// Providers delimit blocks with ReasoningStartPart/ReasoningEndPart and carry
+// the block identity on every part, so deltas are matched to their block by ID.
+// Text deltas concatenate; metadata replaces, because a provider sends the
+// opaque token once as a whole at the end of a block (Anthropic's
+// signature_delta is a complete signature, not an increment) and a later part
+// carries the authoritative value.
+type reasoningAccumulator struct {
+	parts []ReasoningPart
+	byID  map[string]int
+}
+
+// openBlock starts a block, or returns the existing one when a provider
+// re-announces the same ID.
+func (a *reasoningAccumulator) openBlock(id string, format ReasoningFormat, meta map[string]any) int {
+	if idx, ok := a.index(id); ok {
+		a.merge(idx, format, meta)
+		return idx
+	}
+	a.parts = append(a.parts, ReasoningPart{ID: id, Format: format, ProviderMetadata: meta})
+	idx := len(a.parts) - 1
+	if id != "" {
+		if a.byID == nil {
+			a.byID = make(map[string]int)
+		}
+		a.byID[id] = idx
+	}
+	return idx
+}
+
+// index finds the block a part belongs to. An unidentified part joins the most
+// recent block, which is what providers that omit block IDs imply.
+func (a *reasoningAccumulator) index(id string) (int, bool) {
+	if id != "" {
+		idx, ok := a.byID[id]
+		return idx, ok
+	}
+	if len(a.parts) == 0 {
+		return 0, false
+	}
+	return len(a.parts) - 1, true
+}
+
+func (a *reasoningAccumulator) merge(idx int, format ReasoningFormat, meta map[string]any) {
+	if format != ReasoningFormatUnknown {
+		a.parts[idx].Format = format
+	}
+	if len(meta) == 0 {
+		return
+	}
+	if a.parts[idx].ProviderMetadata == nil {
+		a.parts[idx].ProviderMetadata = make(map[string]any, len(meta))
+	}
+	for key, value := range meta {
+		a.parts[idx].ProviderMetadata[key] = value
+	}
+}
+
+func (a *reasoningAccumulator) appendDelta(id, text string, format ReasoningFormat, meta map[string]any) {
+	idx, ok := a.index(id)
+	if !ok {
+		idx = a.openBlock(id, format, nil)
+	}
+	a.parts[idx].Text += text
+	a.merge(idx, format, meta)
+}
+
+// closeBlock attaches the block's final metadata, which is where providers
+// deliver the opaque token.
+func (a *reasoningAccumulator) closeBlock(id string, format ReasoningFormat, meta map[string]any) {
+	idx, ok := a.index(id)
+	if !ok {
+		idx = a.openBlock(id, format, nil)
+	}
+	a.merge(idx, format, meta)
+}
+
+func (a *reasoningAccumulator) result() []ReasoningPart {
+	return a.parts
+}
 
 // --- Image ---
 

--- a/sdk/message.go
+++ b/sdk/message.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -137,6 +138,16 @@ type ReasoningPart struct {
 	// provider that speaks the same dialect.
 	Format ReasoningFormat `json:"format,omitempty"`
 
+	// Model names the model that produced this block, as the provider reported
+	// it in the response. Opaque tokens are verified by the model that issued
+	// them: replaying a block to a different model of the same dialect is a
+	// 400, not a silent no-op. Comparison is by normalized family and version
+	// rather than raw equality, since the same model reaches us under several
+	// spellings (claude-sonnet-5, anthropic/claude-sonnet-5,
+	// us.anthropic.claude-sonnet-5-v1:0) and its signatures are portable
+	// across those endpoints.
+	Model string `json:"model,omitempty"`
+
 	ProviderMetadata map[string]any `json:"providerMetadata,omitempty"`
 }
 
@@ -151,6 +162,46 @@ func ReasoningText(parts []ReasoningPart) string {
 		sb.WriteString(parts[i].Text)
 	}
 	return sb.String()
+}
+
+// SameReasoningModel reports whether two model identifiers name the same
+// model for reasoning-replay purposes. Exact strings match trivially; beyond
+// that both ids are reduced to a normalized Claude family+version, which
+// tolerates gateway and Bedrock spellings of one model while still separating
+// models whose tokens cannot verify each other. Unparseable pairs do not
+// match: replaying a token to the wrong model is a hard 400, while dropping a
+// block loses at most one turn of thinking context, so uncertainty resolves
+// toward dropping.
+func SameReasoningModel(a, b string) bool {
+	a, b = strings.ToLower(strings.TrimSpace(a)), strings.ToLower(strings.TrimSpace(b))
+	if a == "" || b == "" {
+		// A missing producer means provenance was lost (or predates this
+		// field); a missing target means the caller has nothing to compare
+		// against. Neither can establish a mismatch.
+		return true
+	}
+	if a == b {
+		return true
+	}
+	fa, oka := claudeFamilyVersion(a)
+	fb, okb := claudeFamilyVersion(b)
+	return oka && okb && fa == fb
+}
+
+// claudeReasoningIdentity extracts "family-major.minor" from a Claude model id
+// in any of its spellings, reporting false for anything it cannot read.
+var claudeIdentityPattern = regexp.MustCompile(`claude-([a-z]+)-(\d+)(?:[.-](\d{1,2}))?(?:[.:@-]|$)`)
+
+func claudeFamilyVersion(id string) (string, bool) {
+	match := claudeIdentityPattern.FindStringSubmatch(id)
+	if match == nil {
+		return "", false
+	}
+	minor := match[3]
+	if minor == "" {
+		minor = "0"
+	}
+	return match[1] + "-" + match[2] + "." + minor, true
 }
 
 // ReasoningMetadata builds a provider-namespaced metadata bag, skipping empty
@@ -197,12 +248,12 @@ type reasoningAccumulator struct {
 
 // openBlock starts a block, or returns the existing one when a provider
 // re-announces the same ID.
-func (a *reasoningAccumulator) openBlock(id string, format ReasoningFormat, meta map[string]any) int {
+func (a *reasoningAccumulator) openBlock(id string, format ReasoningFormat, model string, meta map[string]any) int {
 	if idx, ok := a.index(id); ok {
-		a.merge(idx, format, meta)
+		a.merge(idx, format, model, meta)
 		return idx
 	}
-	a.parts = append(a.parts, ReasoningPart{ID: id, Format: format, ProviderMetadata: meta})
+	a.parts = append(a.parts, ReasoningPart{ID: id, Format: format, Model: model, ProviderMetadata: meta})
 	idx := len(a.parts) - 1
 	if id != "" {
 		if a.byID == nil {
@@ -226,9 +277,12 @@ func (a *reasoningAccumulator) index(id string) (int, bool) {
 	return len(a.parts) - 1, true
 }
 
-func (a *reasoningAccumulator) merge(idx int, format ReasoningFormat, meta map[string]any) {
+func (a *reasoningAccumulator) merge(idx int, format ReasoningFormat, model string, meta map[string]any) {
 	if format != ReasoningFormatUnknown {
 		a.parts[idx].Format = format
+	}
+	if model != "" {
+		a.parts[idx].Model = model
 	}
 	if len(meta) == 0 {
 		return
@@ -241,23 +295,23 @@ func (a *reasoningAccumulator) merge(idx int, format ReasoningFormat, meta map[s
 	}
 }
 
-func (a *reasoningAccumulator) appendDelta(id, text string, format ReasoningFormat, meta map[string]any) {
+func (a *reasoningAccumulator) appendDelta(id, text string, format ReasoningFormat, model string, meta map[string]any) {
 	idx, ok := a.index(id)
 	if !ok {
-		idx = a.openBlock(id, format, nil)
+		idx = a.openBlock(id, format, model, nil)
 	}
 	a.parts[idx].Text += text
-	a.merge(idx, format, meta)
+	a.merge(idx, format, model, meta)
 }
 
 // closeBlock attaches the block's final metadata, which is where providers
 // deliver the opaque token.
-func (a *reasoningAccumulator) closeBlock(id string, format ReasoningFormat, meta map[string]any) {
+func (a *reasoningAccumulator) closeBlock(id string, format ReasoningFormat, model string, meta map[string]any) {
 	idx, ok := a.index(id)
 	if !ok {
-		idx = a.openBlock(id, format, nil)
+		idx = a.openBlock(id, format, model, nil)
 	}
-	a.merge(idx, format, meta)
+	a.merge(idx, format, model, meta)
 }
 
 func (a *reasoningAccumulator) result() []ReasoningPart {

--- a/sdk/reasoning_dialect_test.go
+++ b/sdk/reasoning_dialect_test.go
@@ -43,7 +43,7 @@ func TestEveryProviderStampsItsReasoningDialect(t *testing.T) {
 		},
 		{
 			name: "openai-responses",
-			response: `{"id":"resp_1","status":"completed","output":[
+			response: `{"id":"resp_1","status":"completed","model":"gpt-5.6","output":[
 				{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"t"}],"encrypted_content":"EC"}],
 				"usage":{"input_tokens":1,"output_tokens":1}}`,
 			want: sdk.ReasoningFormatOpenAIResponses,
@@ -59,7 +59,7 @@ func TestEveryProviderStampsItsReasoningDialect(t *testing.T) {
 			name: "google",
 			response: `{"candidates":[{"content":{"parts":[
 				{"text":"t","thought":true,"thoughtSignature":"SIG"},{"text":"a"}]},"finishReason":"STOP"}],
-				"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1}}`,
+				"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1},"modelVersion":"gemini-3-pro"}`,
 			want: sdk.ReasoningFormatGoogle,
 			generate: func(t *testing.T, baseURL string) (*sdk.GenerateResult, error) {
 				p := googlegenerative.New(googlegenerative.WithAPIKey("k"), googlegenerative.WithBaseURL(baseURL))
@@ -117,6 +117,12 @@ func TestEveryProviderStampsItsReasoningDialect(t *testing.T) {
 			for i, part := range result.ReasoningParts {
 				if part.Format != tc.want {
 					t.Errorf("part %d format: got %q, want %q", i, part.Format, tc.want)
+				}
+				// The producing model must be stamped too: replay guards
+				// compare it against the target model, and a missing stamp
+				// silently disables that check.
+				if part.Model == "" {
+					t.Errorf("part %d has no producing model", i)
 				}
 			}
 		})

--- a/sdk/reasoning_dialect_test.go
+++ b/sdk/reasoning_dialect_test.go
@@ -1,0 +1,182 @@
+package sdk_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	anthropicmessages "github.com/memohai/twilight-ai/provider/anthropic/messages"
+	"github.com/memohai/twilight-ai/provider/github/copilot"
+	googlegenerative "github.com/memohai/twilight-ai/provider/google/generativeai"
+	"github.com/memohai/twilight-ai/provider/openai/completions"
+	"github.com/memohai/twilight-ai/provider/openai/responses"
+	sdk "github.com/memohai/twilight-ai/sdk"
+)
+
+// A reasoning part with no dialect is never replayed, so a provider that
+// forgets to stamp Format silently stops sending reasoning back — it compiles,
+// and every other test still passes. This walks each provider's parse path with
+// a canned response and asserts the dialect actually arrives.
+func TestEveryProviderStampsItsReasoningDialect(t *testing.T) {
+	cases := []struct {
+		name     string
+		response string
+		want     sdk.ReasoningFormat
+		generate func(t *testing.T, baseURL string) (*sdk.GenerateResult, error)
+	}{
+		{
+			name: "anthropic",
+			response: `{"id":"msg_1","type":"message","model":"claude-opus-5","role":"assistant",
+				"content":[{"type":"thinking","thinking":"t","signature":"SIG"},{"type":"text","text":"a"}],
+				"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`,
+			want: sdk.ReasoningFormatAnthropic,
+			generate: func(t *testing.T, baseURL string) (*sdk.GenerateResult, error) {
+				p := anthropicmessages.New(anthropicmessages.WithAPIKey("k"), anthropicmessages.WithBaseURL(baseURL))
+				return p.DoGenerate(context.Background(), sdk.GenerateParams{
+					Model:    &sdk.Model{ID: "claude-opus-5"},
+					Messages: []sdk.Message{sdk.UserMessage("hi")},
+				})
+			},
+		},
+		{
+			name: "openai-responses",
+			response: `{"id":"resp_1","status":"completed","output":[
+				{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"t"}],"encrypted_content":"EC"}],
+				"usage":{"input_tokens":1,"output_tokens":1}}`,
+			want: sdk.ReasoningFormatOpenAIResponses,
+			generate: func(t *testing.T, baseURL string) (*sdk.GenerateResult, error) {
+				p := responses.New(responses.WithAPIKey("k"), responses.WithBaseURL(baseURL))
+				return p.DoGenerate(context.Background(), sdk.GenerateParams{
+					Model:    p.ChatModel("gpt-5.6"),
+					Messages: []sdk.Message{sdk.UserMessage("hi")},
+				})
+			},
+		},
+		{
+			name: "google",
+			response: `{"candidates":[{"content":{"parts":[
+				{"text":"t","thought":true,"thoughtSignature":"SIG"},{"text":"a"}]},"finishReason":"STOP"}],
+				"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1}}`,
+			want: sdk.ReasoningFormatGoogle,
+			generate: func(t *testing.T, baseURL string) (*sdk.GenerateResult, error) {
+				p := googlegenerative.New(googlegenerative.WithAPIKey("k"), googlegenerative.WithBaseURL(baseURL))
+				return p.DoGenerate(context.Background(), sdk.GenerateParams{
+					Model:    &sdk.Model{ID: "gemini-3-pro"},
+					Messages: []sdk.Message{sdk.UserMessage("hi")},
+				})
+			},
+		},
+		{
+			name: "copilot",
+			response: `{"id":"c1","model":"m","created":1,"choices":[{"index":0,
+				"message":{"role":"assistant","content":"a","reasoning_text":"t","reasoning_opaque":"OP"},
+				"finish_reason":"stop"}]}`,
+			want: sdk.ReasoningFormatCopilot,
+			generate: func(t *testing.T, baseURL string) (*sdk.GenerateResult, error) {
+				p := copilot.New(copilot.WithAPIKey("k"), copilot.WithBaseURL(baseURL))
+				return p.DoGenerate(context.Background(), sdk.GenerateParams{
+					Model:    &sdk.Model{ID: "m"},
+					Messages: []sdk.Message{sdk.UserMessage("hi")},
+				})
+			},
+		},
+		{
+			name: "openai-chat",
+			response: `{"id":"c1","model":"deepseek-reasoner","created":1,"choices":[{"index":0,
+				"message":{"role":"assistant","content":"a","reasoning_content":"t"},
+				"finish_reason":"stop"}]}`,
+			want: sdk.ReasoningFormatOpenAIChat,
+			generate: func(t *testing.T, baseURL string) (*sdk.GenerateResult, error) {
+				p := completions.New(completions.WithAPIKey("k"), completions.WithBaseURL(baseURL))
+				return p.DoGenerate(context.Background(), sdk.GenerateParams{
+					Model:    &sdk.Model{ID: "deepseek-reasoner"},
+					Messages: []sdk.Message{sdk.UserMessage("hi")},
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tc.response)
+			}))
+			defer srv.Close()
+
+			result, err := tc.generate(t, srv.URL)
+			if err != nil {
+				t.Fatalf("DoGenerate: %v", err)
+			}
+			if len(result.ReasoningParts) == 0 {
+				t.Fatalf("no reasoning parts produced")
+			}
+			for i, part := range result.ReasoningParts {
+				if part.Format != tc.want {
+					t.Errorf("part %d format: got %q, want %q", i, part.Format, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// Every dialect constant must be distinct, or a replay check would accept a
+// foreign block.
+func TestReasoningFormatsAreDistinct(t *testing.T) {
+	formats := []sdk.ReasoningFormat{
+		sdk.ReasoningFormatAnthropic,
+		sdk.ReasoningFormatOpenAIResponses,
+		sdk.ReasoningFormatGoogle,
+		sdk.ReasoningFormatCopilot,
+		sdk.ReasoningFormatOpenAIChat,
+	}
+	seen := make(map[sdk.ReasoningFormat]bool, len(formats))
+	for _, f := range formats {
+		if f == sdk.ReasoningFormatUnknown {
+			t.Errorf("a named dialect must not equal the unknown dialect")
+		}
+		if seen[f] {
+			t.Errorf("duplicate dialect value %q", f)
+		}
+		seen[f] = true
+	}
+}
+
+// The dialect survives persistence: a part stored as JSON and read back keeps
+// its Format, or every replayed conversation would look unmarked.
+func TestReasoningFormatSurvivesJSONRoundTrip(t *testing.T) {
+	original := sdk.Message{
+		Role: sdk.MessageRoleAssistant,
+		Content: []sdk.MessagePart{
+			sdk.ReasoningPart{
+				ID:               "rs_1",
+				Text:             "t",
+				Format:           sdk.ReasoningFormatOpenAIResponses,
+				ProviderMetadata: map[string]any{"openai": map[string]any{"itemId": "rs_1"}},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var restored sdk.Message
+	if err := json.Unmarshal(raw, &restored); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	part, ok := restored.Content[0].(sdk.ReasoningPart)
+	if !ok {
+		t.Fatalf("content[0] = %T, want ReasoningPart", restored.Content[0])
+	}
+	if part.Format != sdk.ReasoningFormatOpenAIResponses {
+		t.Errorf("format: got %q, want %q", part.Format, sdk.ReasoningFormatOpenAIResponses)
+	}
+	if part.ID != "rs_1" {
+		t.Errorf("id: got %q, want rs_1", part.ID)
+	}
+}

--- a/sdk/reasoning_roundtrip_test.go
+++ b/sdk/reasoning_roundtrip_test.go
@@ -1,0 +1,166 @@
+package sdk
+
+import "testing"
+
+// The provider wire protocols treat each reasoning block as an opaque,
+// indivisible round-trip unit: Anthropic rejects a modified sequence of
+// thinking blocks with a 400, and OpenAI rejects reordered reasoning items.
+// The stream carries per-block identity (ReasoningStartPart.ID), so the
+// accumulator must preserve blocks rather than flattening them into one
+// string with one metadata bag.
+
+func reasoningMeta(sig string) map[string]any {
+	return map[string]any{"anthropic": map[string]any{"signature": sig}}
+}
+
+func anthropicSignature(t *testing.T, meta map[string]any) string {
+	t.Helper()
+	am, ok := meta["anthropic"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	sig, _ := am["signature"].(string)
+	return sig
+}
+
+// Two thinking blocks, each with its own signature, as interleaved thinking
+// produces. Both signatures must survive; pairing each with its own text is
+// what makes the replay verifiable.
+func TestToResultPreservesEveryReasoningBlockSignature(t *testing.T) {
+	ch := make(chan StreamPart, 16)
+	for _, p := range []StreamPart{
+		&ReasoningStartPart{ID: "b1", Format: ReasoningFormatAnthropic},
+		&ReasoningDeltaPart{ID: "b1", Text: "AAA"},
+		&ReasoningEndPart{ID: "b1", ProviderMetadata: reasoningMeta("SIG_A")},
+		&ReasoningStartPart{ID: "b2", Format: ReasoningFormatAnthropic},
+		&ReasoningDeltaPart{ID: "b2", Text: "BBB"},
+		&ReasoningEndPart{ID: "b2", ProviderMetadata: reasoningMeta("SIG_B")},
+		&FinishPart{FinishReason: FinishReasonStop},
+	} {
+		ch <- p
+	}
+	close(ch)
+
+	result, err := (&StreamResult{Stream: ch}).ToResult()
+	if err != nil {
+		t.Fatalf("ToResult: %v", err)
+	}
+
+	if len(result.ReasoningParts) != 2 {
+		t.Fatalf("ReasoningParts: got %d, want 2 (%+v)", len(result.ReasoningParts), result.ReasoningParts)
+	}
+	for i, want := range []struct{ text, sig string }{{"AAA", "SIG_A"}, {"BBB", "SIG_B"}} {
+		block := result.ReasoningParts[i]
+		if block.Text != want.text {
+			t.Errorf("block %d text: got %q, want %q", i, block.Text, want.text)
+		}
+		if got := anthropicSignature(t, block.ProviderMetadata); got != want.sig {
+			t.Errorf("block %d signature: got %q, want %q", i, got, want.sig)
+		}
+	}
+	// The flat view stays available for display, derived from the blocks.
+	if result.Reasoning != "AAABBB" {
+		t.Errorf("Reasoning flat view: got %q, want %q", result.Reasoning, "AAABBB")
+	}
+}
+
+// A redacted thinking block carries no readable text, only an encrypted blob.
+// Anthropic requires it replayed verbatim, so an empty-text block is
+// meaningful and must not be treated as absent. rig puts it well: emptiness
+// is a property of the list, not of its members.
+func TestToResultKeepsEmptyTextReasoningBlock(t *testing.T) {
+	ch := make(chan StreamPart, 8)
+	for _, p := range []StreamPart{
+		&ReasoningStartPart{ID: "r1", Format: ReasoningFormatAnthropic},
+		&ReasoningEndPart{ID: "r1", ProviderMetadata: map[string]any{
+			"anthropic": map[string]any{"redactedData": "ENCRYPTED_BLOB"},
+		}},
+		&FinishPart{FinishReason: FinishReasonStop},
+	} {
+		ch <- p
+	}
+	close(ch)
+
+	result, err := (&StreamResult{Stream: ch}).ToResult()
+	if err != nil {
+		t.Fatalf("ToResult: %v", err)
+	}
+
+	if len(result.ReasoningParts) != 1 {
+		t.Fatalf("ReasoningParts: got %d, want 1 — empty-text block was dropped", len(result.ReasoningParts))
+	}
+	am, _ := result.ReasoningParts[0].ProviderMetadata["anthropic"].(map[string]any)
+	if data, _ := am["redactedData"].(string); data != "ENCRYPTED_BLOB" {
+		t.Errorf("redactedData: got %q, want %q", data, "ENCRYPTED_BLOB")
+	}
+}
+
+// Signatures arrive as one atomic blob at block end, never as increments.
+// Text deltas concatenate; metadata replaces.
+func TestToResultReplacesRatherThanConcatenatesBlockMetadata(t *testing.T) {
+	ch := make(chan StreamPart, 8)
+	for _, p := range []StreamPart{
+		&ReasoningStartPart{ID: "b1", Format: ReasoningFormatAnthropic, ProviderMetadata: reasoningMeta("PARTIAL")},
+		&ReasoningDeltaPart{ID: "b1", Text: "AA"},
+		&ReasoningDeltaPart{ID: "b1", Text: "BB"},
+		&ReasoningEndPart{ID: "b1", ProviderMetadata: reasoningMeta("FINAL")},
+		&FinishPart{FinishReason: FinishReasonStop},
+	} {
+		ch <- p
+	}
+	close(ch)
+
+	result, err := (&StreamResult{Stream: ch}).ToResult()
+	if err != nil {
+		t.Fatalf("ToResult: %v", err)
+	}
+
+	if len(result.ReasoningParts) != 1 {
+		t.Fatalf("ReasoningParts: got %d, want 1", len(result.ReasoningParts))
+	}
+	block := result.ReasoningParts[0]
+	if block.Text != "AABB" {
+		t.Errorf("text: got %q, want %q (deltas concatenate)", block.Text, "AABB")
+	}
+	if got := anthropicSignature(t, block.ProviderMetadata); got != "FINAL" {
+		t.Errorf("signature: got %q, want %q (metadata replaces)", got, "FINAL")
+	}
+}
+
+// Every reasoning block must reach the assistant message that gets replayed,
+// each keeping its own opaque token.
+func TestBuildStepMessagesEmitsOnePartPerReasoningBlock(t *testing.T) {
+	blocks := []ReasoningPart{
+		{Text: "AAA", ProviderMetadata: reasoningMeta("SIG_A")},
+		{Text: "", ProviderMetadata: map[string]any{
+			"anthropic": map[string]any{"redactedData": "BLOB"},
+		}},
+		{Text: "BBB", ProviderMetadata: reasoningMeta("SIG_B")},
+	}
+
+	msgs := buildStepMessages("answer", blocks, nil, nil, nil)
+	if len(msgs) == 0 {
+		t.Fatal("no messages produced")
+	}
+
+	var got []ReasoningPart
+	for _, part := range msgs[0].Content {
+		if rp, ok := part.(ReasoningPart); ok {
+			got = append(got, rp)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("reasoning parts: got %d, want 3 (empty-text block must survive)", len(got))
+	}
+	if s := anthropicSignature(t, got[0].ProviderMetadata); s != "SIG_A" {
+		t.Errorf("part 0 signature: got %q, want SIG_A", s)
+	}
+	if s := anthropicSignature(t, got[2].ProviderMetadata); s != "SIG_B" {
+		t.Errorf("part 2 signature: got %q, want SIG_B", s)
+	}
+	// Reasoning must precede the answer text: Anthropic enforces thinking-first,
+	// and OpenAI 400s on an orphaned trailing reasoning item.
+	if _, ok := msgs[0].Content[0].(ReasoningPart); !ok {
+		t.Errorf("content[0] = %T, want ReasoningPart to lead the message", msgs[0].Content[0])
+	}
+}

--- a/sdk/reasoning_roundtrip_test.go
+++ b/sdk/reasoning_roundtrip_test.go
@@ -138,7 +138,7 @@ func TestBuildStepMessagesEmitsOnePartPerReasoningBlock(t *testing.T) {
 		{Text: "BBB", ProviderMetadata: reasoningMeta("SIG_B")},
 	}
 
-	msgs := buildStepMessages("answer", blocks, nil, nil, nil)
+	msgs := buildStepMessages("answer", nil, blocks, nil, nil, nil)
 	if len(msgs) == 0 {
 		t.Fatal("no messages produced")
 	}

--- a/sdk/step_helpers.go
+++ b/sdk/step_helpers.go
@@ -53,10 +53,15 @@ func addUsage(total, step *Usage) Usage {
 // buildStepMessages creates the messages produced by a step: an assistant
 // message (text/reasoning/tool-calls) and optionally a tool message.
 // The usage is attached to the assistant message for output tracking.
-func buildStepMessages(text, reasoning string, reasoningMeta map[string]any, toolCalls []ToolCall, toolResults []ToolResultPart, usage *Usage) []Message {
+//
+// Reasoning blocks lead the message, one part each, in the order the provider
+// emitted them. Blocks are never filtered on empty text: a redacted thinking
+// block carries its payload entirely in metadata, and dropping it breaks the
+// replay the providers require.
+func buildStepMessages(text string, reasoningParts []ReasoningPart, toolCalls []ToolCall, toolResults []ToolResultPart, usage *Usage) []Message {
 	var assistantParts []MessagePart
-	if reasoning != "" {
-		assistantParts = append(assistantParts, ReasoningPart{Text: reasoning, ProviderMetadata: reasoningMeta})
+	for i := range reasoningParts {
+		assistantParts = append(assistantParts, reasoningParts[i])
 	}
 	if text != "" {
 		assistantParts = append(assistantParts, TextPart{Text: text})

--- a/sdk/step_helpers.go
+++ b/sdk/step_helpers.go
@@ -58,13 +58,13 @@ func addUsage(total, step *Usage) Usage {
 // emitted them. Blocks are never filtered on empty text: a redacted thinking
 // block carries its payload entirely in metadata, and dropping it breaks the
 // replay the providers require.
-func buildStepMessages(text string, reasoningParts []ReasoningPart, toolCalls []ToolCall, toolResults []ToolResultPart, usage *Usage) []Message {
+func buildStepMessages(text string, textMeta map[string]any, reasoningParts []ReasoningPart, toolCalls []ToolCall, toolResults []ToolResultPart, usage *Usage) []Message {
 	var assistantParts []MessagePart
 	for i := range reasoningParts {
 		assistantParts = append(assistantParts, reasoningParts[i])
 	}
 	if text != "" {
-		assistantParts = append(assistantParts, TextPart{Text: text})
+		assistantParts = append(assistantParts, TextPart{Text: text, ProviderMetadata: textMeta})
 	}
 	for _, tc := range toolCalls {
 		assistantParts = append(assistantParts, ToolCallPart{

--- a/sdk/step_helpers_test.go
+++ b/sdk/step_helpers_test.go
@@ -33,7 +33,7 @@ func TestAddUsageAccumulatesCacheWriteTTLDetails(t *testing.T) {
 
 func TestBuildStepMessagesPreservesToolCallProviderMetadata(t *testing.T) {
 	meta := map[string]any{"google": map[string]any{"thoughtSignature": "sig-1"}}
-	msgs := buildStepMessages("", "", nil, []ToolCall{{
+	msgs := buildStepMessages("", nil, []ToolCall{{
 		ToolCallID:       "call-1",
 		ToolName:         "lookup",
 		Input:            map[string]any{"q": "memoh"},

--- a/sdk/step_helpers_test.go
+++ b/sdk/step_helpers_test.go
@@ -33,7 +33,7 @@ func TestAddUsageAccumulatesCacheWriteTTLDetails(t *testing.T) {
 
 func TestBuildStepMessagesPreservesToolCallProviderMetadata(t *testing.T) {
 	meta := map[string]any{"google": map[string]any{"thoughtSignature": "sig-1"}}
-	msgs := buildStepMessages("", nil, []ToolCall{{
+	msgs := buildStepMessages("", nil, nil, []ToolCall{{
 		ToolCallID:       "call-1",
 		ToolName:         "lookup",
 		Input:            map[string]any{"q": "memoh"},

--- a/sdk/stream.go
+++ b/sdk/stream.go
@@ -63,6 +63,7 @@ func (p *TextEndPart) Type() StreamPartType { return StreamPartTypeTextEnd }
 
 type ReasoningStartPart struct {
 	ID               string
+	Model            string
 	Format           ReasoningFormat
 	ProviderMetadata map[string]any
 }
@@ -71,6 +72,7 @@ func (p *ReasoningStartPart) Type() StreamPartType { return StreamPartTypeReason
 
 type ReasoningDeltaPart struct {
 	ID               string
+	Model            string
 	Text             string
 	Format           ReasoningFormat
 	ProviderMetadata map[string]any
@@ -80,6 +82,7 @@ func (p *ReasoningDeltaPart) Type() StreamPartType { return StreamPartTypeReason
 
 type ReasoningEndPart struct {
 	ID               string
+	Model            string
 	Format           ReasoningFormat
 	ProviderMetadata map[string]any
 }
@@ -264,12 +267,16 @@ func (sr *StreamResult) ToResult() (*GenerateResult, error) {
 		switch p := part.(type) {
 		case *TextDeltaPart:
 			result.Text += p.Text
+		case *TextEndPart:
+			if p.ProviderMetadata != nil {
+				result.TextProviderMetadata = p.ProviderMetadata
+			}
 		case *ReasoningStartPart:
-			reasoning.openBlock(p.ID, p.Format, p.ProviderMetadata)
+			reasoning.openBlock(p.ID, p.Format, p.Model, p.ProviderMetadata)
 		case *ReasoningDeltaPart:
-			reasoning.appendDelta(p.ID, p.Text, p.Format, p.ProviderMetadata)
+			reasoning.appendDelta(p.ID, p.Text, p.Format, p.Model, p.ProviderMetadata)
 		case *ReasoningEndPart:
-			reasoning.closeBlock(p.ID, p.Format, p.ProviderMetadata)
+			reasoning.closeBlock(p.ID, p.Format, p.Model, p.ProviderMetadata)
 		case *StreamToolCallPart:
 			result.ToolCalls = append(result.ToolCalls, ToolCall{
 				ToolCallID:       p.ToolCallID,

--- a/sdk/stream.go
+++ b/sdk/stream.go
@@ -63,6 +63,7 @@ func (p *TextEndPart) Type() StreamPartType { return StreamPartTypeTextEnd }
 
 type ReasoningStartPart struct {
 	ID               string
+	Format           ReasoningFormat
 	ProviderMetadata map[string]any
 }
 
@@ -71,6 +72,7 @@ func (p *ReasoningStartPart) Type() StreamPartType { return StreamPartTypeReason
 type ReasoningDeltaPart struct {
 	ID               string
 	Text             string
+	Format           ReasoningFormat
 	ProviderMetadata map[string]any
 }
 
@@ -78,6 +80,7 @@ func (p *ReasoningDeltaPart) Type() StreamPartType { return StreamPartTypeReason
 
 type ReasoningEndPart struct {
 	ID               string
+	Format           ReasoningFormat
 	ProviderMetadata map[string]any
 }
 
@@ -255,14 +258,18 @@ func (sr *StreamResult) Text() (string, error) {
 // ToResult consumes the entire stream and assembles a GenerateResult.
 func (sr *StreamResult) ToResult() (*GenerateResult, error) {
 	result := &GenerateResult{}
-	var reasoning string
+	var reasoning reasoningAccumulator
 
 	for part := range sr.Stream {
 		switch p := part.(type) {
 		case *TextDeltaPart:
 			result.Text += p.Text
+		case *ReasoningStartPart:
+			reasoning.openBlock(p.ID, p.Format, p.ProviderMetadata)
 		case *ReasoningDeltaPart:
-			reasoning += p.Text
+			reasoning.appendDelta(p.ID, p.Text, p.Format, p.ProviderMetadata)
+		case *ReasoningEndPart:
+			reasoning.closeBlock(p.ID, p.Format, p.ProviderMetadata)
 		case *StreamToolCallPart:
 			result.ToolCalls = append(result.ToolCalls, ToolCall{
 				ToolCallID:       p.ToolCallID,
@@ -292,7 +299,8 @@ func (sr *StreamResult) ToResult() (*GenerateResult, error) {
 		}
 	}
 
-	result.Reasoning = reasoning
+	result.ReasoningParts = reasoning.result()
+	result.Reasoning = ReasoningText(result.ReasoningParts)
 	result.Steps = sr.Steps
 	result.Messages = sr.Messages
 	result.DeferredToolApproval = sr.DeferredToolApproval

--- a/sdk/stream_text.go
+++ b/sdk/stream_text.go
@@ -79,8 +79,7 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 
 			var (
 				stepText            string
-				stepReasoning       string
-				stepReasoningMeta   map[string]any
+				stepReasoning       reasoningAccumulator
 				stepToolCalls       []ToolCall
 				stepUsage           Usage
 				stepResponse        ResponseMetadata
@@ -93,12 +92,12 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 				switch p := part.(type) {
 				case *TextDeltaPart:
 					stepText += p.Text
+				case *ReasoningStartPart:
+					stepReasoning.openBlock(p.ID, p.Format, p.ProviderMetadata)
 				case *ReasoningDeltaPart:
-					stepReasoning += p.Text
+					stepReasoning.appendDelta(p.ID, p.Text, p.Format, p.ProviderMetadata)
 				case *ReasoningEndPart:
-					if p.ProviderMetadata != nil {
-						stepReasoningMeta = p.ProviderMetadata
-					}
+					stepReasoning.closeBlock(p.ID, p.Format, p.ProviderMetadata)
 				case *StreamToolCallPart:
 					stepToolCalls = append(stepToolCalls, ToolCall{
 						ToolCallID:       p.ToolCallID,
@@ -135,10 +134,11 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 
 			// No tool calls or not a tool-calls finish → done
 			if !autoExecuteTools || stepFinishReason != FinishReasonToolCalls || len(stepToolCalls) == 0 || !hasExecutableTools(stepToolCalls, toolMap) {
-				stepMsgs := buildStepMessages(stepText, stepReasoning, stepReasoningMeta, stepToolCalls, nil, &stepUsage)
+				stepMsgs := buildStepMessages(stepText, stepReasoning.result(), stepToolCalls, nil, &stepUsage)
 				stepR := StepResult{
 					Text:            stepText,
-					Reasoning:       stepReasoning,
+					Reasoning:       ReasoningText(stepReasoning.result()),
+					ReasoningParts:  stepReasoning.result(),
 					FinishReason:    stepFinishReason,
 					RawFinishReason: stepRawFinishReason,
 					Usage:           stepUsage,
@@ -162,10 +162,11 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 			if err != nil {
 				var deferred *ToolApprovalDeferredError
 				if errors.As(err, &deferred) {
-					stepMsgs := buildStepMessages(stepText, stepReasoning, stepReasoningMeta, stepToolCalls, nil, &stepUsage)
+					stepMsgs := buildStepMessages(stepText, stepReasoning.result(), stepToolCalls, nil, &stepUsage)
 					stepR := StepResult{
 						Text:                 stepText,
-						Reasoning:            stepReasoning,
+						Reasoning:            ReasoningText(stepReasoning.result()),
+						ReasoningParts:       stepReasoning.result(),
 						FinishReason:         stepFinishReason,
 						RawFinishReason:      stepRawFinishReason,
 						Usage:                stepUsage,
@@ -187,10 +188,11 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 				return
 			}
 
-			stepMsgs := buildStepMessages(stepText, stepReasoning, stepReasoningMeta, stepToolCalls, toolResults, &stepUsage)
+			stepMsgs := buildStepMessages(stepText, stepReasoning.result(), stepToolCalls, toolResults, &stepUsage)
 			stepR := StepResult{
 				Text:            stepText,
-				Reasoning:       stepReasoning,
+				Reasoning:       ReasoningText(stepReasoning.result()),
+				ReasoningParts:  stepReasoning.result(),
 				FinishReason:    stepFinishReason,
 				RawFinishReason: stepRawFinishReason,
 				Usage:           stepUsage,

--- a/sdk/stream_text.go
+++ b/sdk/stream_text.go
@@ -79,8 +79,10 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 
 			var (
 				stepText            string
+				stepTextMeta        map[string]any
 				stepReasoning       reasoningAccumulator
 				stepToolCalls       []ToolCall
+				stepErrored         bool
 				stepUsage           Usage
 				stepResponse        ResponseMetadata
 				stepFinishReason    FinishReason
@@ -92,12 +94,16 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 				switch p := part.(type) {
 				case *TextDeltaPart:
 					stepText += p.Text
+				case *TextEndPart:
+					if p.ProviderMetadata != nil {
+						stepTextMeta = p.ProviderMetadata
+					}
 				case *ReasoningStartPart:
-					stepReasoning.openBlock(p.ID, p.Format, p.ProviderMetadata)
+					stepReasoning.openBlock(p.ID, p.Format, p.Model, p.ProviderMetadata)
 				case *ReasoningDeltaPart:
-					stepReasoning.appendDelta(p.ID, p.Text, p.Format, p.ProviderMetadata)
+					stepReasoning.appendDelta(p.ID, p.Text, p.Format, p.Model, p.ProviderMetadata)
 				case *ReasoningEndPart:
-					stepReasoning.closeBlock(p.ID, p.Format, p.ProviderMetadata)
+					stepReasoning.closeBlock(p.ID, p.Format, p.Model, p.ProviderMetadata)
 				case *StreamToolCallPart:
 					stepToolCalls = append(stepToolCalls, ToolCall{
 						ToolCallID:       p.ToolCallID,
@@ -115,11 +121,20 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 					stepFinishReason = p.FinishReason
 					stepRawFinishReason = p.RawFinishReason
 					continue
+				case *ErrorPart:
+					stepErrored = true
 				}
 
 				if !send(part) {
 					return
 				}
+			}
+			// A provider error poisons the step: the consumer already saw the
+			// ErrorPart, and committing what remains would persist a step the
+			// provider itself reported as broken. ToResult treats the same
+			// part as fatal; the streaming loop has to agree with it.
+			if stepErrored {
+				return
 			}
 			if !sawFinishStep {
 				if ctx.Err() == nil {
@@ -134,7 +149,7 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 
 			// No tool calls or not a tool-calls finish → done
 			if !autoExecuteTools || stepFinishReason != FinishReasonToolCalls || len(stepToolCalls) == 0 || !hasExecutableTools(stepToolCalls, toolMap) {
-				stepMsgs := buildStepMessages(stepText, stepReasoning.result(), stepToolCalls, nil, &stepUsage)
+				stepMsgs := buildStepMessages(stepText, stepTextMeta, stepReasoning.result(), stepToolCalls, nil, &stepUsage)
 				stepR := StepResult{
 					Text:            stepText,
 					Reasoning:       ReasoningText(stepReasoning.result()),
@@ -162,7 +177,7 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 			if err != nil {
 				var deferred *ToolApprovalDeferredError
 				if errors.As(err, &deferred) {
-					stepMsgs := buildStepMessages(stepText, stepReasoning.result(), stepToolCalls, nil, &stepUsage)
+					stepMsgs := buildStepMessages(stepText, stepTextMeta, stepReasoning.result(), stepToolCalls, nil, &stepUsage)
 					stepR := StepResult{
 						Text:                 stepText,
 						Reasoning:            ReasoningText(stepReasoning.result()),
@@ -188,7 +203,7 @@ func (c *Client) StreamText(ctx context.Context, options ...GenerateOption) (*St
 				return
 			}
 
-			stepMsgs := buildStepMessages(stepText, stepReasoning.result(), stepToolCalls, toolResults, &stepUsage)
+			stepMsgs := buildStepMessages(stepText, stepTextMeta, stepReasoning.result(), stepToolCalls, toolResults, &stepUsage)
 			stepR := StepResult{
 				Text:            stepText,
 				Reasoning:       ReasoningText(stepReasoning.result()),


### PR DESCRIPTION
## The bug

We weren't replaying Anthropic's reasoning blocks properly, and the failure mode is a hard 400 rather than something degrading quietly.

A model can emit several thinking blocks in one assistant turn — Anthropic interleaves them with tool calls — and each block carries its own signature. We were flattening all of them into one string with one metadata bag, so the surviving signature no longer matched the text it was supposed to sign. Anthropic checks that sequence and rejects anything it didn't produce:

> Within the latest assistant message, the sequence of consecutive `thinking` blocks must match what the model generated in the original request: you can't rearrange, edit, or partially drop them. This includes `redacted_thinking` blocks.

Their docs name our exact mistakes as the top two causes: filtering content blocks by type and dropping `redacted_thinking`, or rebuilding the assistant message instead of echoing it. We did both.

## Four defects, each reproduced before fixing

- **`StreamResult.ToResult` never read `ReasoningEndPart.ProviderMetadata`** — so it dropped *every* signature, not just the extras. Codex's `DoGenerate` runs through it, which made its reasoning unreplayable across the board.
- **Anthropic, Responses and Google appended block text but overwrote block metadata** — N blocks of text ended up under the last block's token.
- **Anthropic threw away `redacted_thinking`** — that was an empty `case` with a comment saying the block has no readable text. True, but its whole payload is the encrypted `data` field, and it has to go back verbatim.
- **Empty-text blocks were filtered out** — emptiness is meaningful here. A redacted block carries everything in metadata; rig's comment on this is worth stealing: *emptiness is a property of the list, not of its members.*

## What changed

Reasoning is now a list of blocks that survives from the stream all the way to the wire. `ReasoningPart` picked up the provider's block id and a dialect tag, which let `ReasoningBlock` and its converters go away entirely. Both stream paths share one accumulator, so they can't drift: text deltas concatenate, metadata replaces — a provider sends the token once as a whole at the end of a block, so the later value wins.

The dialect tag is what makes replay explicit. Each provider stamps its own constant and replays only blocks that match, instead of guessing ownership from whether some field happens to be present. Anything foreign or unmarked gets dropped rather than re-sent as plain text — feeding a model its own inner monologue back as ordinary content teaches it to imitate the form in user-visible answers, which is a real bug Pydantic AI hit and had to fix (pydantic/pydantic-ai#5869 ran for 90+ turns before someone caught it). "Unmarked" also covers reasoning we persisted before dialects existed, where we can't know how the blocks were originally split.

Dialects are hardcoded per provider, not sniffed from model ids. Responses and Codex share one — Codex isn't merely Responses-compatible, it *is* the Responses API behind a different base URL, and the reasoning items serialize byte-for-byte identically.

## Fixed along the way

These turned up while wiring the dialects through and are hard to separate from the above:

- **Copilot was using the wrong fields.** It read and wrote `reasoning_content`/`reasoning`, which belong to DeepSeek and OpenRouter. Copilot's own fields are `reasoning_text` and `reasoning_opaque` — Microsoft's source lists the dialects side by side with comments saying which is whose. So Copilot's signature channel was never actually connected. As upstream does, we only send the text when its token is there.
- **Responses read `encrypted_content` but never asked for it** — no `include`, no `store: false`, so that code path was effectively dead. Codex was already sending both.
- **Both streaming paths read `encrypted_content` at `output_item.added`, where it doesn't exist yet.** The API populates it only on `output_item.done` (LangChain.js hit the identical bug, langchainjs/#10844), so every streamed reasoning item lost its payload — and with `store: false` the next turn would replay a bare `rs_…` id the server can neither decrypt nor look up. The done event now closes the block with the item's final metadata, which the accumulator merges by block ID even when a tool call closed the block early. Guard tests use the real event ordering and were checked to fail against the pre-fix code.
- **Neither OpenAI package replayed the reasoning item id**, which the schema requires. Parts sharing an id now regroup into a single item, which is how a multi-summary item arrives in the first place.
- The duplicated encrypted-content extractor moved into `provider/openai`, since both packages speak the same dialect.

## Verified against the real API

Guard tests cover each defect plus an end-to-end replay, and the dialect guard was checked against a deliberately missing assignment first — that failure is silent otherwise, and a guard that has never failed isn't a guard.

Then we ran it against a live Claude 4.6 through a logging proxy. A single response came back with **five `redacted_thinking` blocks**, and all five went back out on the next turn with their payloads intact and in order. Signatures stayed paired with their own text across six turns including tool calls, and the dialect tag survived the round trip through Postgres. No 400s.

Before this change that response would have lost all five blocks to the empty `case`.

Worth noting: multi-block responses do happen, and more often than we assumed going in.

## Breaking

Downstream will need edits:

| Change | Effect |
|---|---|
| `ReasoningBlock` removed | compile error — use `ReasoningPart` |
| `ReasoningPartsFromBlocks` / `reasoningBlocksOf` removed | compile error — no conversion needed now |
| `GenerateResult.ReasoningProviderMetadata` removed | compile error — read `ReasoningParts[i].ProviderMetadata` |
| `ReasoningBlocks` → `ReasoningParts` | compile error |
| `ReasoningPart` gained `ID` / `Format` | additive, fine |
| Unmarked reasoning is no longer replayed | **behaviour change, and the compiler won't tell you** |
| Copilot switched to `reasoning_opaque` / `reasoning_text` | behaviour change (from broken to working) |
| Responses now sends `store: false` + `include: ["reasoning.encrypted_content"]` on every request | **behaviour change, and the compiler won't tell you** |

The unmarked-reasoning and `store: false` rows are the ones to watch. An old `ReasoningPart{Text: ...}` with no `Format` gets dropped on replay instead of being downgraded to text. That's deliberate, but it needs to be in the release notes.

On `store: false`: the SDK carries conversation state in its own message list, so the server must not store it — that makes `encrypted_content` the only channel for reasoning state across turns, and it is returned only when asked for. Against the official OpenAI endpoint both fields are harmless no-ops for non-reasoning models. But this provider accepts a custom `baseURL`, and a Responses-compatible gateway that doesn't recognise `include` or `store` may reject the request. If that bites someone we add an opt-out; until then the correct-by-default behaviour wins.


## Review findings (thanks @Ranne)

Post-review, three more fixes landed on this branch:

**A tool call with unparseable arguments no longer runs.** Every streaming provider emitted an ErrorPart on a JSON parse failure and then emitted the call anyway with nil input — the step loop forwards ErrorPart without stopping, so the tool executed on empty arguments and `OnStepCommitted` persisted the step. Providers now drop the call they couldn't parse (empty argument buffers still pass; no-arg tools close without input), and the streaming loop treats a provider ErrorPart as fatal to the step, matching what `ToResult` already did. Guarded end-to-end: malformed args → ErrorPart, no call, no execution, no commit.

**Google thought signatures survive on ordinary parts.** Gemini binds the signature to the part that carries it, not to thought parts — a response with no function call signs a plain text part, usually the last one. Our parse paths only kept signatures from thought parts, so that token was dropped and a later Gemini 3 request would fail its check. The signature now rides the text it arrived with: `GenerateResult.TextProviderMetadata` (one slot — this wire signs at most one part per step), `TextEndPart` in streaming, and back onto the `TextPart` on replay, which the request side already knew how to send.

**Reasoning blocks record the model that produced them.** Switching models mid-conversation and replaying the old blocks is a hard 400 (`messages.N.content: Invalid input`) — reproduced live on a Sonnet 5 → 4.6 switch. `ReasoningPart` gained `Model`, stamped from what the response reports; the Anthropic replay guard drops blocks whose producer doesn't match the target, compared by normalized family+version rather than raw strings so gateway/Bedrock spellings of one model keep working. Blocks persisted before the field existed replay as before. The original PR deliberately left this field out on the assumption that a model switch degrades silently — it doesn't, and the live 400 overturned that call.
